### PR TITLE
NatSpec: Fix duplicated display of the data type in NatSpec `/// @return` comments

### DIFF
--- a/packages/contracts/docs/templates/common.hbs
+++ b/packages/contracts/docs/templates/common.hbs
@@ -15,8 +15,8 @@
 | {{name}} | {{type}} | {{{joinLines natspec}}} |
 {{/each}}
 {{#if natspec.returns}}
-{{#each returns}}
 | **Output** | |
+{{#each returns}}
 | {{#if name}}{{name}}{{else}}[{{@index}}]{{/if}} | {{type}} | {{{joinLines natspec}}} |
 {{/each}}
 {{/if}}

--- a/packages/contracts/src/core/dao/DAO.sol
+++ b/packages/contracts/src/core/dao/DAO.sol
@@ -57,7 +57,7 @@ contract DAO is
     bytes32 public constant REGISTER_STANDARD_CALLBACK_PERMISSION_ID =
         keccak256("REGISTER_STANDARD_CALLBACK_PERMISSION");
 
-    /// @notice Only allows 256 actions to execute per tx.
+    /// @notice The internal constant storing the maximal action array length.
     uint256 internal constant MAX_ACTIONS = 256;
 
     /// @notice The [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) signature validator contract.
@@ -69,11 +69,11 @@ contract DAO is
     /// @notice The [EIP-4824](https://eips.ethereum.org/EIPS/eip-4824) DAO uri.
     string private _daoURI;
 
-    /// @notice Thrown if action length is more than MAX_ACTIONS.
+    /// @notice Thrown if the action array length is larger than `MAX_ACTIONS`.
     error TooManyActions();
 
     /// @notice Thrown if action execution has failed.
-    /// @param index Index of action in the array that failed.
+    /// @param index The index of the action in the action array that failed.
     error ActionFailed(uint256 index);
 
     /// @notice Thrown if the deposit amount is zero.

--- a/packages/contracts/src/core/dao/DAO.sol
+++ b/packages/contracts/src/core/dao/DAO.sol
@@ -266,7 +266,7 @@ contract DAO is
 
     /// @notice Fallback to handle future versions of the [ERC-165](https://eips.ethereum.org/EIPS/eip-165) standard.
     /// @param _input An alias being equivalent to `msg.data`. This feature of the fallback function was introduced with the [solidity compiler version 0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6)
-    /// @return bytes The magic number registered for the function selector triggering the fallback.
+    /// @return The magic number registered for the function selector triggering the fallback.
     fallback(bytes calldata _input) external returns (bytes memory) {
         bytes4 magicNumber = _handleCallback(msg.sig, _input);
         return abi.encode(magicNumber);

--- a/packages/contracts/src/core/dao/IDAO.sol
+++ b/packages/contracts/src/core/dao/IDAO.sol
@@ -121,7 +121,7 @@ interface IDAO {
     /// @notice Checks whether a signature is valid for the provided hash by forwarding the call to the set [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) signature validator contract.
     /// @param _hash The hash of the data to be signed.
     /// @param _signature The signature byte array associated with `_hash`.
-    /// @return magicValue Returns the `bytes4` magic value `0x1626ba7e` if the signature is valid.
+    /// @return Returns the `bytes4` magic value `0x1626ba7e` if the signature is valid.
     function isValidSignature(bytes32 _hash, bytes memory _signature) external returns (bytes4);
 
     /// @notice Registers an ERC standard having a callback by registering its [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID and callback function signature.

--- a/packages/contracts/src/core/dao/IDAO.sol
+++ b/packages/contracts/src/core/dao/IDAO.sol
@@ -41,7 +41,7 @@ interface IDAO {
     /// @param _callId The ID of the call. The definition of the value of `callId` is up to the calling contract and can be used, e.g., as a nonce.
     /// @param _actions The array of actions.
     /// @param _allowFailureMap A bitmap allowing execution to succeed, even if individual actions might revert. If the bit at index `i` is 1, the execution succeeds even if the `i`th action reverts. A failure map value of 0 requires every action to not revert.
-    /// @return bytes[] The array of results obtained from the executed actions in `bytes`.
+    /// @return The array of results obtained from the executed actions in `bytes`.
     /// @return The constructed failureMap which contains which actions have actually failed.
     function execute(
         bytes32 _callId,

--- a/packages/contracts/src/core/dao/IDAO.sol
+++ b/packages/contracts/src/core/dao/IDAO.sol
@@ -21,7 +21,7 @@ interface IDAO {
     /// @param _who The address of a EOA or contract to give the permissions.
     /// @param _permissionId The permission identifier.
     /// @param _data The optional data passed to the `PermissionCondition` registered.
-    /// @return bool Returns true if the address has permission, false if not.
+    /// @return Returns true if the address has permission, false if not.
     function hasPermission(
         address _where,
         address _who,
@@ -42,7 +42,7 @@ interface IDAO {
     /// @param _actions The array of actions.
     /// @param _allowFailureMap A bitmap allowing execution to succeed, even if individual actions might revert. If the bit at index `i` is 1, the execution succeeds even if the `i`th action reverts. A failure map value of 0 requires every action to not revert.
     /// @return bytes[] The array of results obtained from the executed actions in `bytes`.
-    /// @return uint256 The constructed failureMap which contains which actions have actually failed.
+    /// @return The constructed failureMap which contains which actions have actually failed.
     function execute(
         bytes32 _callId,
         Action[] memory _actions,

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -336,7 +336,7 @@ abstract contract PermissionManager is Initializable {
     /// @param _where The address of the target contract for which `_who` recieves permission.
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.
-    /// @return bytes32 The permission hash.
+    /// @return The permission hash.
     function permissionHash(
         address _where,
         address _who,

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -194,7 +194,7 @@ abstract contract PermissionManager is Initializable {
     /// @param _who The address (EOA or contract) for which the permission is checked.
     /// @param _permissionId The permission identifier.
     /// @param _data The optional data passed to the `PermissionCondition` registered.
-    /// @return bool Returns true if `_who` has the permissions on the target contract via the specified permission identifier.
+    /// @return Returns true if `_who` has the permissions on the target contract via the specified permission identifier.
     function isGranted(
         address _where,
         address _who,
@@ -291,7 +291,7 @@ abstract contract PermissionManager is Initializable {
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.
     /// @param _data The optional data passed to the `PermissionCondition` registered.
-    /// @return bool Returns true if `_who` has the permissions on the contract via the specified permissionId identifier.
+    /// @return Returns true if `_who` has the permissions on the contract via the specified permissionId identifier.
     function _isGranted(
         address _where,
         address _who,
@@ -348,7 +348,7 @@ abstract contract PermissionManager is Initializable {
     /// @notice Decides if the granting permissionId is restricted when `_who = ANY_ADDR` or `_where = ANY_ADDR`.
     /// @dev by default, every permission is unrestricted and it's the derived contract's responsibility to override it. NOTE: ROOT_PERMISSION_ID is included and not required to set it again.
     /// @param _permissionId The permission identifier.
-    /// @return bool Whether ot not permissionId is restricted.
+    /// @return Whether ot not permissionId is restricted.
     function isPermissionRestrictedForAnyAddr(
         bytes32 _permissionId
     ) internal view virtual returns (bool) {

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -346,9 +346,9 @@ abstract contract PermissionManager is Initializable {
     }
 
     /// @notice Decides if the granting permissionId is restricted when `_who = ANY_ADDR` or `_where = ANY_ADDR`.
-    /// @dev by default, every permission is unrestricted and it's the derived contract's responsibility to override it. NOTE: ROOT_PERMISSION_ID is included and not required to set it again.
     /// @param _permissionId The permission identifier.
-    /// @return Whether ot not permissionId is restricted.
+    /// @return Whether or not the permission is restricted.
+    /// @dev By default, every permission is unrestricted and it is the derived contract's responsibility to override it. Note, that the `ROOT_PERMISSION_ID` is included not required to be set it again.
     function isPermissionRestrictedForAnyAddr(
         bytes32 _permissionId
     ) internal view virtual returns (bool) {

--- a/packages/contracts/src/core/plugin/Plugin.sol
+++ b/packages/contracts/src/core/plugin/Plugin.sol
@@ -23,7 +23,7 @@ abstract contract Plugin is IPlugin, ERC165, DaoAuthorizable {
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return _interfaceId == type(IPlugin).interfaceId || super.supportsInterface(_interfaceId);
     }

--- a/packages/contracts/src/core/plugin/PluginCloneable.sol
+++ b/packages/contracts/src/core/plugin/PluginCloneable.sol
@@ -30,7 +30,7 @@ abstract contract PluginCloneable is IPlugin, ERC165Upgradeable, DaoAuthorizable
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return _interfaceId == type(IPlugin).interfaceId || super.supportsInterface(_interfaceId);
     }

--- a/packages/contracts/src/core/plugin/PluginUUPSUpgradeable.sol
+++ b/packages/contracts/src/core/plugin/PluginUUPSUpgradeable.sol
@@ -42,7 +42,7 @@ abstract contract PluginUUPSUpgradeable is
 
     /// @notice Checks if an interface is supported by this or its parent contract.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == type(IPlugin).interfaceId ||

--- a/packages/contracts/src/core/plugin/dao-authorizable/DaoAuthorizable.sol
+++ b/packages/contracts/src/core/plugin/dao-authorizable/DaoAuthorizable.sol
@@ -21,7 +21,7 @@ abstract contract DaoAuthorizable is Context {
     }
 
     /// @notice Returns the DAO contract.
-    /// @return IDAO The DAO contract.
+    /// @return The DAO contract.
     function dao() public view returns (IDAO) {
         return dao_;
     }

--- a/packages/contracts/src/core/plugin/dao-authorizable/DaoAuthorizableUpgradeable.sol
+++ b/packages/contracts/src/core/plugin/dao-authorizable/DaoAuthorizableUpgradeable.sol
@@ -22,7 +22,7 @@ abstract contract DaoAuthorizableUpgradeable is ContextUpgradeable {
     }
 
     /// @notice Returns the DAO contract.
-    /// @return IDAO The DAO contract.
+    /// @return The DAO contract.
     function dao() public view returns (IDAO) {
         return dao_;
     }

--- a/packages/contracts/src/core/plugin/proposal/Proposal.sol
+++ b/packages/contracts/src/core/plugin/proposal/Proposal.sol
@@ -23,7 +23,7 @@ abstract contract Proposal is IProposal, ERC165 {
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return _interfaceId == type(IProposal).interfaceId || super.supportsInterface(_interfaceId);
     }

--- a/packages/contracts/src/core/plugin/proposal/ProposalUpgradeable.sol
+++ b/packages/contracts/src/core/plugin/proposal/ProposalUpgradeable.sol
@@ -23,7 +23,7 @@ abstract contract ProposalUpgradeable is IProposal, ERC165Upgradeable {
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return _interfaceId == type(IProposal).interfaceId || super.supportsInterface(_interfaceId);
     }

--- a/packages/contracts/src/core/utils/BitMap.sol
+++ b/packages/contracts/src/core/utils/BitMap.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 
 /// @param bitmap The `uint256` representation of bits.
 /// @param index The index number to check whether 1 or 0 is set.
-/// @return bool Returns `true` whether the bit is set at `index` on `bitmap`.
+/// @return Returns `true` whether the bit is set at `index` on `bitmap`.
 function hasBit(uint256 bitmap, uint8 index) pure returns (bool) {
     uint256 bitValue = bitmap & (1 << index);
     return bitValue > 0;
@@ -12,7 +12,7 @@ function hasBit(uint256 bitmap, uint8 index) pure returns (bool) {
 
 /// @param bitmap The `uint256` representation of bits.
 /// @param index The index number to set the bit.
-/// @return uint256 Returns a new number on which the bit is set at `index`.
+/// @return Returns a new number on which the bit is set at `index`.
 function flipBit(uint256 bitmap, uint8 index) pure returns (uint256) {
     return bitmap ^ (1 << index);
 }

--- a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
@@ -246,7 +246,7 @@ contract PluginRepo is
 
     /// @notice The hash of the version tag obtained from the packed, bytes-encoded release and build number.
     /// @param _tag The version tag.
-    /// @return bytes32 The version tag hash.
+    /// @return The version tag hash.
     function tagHash(Tag memory _tag) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(_tag.release, _tag.build));
     }

--- a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
@@ -204,15 +204,15 @@ contract PluginRepo is
 
     /// @notice Returns the latest version for a given release number.
     /// @param _release The release number.
-    /// @return Version The latest version of this release.
+    /// @return The latest version of this release.
     function getLatestVersion(uint8 _release) public view returns (Version memory) {
         uint16 latestBuild = uint16(buildsPerRelease[_release]);
         return getVersion(tagHash(Tag(_release, latestBuild)));
     }
 
     /// @notice Returns the latest version for a given plugin setup.
-    /// @param _pluginSetup the plugin setup address
-    /// @return Version latest version that is bound to the _pluginSetup
+    /// @param _pluginSetup The plugin setup address
+    /// @return The latest version associated with the plugin Setup.
     function getLatestVersion(address _pluginSetup) public view returns (Version memory) {
         return getVersion(latestTagHashForPluginSetup[_pluginSetup]);
     }
@@ -259,7 +259,7 @@ contract PluginRepo is
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == type(IPluginRepo).interfaceId ||

--- a/packages/contracts/src/framework/plugin/setup/IPluginSetup.sol
+++ b/packages/contracts/src/framework/plugin/setup/IPluginSetup.sol
@@ -59,7 +59,7 @@ interface IPluginSetup {
     ) external returns (PermissionLib.MultiTargetPermission[] memory permissions);
 
     /// @notice Returns the plugin's base implementation.
-    /// @return address The address of the plugin implementation contract.
+    /// @return The address of the plugin implementation contract.
     /// @dev The implementation can be instantiated via the `new` keyword, cloned via the minimal clones pattern (see [ERC-1167](https://eips.ethereum.org/EIPS/eip-1167)), or proxied via the UUPS pattern (see [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822)).
     function getImplementationAddress() external view returns (address);
 }

--- a/packages/contracts/src/framework/plugin/setup/PluginSetup.sol
+++ b/packages/contracts/src/framework/plugin/setup/PluginSetup.sol
@@ -29,7 +29,7 @@ abstract contract PluginSetup is ERC165, IPluginSetup {
     /// @notice A convenience function to create an [ERC-1967](https://eips.ethereum.org/EIPS/eip-1967) proxy contract pointing to an implementation and being associated to a DAO.
     /// @param _implementation The address of the implementation contract to which the proxy is pointing to.
     /// @param _data The data to initialize the storage of the proxy contract.
-    /// @return address The address of the created proxy contract.
+    /// @return The address of the created proxy contract.
     function createERC1967Proxy(
         address _implementation,
         bytes memory _data
@@ -39,7 +39,7 @@ abstract contract PluginSetup is ERC165, IPluginSetup {
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == type(IPluginSetup).interfaceId || super.supportsInterface(_interfaceId);

--- a/packages/contracts/src/framework/plugin/setup/PluginSetupProcessorHelpers.sol
+++ b/packages/contracts/src/framework/plugin/setup/PluginSetupProcessorHelpers.sol
@@ -39,7 +39,7 @@ function _getPluginInstallationId(address _dao, address _plugin) pure returns (b
 /// @param _helpersHash The hash of the helper contract addresses.
 /// @param _data The bytes-encoded initialize data for the upgrade that is returned by `prepareUpdate`.
 /// @param _preparationType The type of preparation the plugin is currently undergoing. Without this, it is possible to call `applyUpdate` even after `applyInstallation` is called.
-/// @return bytes32 The prepared setup id.
+/// @return The prepared setup id.
 function _getPreparedSetupId(
     PluginSetupRef memory _pluginSetupRef,
     bytes32 _permissionsHash,
@@ -63,7 +63,7 @@ function _getPreparedSetupId(
 /// @notice Returns an identifier for applied installations.
 /// @param _pluginSetupRef The reference of the plugin setup containing plugin setup repo and version tag.
 /// @param _helpersHash The hash of the helper contract addresses.
-/// @return bytes32 The applied setup id.
+/// @return The applied setup id.
 function _getAppliedSetupId(
     PluginSetupRef memory _pluginSetupRef,
     bytes32 _helpersHash

--- a/packages/contracts/src/framework/utils/TokenFactory.sol
+++ b/packages/contracts/src/framework/utils/TokenFactory.sol
@@ -73,8 +73,8 @@ contract TokenFactory {
     /// @param _managingDao The address of the DAO managing the token.
     /// @param _tokenConfig The token configuration struct containing the name, and symbol of the token to be create, but also an address. For `address(0)`, a new governance token is created. For any other address pointing to an [ERC-20](https://eips.ethereum.org/EIPS/eip-20)-compatible contract, a wrapped governance token is created.
     /// @param _mintSettings The token mint settings struct containing the `receivers` and `amounts`.
-    /// @return ERC20VotesUpgradeable The address of the created token.
-    /// @return MerkleMinter The `MerkleMinter` contract address being used to mint token address(zero address in case passed token addr was not zero)
+    /// @return The address of the created token.
+    /// @return The `MerkleMinter` contract address being used to mint token address(zero address in case passed token addr was not zero)
     function createToken(
         DAO _managingDao,
         TokenConfig calldata _tokenConfig,

--- a/packages/contracts/src/framework/utils/TokenFactory.sol
+++ b/packages/contracts/src/framework/utils/TokenFactory.sol
@@ -73,8 +73,8 @@ contract TokenFactory {
     /// @param _managingDao The address of the DAO managing the token.
     /// @param _tokenConfig The token configuration struct containing the name, and symbol of the token to be create, but also an address. For `address(0)`, a new governance token is created. For any other address pointing to an [ERC-20](https://eips.ethereum.org/EIPS/eip-20)-compatible contract, a wrapped governance token is created.
     /// @param _mintSettings The token mint settings struct containing the `receivers` and `amounts`.
-    /// @return The address of the created token.
-    /// @return The `MerkleMinter` contract address being used to mint token address(zero address in case passed token addr was not zero)
+    /// @return The created `ERC20VotesUpgradeable` compatible token contract.
+    /// @return The created `MerkleMinter` contract used to mint the `ERC20VotesUpgradeable` tokens or `address(0)` if an existing token was provided.
     function createToken(
         DAO _managingDao,
         TokenConfig calldata _tokenConfig,

--- a/packages/contracts/src/plugins/governance/admin/Admin.sol
+++ b/packages/contracts/src/plugins/governance/admin/Admin.sol
@@ -34,7 +34,7 @@ contract Admin is IMembership, PluginCloneable, ProposalUpgradeable {
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(
         bytes4 _interfaceId
     ) public view override(PluginCloneable, ProposalUpgradeable) returns (bool) {

--- a/packages/contracts/src/plugins/governance/majority-voting/IMajorityVoting.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/IMajorityVoting.sol
@@ -64,7 +64,7 @@ interface IMajorityVoting {
     /// @param _proposalId The proposal Id.
     /// @param _account The account address to be checked.
     /// @param  _voteOption Whether the voter abstains, supports or opposes the proposal.
-    /// @return bool Returns true if the account is allowed to vote.
+    /// @return Returns true if the account is allowed to vote.
     /// @dev The function assumes the queried proposal exists.
     function canVote(
         uint256 _proposalId,

--- a/packages/contracts/src/plugins/governance/majority-voting/MajorityVotingBase.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/MajorityVotingBase.sol
@@ -245,7 +245,7 @@ abstract contract MajorityVotingBase is
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(
         bytes4 _interfaceId
     )

--- a/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVoting.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVoting.sol
@@ -44,7 +44,7 @@ contract AddresslistVoting is IMembership, Addresslist, MajorityVotingBase {
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == ADDRESSLIST_VOTING_INTERFACE_ID ||

--- a/packages/contracts/src/plugins/governance/majority-voting/token/TokenVoting.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/token/TokenVoting.sol
@@ -47,7 +47,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == TOKEN_VOTING_INTERFACE_ID ||
@@ -57,7 +57,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
 
     /// @notice getter function for the voting token.
     /// @dev public function also useful for registering interfaceId and for distinguishing from majority voting interface.
-    /// @return IVotesUpgradeable the token used for voting.
+    /// @return The token used for voting.
     function getVotingToken() public view returns (IVotesUpgradeable) {
         return votingToken;
     }

--- a/packages/contracts/src/plugins/governance/multisig/IMultisig.sol
+++ b/packages/contracts/src/plugins/governance/multisig/IMultisig.sol
@@ -26,7 +26,7 @@ interface IMultisig {
     /// - the voter is not listed.
     /// @param _proposalId The proposal Id.
     /// @param _account The address of the user to check.
-    /// @return bool Returns true if the account is allowed to vote.
+    /// @return Returns true if the account is allowed to vote.
     /// @dev The function assumes the queried proposal exists.
     function canApprove(uint256 _proposalId, address _account) external view returns (bool);
 

--- a/packages/contracts/src/plugins/governance/multisig/Multisig.sol
+++ b/packages/contracts/src/plugins/governance/multisig/Multisig.sol
@@ -137,7 +137,7 @@ contract Multisig is
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(
         bytes4 _interfaceId
     ) public view virtual override(PluginUUPSUpgradeable, ProposalUpgradeable) returns (bool) {

--- a/packages/contracts/src/plugins/token/MerkleDistributor.sol
+++ b/packages/contracts/src/plugins/token/MerkleDistributor.sol
@@ -55,7 +55,7 @@ contract MerkleDistributor is IMerkleDistributor, PluginUUPSUpgradeable {
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == type(IMerkleDistributor).interfaceId ||

--- a/packages/contracts/src/plugins/token/MerkleMinter.sol
+++ b/packages/contracts/src/plugins/token/MerkleMinter.sol
@@ -58,7 +58,7 @@ contract MerkleMinter is IMerkleMinter, PluginUUPSUpgradeable {
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == type(IMerkleMinter).interfaceId ||

--- a/packages/contracts/src/token/ERC20/governance/GovernanceERC20.sol
+++ b/packages/contracts/src/token/ERC20/governance/GovernanceERC20.sol
@@ -89,7 +89,7 @@ contract GovernanceERC20 is
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == type(IERC20Upgradeable).interfaceId ||

--- a/packages/contracts/src/token/ERC20/governance/GovernanceWrappedERC20.sol
+++ b/packages/contracts/src/token/ERC20/governance/GovernanceWrappedERC20.sol
@@ -55,7 +55,7 @@ contract GovernanceWrappedERC20 is
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
-    /// @return bool Returns `true` if the interface is supported.
+    /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == type(IGovernanceWrappedERC20).interfaceId ||

--- a/packages/contracts/src/utils/Proxy.sol
+++ b/packages/contracts/src/utils/Proxy.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 /// @notice Free function to create a [ERC-1967](https://eips.ethereum.org/EIPS/eip-1967) proxy contract based on the passed base contract address.
 /// @param _logic The base contract address.
 /// @param _data The constructor arguments for this contract.
-/// @return address The address of the proxy contract created.
+/// @return The address of the proxy contract created.
 /// @dev Initializes the upgradeable proxy with an initial implementation specified by _logic. If _data is non-empty, it’s used as data in a delegate call to _logic. This will typically be an encoded function call, and allows initializing the storage of the proxy like a Solidity constructor (see [OpenZepplin ERC1967Proxy-constructor](https://docs.openzeppelin.com/contracts/4.x/api/proxy#ERC1967Proxy-constructor-address-bytes-)).
 function createERC1967Proxy(address _logic, bytes memory _data) returns (address) {
     return address(new ERC1967Proxy(_logic, _data));


### PR DESCRIPTION
## Description

Many NatSpec `/// @return` comments included the data type, which would then be displayed twice

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.