### PR TITLE
Added exhaustive tests for the governance tokens

### DIFF
--- a/packages/contracts/test/token/erc20/governance-erc20.ts
+++ b/packages/contracts/test/token/erc20/governance-erc20.ts
@@ -23,6 +23,10 @@ const governanceERC20Symbol = 'GOV';
 
 const addressZero = ethers.constants.AddressZero;
 
+let from: SignerWithAddress;
+let to: SignerWithAddress;
+let other: SignerWithAddress;
+
 describe('GovernanceERC20', function () {
   let signers: SignerWithAddress[];
   let dao: DAO;
@@ -35,6 +39,10 @@ describe('GovernanceERC20', function () {
     signers = await ethers.getSigners();
     dao = await deployNewDAO(signers[0].address);
     GovernanceERC20 = await ethers.getContractFactory('GovernanceERC20');
+
+    from = signers[0];
+    to = signers[1];
+    other = signers[2];
   });
 
   beforeEach(async function () {
@@ -206,13 +214,13 @@ describe('GovernanceERC20', function () {
 
       // verify that past votes are correct
       expect(
-        await token.getPastVotes(signers[0].address, tx1.blockNumber)
+        await token.getPastVotes(signers[0].address, tx1.blockNumber!)
       ).to.eq(0);
       expect(
-        await token.getPastVotes(signers[1].address, tx1.blockNumber)
+        await token.getPastVotes(signers[1].address, tx1.blockNumber!)
       ).to.eq(balanceSigner1.add(balanceSigner0));
       expect(
-        await token.getPastVotes(signers[2].address, tx1.blockNumber)
+        await token.getPastVotes(signers[2].address, tx1.blockNumber!)
       ).to.eq(balanceSigner2);
     });
   });
@@ -373,6 +381,418 @@ describe('GovernanceERC20', function () {
       await token.transfer(signers[1].address, 30);
 
       expect(await token.getVotes(signers[1].address)).to.equal(30);
+    });
+
+    context('exhaustive tests', async () => {
+      context('`to` has a zero-balance', async () => {
+        beforeEach(async () => {
+          expect(await token.balanceOf(to.address)).to.eq(0);
+        });
+
+        context('`to` delegated to `other`', async () => {
+          beforeEach(async () => {
+            await expect(token.connect(to).delegate(other.address))
+              .to.emit(token, 'DelegateChanged')
+              .withArgs(to.address, addressZero, other.address);
+          });
+
+          context('`to` receives via `mint` from `address(0)`', async () => {
+            beforeEach(async () => {
+              await expect(token.mint(to.address, 100)).to.not.emit(
+                token,
+                'DelegateChanged'
+              );
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(other.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(100);
+            });
+          });
+
+          context('`to` receives via transfer from `from`', async () => {
+            beforeEach(async () => {
+              await token.mint(from.address, 100);
+              await expect(
+                token.connect(from).transfer(to.address, 100)
+              ).to.not.emit(token, 'DelegateChanged');
+            });
+
+            it('`from` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`from`s delegate has not changed', async () => {
+              expect(await token.delegates(from.address)).to.equal(
+                from.address
+              );
+            });
+            it('`from`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(from.address);
+              expect(await token.getVotes(delegate)).to.equal(0);
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(other.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(100);
+            });
+          });
+        });
+
+        context('`to` has not delegated before', async () => {
+          context('`to` receives via `mint` from `address(0)`', async () => {
+            beforeEach(async () => {
+              await expect(token.mint(to.address, 100))
+                .to.emit(token, 'DelegateChanged')
+                .withArgs(to.address, addressZero, to.address); // the mint triggers automatic self-delegation
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(100);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(to.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(100);
+            });
+          });
+
+          context('`to` receives via transfer from `from`', async () => {
+            beforeEach(async () => {
+              await token.mint(from.address, 100);
+              await expect(token.connect(from).transfer(to.address, 100))
+                .to.emit(token, 'DelegateChanged')
+                .withArgs(to.address, addressZero, to.address); // the transfer triggers automatic self-delegation
+            });
+
+            it('`from` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(100);
+            });
+            it('`from`s delegate has not changed', async () => {
+              expect(await token.delegates(from.address)).to.equal(
+                from.address
+              );
+            });
+            it('`from`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(from.address);
+              expect(await token.getVotes(delegate)).to.equal(0);
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(100);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(to.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(100);
+            });
+          });
+        });
+      });
+
+      context('`to` has a non-zero-balance', async () => {
+        beforeEach(async () => {
+          await expect(token.mint(to.address, 100))
+            .to.emit(token, 'DelegateChanged')
+            .withArgs(to.address, addressZero, to.address);
+          expect(await token.balanceOf(to.address)).to.eq(100);
+        });
+
+        context('`to` delegated to `other`', async () => {
+          beforeEach(async () => {
+            await expect(token.connect(to).delegate(other.address))
+              .to.emit(token, 'DelegateChanged')
+              .withArgs(to.address, to.address, other.address); // this changes the delegate from himself (`to`) to `other`
+          });
+
+          context('`to` receives via `mint` from `address(0)`', async () => {
+            beforeEach(async () => {
+              await expect(token.mint(to.address, 100)).to.not.emit(
+                token,
+                'DelegateChanged'
+              );
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(other.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(200);
+            });
+
+            context('`to` transfers to `other`', async () => {
+              beforeEach(async () => {
+                await expect(
+                  token.connect(to).transfer(other.address, 100)
+                ).to.not.emit(token, 'DelegateChanged');
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(100);
+              });
+            });
+
+            context('`to` delegates to `other`', async () => {
+              beforeEach(async () => {
+                await expect(token.connect(to).delegate(other.address))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate is correctly changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(200);
+              });
+            });
+          });
+
+          context('`to` receives via transfer from `from`', async () => {
+            beforeEach(async () => {
+              await token.mint(from.address, 100);
+              await expect(
+                token.connect(from).transfer(to.address, 100)
+              ).to.not.emit(token, 'DelegateChanged');
+            });
+
+            it('`from` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`from`s delegate has not changed', async () => {
+              expect(await token.delegates(from.address)).to.equal(
+                from.address
+              );
+            });
+            it('`from`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(from.address);
+              expect(await token.getVotes(delegate)).to.equal(0);
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(other.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(200);
+            });
+
+            context('`to` transfers to `other`', async () => {
+              beforeEach(async () => {
+                await expect(
+                  token.connect(to).transfer(other.address, 100)
+                ).to.not.emit(token, 'DelegateChanged');
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(100);
+              });
+            });
+
+            context('`to` delegates to `other`', async () => {
+              beforeEach(async () => {
+                await expect(token.connect(to).delegate(other.address))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate is correctly changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(200);
+              });
+            });
+          });
+        });
+
+        context('`to` has not delegated before', async () => {
+          context('`to` receives via `mint` from `address(0)`', async () => {
+            beforeEach(async () => {
+              await expect(token.mint(to.address, 100)).to.not.emit(
+                token,
+                'DelegateChanged'
+              );
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(200);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(to.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(200);
+            });
+
+            context('`to` transfers to `other`', async () => {
+              beforeEach(async () => {
+                await expect(token.connect(to).transfer(other.address, 100))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(other.address, addressZero, other.address); // the transfer triggers automatic self-delegation for `other`
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(100); // 100 tokens are still left
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(to.address);
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(100);
+              });
+            });
+
+            context('`to` delegates to `other`', async () => {
+              beforeEach(async () => {
+                await expect(token.connect(to).delegate(other.address))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(to.address, to.address, other.address); // `to` delegates to `other`
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate is correctly changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(200);
+              });
+            });
+          });
+
+          context('`to` receives via transfer from `from`', async () => {
+            beforeEach(async () => {
+              await token.mint(from.address, 100);
+              await expect(
+                token.connect(from).transfer(to.address, 100)
+              ).to.not.emit(token, 'DelegateChanged');
+            });
+
+            it('`from` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(200);
+            });
+            it('`from`s delegate has not changed', async () => {
+              expect(await token.delegates(from.address)).to.equal(
+                from.address
+              );
+            });
+            it('`from`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(from.address);
+              expect(await token.getVotes(delegate)).to.equal(0);
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(200);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(to.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(200);
+            });
+
+            context('`to` transfers to `other`', async () => {
+              beforeEach(async () => {
+                await expect(token.connect(to).transfer(other.address, 100))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(other.address, addressZero, other.address);
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(100);
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(to.address);
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(100);
+              });
+            });
+
+            context('`to` delegates to `other`', async () => {
+              beforeEach(async () => {
+                await expect(token.connect(to).delegate(other.address))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(to.address, to.address, other.address); // `to` delegates to `other`
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate is correctly changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(200);
+              });
+            });
+          });
+        });
+      });
     });
   });
 });

--- a/packages/contracts/test/token/erc20/governance-erc20.ts
+++ b/packages/contracts/test/token/erc20/governance-erc20.ts
@@ -385,7 +385,7 @@ describe('GovernanceERC20', function () {
     });
 
     context('exhaustive tests', async () => {
-      context('`to` has a zero-balance', async () => {
+      context('`to` has a zero balance', async () => {
         beforeEach(async () => {
           expect(await token.balanceOf(to.address)).to.eq(0);
           toDelegate = addressZero;
@@ -506,7 +506,7 @@ describe('GovernanceERC20', function () {
         });
       });
 
-      context('`to` has a non-zero-balance', async () => {
+      context('`to` has a non-zero balance', async () => {
         beforeEach(async () => {
           await expect(token.mint(to.address, 100))
             .to.emit(token, 'DelegateChanged')

--- a/packages/contracts/test/token/erc20/governance-erc20.ts
+++ b/packages/contracts/test/token/erc20/governance-erc20.ts
@@ -427,7 +427,7 @@ describe('GovernanceERC20', function () {
             });
 
             it('`from` has the correct voting power', async () => {
-              expect(await token.getVotes(to.address)).to.equal(0);
+              expect(await token.getVotes(from.address)).to.equal(0);
             });
             it('`from`s delegate has not changed', async () => {
               expect(await token.delegates(from.address)).to.equal(
@@ -481,7 +481,7 @@ describe('GovernanceERC20', function () {
             });
 
             it('`from` has the correct voting power', async () => {
-              expect(await token.getVotes(to.address)).to.equal(100);
+              expect(await token.getVotes(from.address)).to.equal(0);
             });
             it('`from`s delegate has not changed', async () => {
               expect(await token.delegates(from.address)).to.equal(
@@ -564,7 +564,6 @@ describe('GovernanceERC20', function () {
                 await expect(token.connect(to).delegate(other.address))
                   .to.emit(token, 'DelegateChanged')
                   .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
-                //toDelegate = other.address;
               });
 
               it('`to` has the correct voting power', async () => {
@@ -590,7 +589,7 @@ describe('GovernanceERC20', function () {
             });
 
             it('`from` has the correct voting power', async () => {
-              expect(await token.getVotes(to.address)).to.equal(0);
+              expect(await token.getVotes(from.address)).to.equal(0);
             });
             it('`from`s delegate has not changed', async () => {
               expect(await token.delegates(from.address)).to.equal(
@@ -635,7 +634,6 @@ describe('GovernanceERC20', function () {
                 await expect(token.connect(to).delegate(other.address))
                   .to.emit(token, 'DelegateChanged')
                   .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
-                //toDelegate = other.address;
               });
 
               it('`to` has the correct voting power', async () => {
@@ -717,7 +715,7 @@ describe('GovernanceERC20', function () {
             });
 
             it('`from` has the correct voting power', async () => {
-              expect(await token.getVotes(to.address)).to.equal(200);
+              expect(await token.getVotes(from.address)).to.equal(0);
             });
             it('`from`s delegate has not changed', async () => {
               expect(await token.delegates(from.address)).to.equal(

--- a/packages/contracts/test/token/erc20/governance-wrapped-erc20.ts
+++ b/packages/contracts/test/token/erc20/governance-wrapped-erc20.ts
@@ -27,6 +27,10 @@ const governanceWrappedERC20Symbol = 'gwTOK';
 
 const addressZero = ethers.constants.AddressZero;
 
+let from: SignerWithAddress;
+let to: SignerWithAddress;
+let other: SignerWithAddress;
+
 describe('GovernanceWrappedERC20', function () {
   let signers: SignerWithAddress[];
   let governanceToken: GovernanceWrappedERC20;
@@ -50,6 +54,10 @@ describe('GovernanceWrappedERC20', function () {
       {account: signers[1].address, amount: 456},
       {account: signers[2].address, amount: 789},
     ];
+
+    from = signers[0];
+    to = signers[1];
+    other = signers[2];
   });
 
   beforeEach(async function () {
@@ -485,6 +493,436 @@ describe('GovernanceWrappedERC20', function () {
       await token.transfer(signers[1].address, 30);
 
       expect(await token.getVotes(signers[1].address)).to.equal(30);
+    });
+
+    context('exhaustive tests', async () => {
+      context('`to` has a zero-balance', async () => {
+        beforeEach(async () => {
+          expect(await token.balanceOf(to.address)).to.eq(0);
+        });
+
+        context('`to` delegated to `other`', async () => {
+          beforeEach(async () => {
+            await expect(token.connect(to).delegate(other.address))
+              .to.emit(token, 'DelegateChanged')
+              .withArgs(to.address, addressZero, other.address);
+          });
+
+          context(
+            '`to` receives via `depositFor` from `address(0)`',
+            async () => {
+              beforeEach(async () => {
+                await expect(token.depositFor(to.address, 100)).to.not.emit(
+                  token,
+                  'DelegateChanged'
+                );
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(100);
+              });
+            }
+          );
+
+          context('`to` receives via transfer from `from`', async () => {
+            beforeEach(async () => {
+              await token.depositFor(from.address, 100);
+              await expect(
+                token.connect(from).transfer(to.address, 100)
+              ).to.not.emit(token, 'DelegateChanged');
+            });
+
+            it('`from` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`from`s delegate has not changed', async () => {
+              expect(await token.delegates(from.address)).to.equal(
+                from.address
+              );
+            });
+            it('`from`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(from.address);
+              expect(await token.getVotes(delegate)).to.equal(0);
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(other.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(100);
+            });
+          });
+        });
+
+        context('`to` has not delegated before', async () => {
+          context(
+            '`to` receives via `depositFor` from `address(0)`',
+            async () => {
+              beforeEach(async () => {
+                await expect(token.depositFor(to.address, 100))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(to.address, addressZero, to.address); // the mint triggers automatic self-delegation
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(100);
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(to.address);
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(100);
+              });
+            }
+          );
+
+          context('`to` receives via transfer from `from`', async () => {
+            beforeEach(async () => {
+              await token.depositFor(from.address, 100);
+              await expect(token.connect(from).transfer(to.address, 100))
+                .to.emit(token, 'DelegateChanged')
+                .withArgs(to.address, addressZero, to.address); // the transfer triggers automatic self-delegation
+            });
+
+            it('`from` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(100);
+            });
+            it('`from`s delegate has not changed', async () => {
+              expect(await token.delegates(from.address)).to.equal(
+                from.address
+              );
+            });
+            it('`from`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(from.address);
+              expect(await token.getVotes(delegate)).to.equal(0);
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(100);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(to.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(100);
+            });
+          });
+        });
+      });
+
+      context('`to` has a non-zero-balance', async () => {
+        beforeEach(async () => {
+          await expect(token.depositFor(to.address, 100))
+            .to.emit(token, 'DelegateChanged')
+            .withArgs(to.address, addressZero, to.address);
+          expect(await token.balanceOf(to.address)).to.eq(100);
+        });
+
+        context('`to` delegated to `other`', async () => {
+          beforeEach(async () => {
+            await expect(token.connect(to).delegate(other.address))
+              .to.emit(token, 'DelegateChanged')
+              .withArgs(to.address, to.address, other.address); // this changes the delegate from himself (`to`) to `other`
+          });
+
+          context(
+            '`to` receives via `depositFor` from `address(0)`',
+            async () => {
+              beforeEach(async () => {
+                await expect(token.depositFor(to.address, 100)).to.not.emit(
+                  token,
+                  'DelegateChanged'
+                );
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(200);
+              });
+
+              context('`to` transfers to `other`', async () => {
+                beforeEach(async () => {
+                  await expect(
+                    token.connect(to).transfer(other.address, 100)
+                  ).to.not.emit(token, 'DelegateChanged');
+                });
+
+                it('`to` has the correct voting power', async () => {
+                  expect(await token.getVotes(to.address)).to.equal(0);
+                });
+                it('`to`s delegate has not changed', async () => {
+                  expect(await token.delegates(to.address)).to.equal(
+                    other.address
+                  );
+                });
+                it('`to`s delegate has the correct voting power', async () => {
+                  const delegate = await token.delegates(to.address);
+                  expect(await token.getVotes(delegate)).to.equal(100);
+                });
+              });
+
+              context('`to` delegates to `other`', async () => {
+                beforeEach(async () => {
+                  await expect(token.connect(to).delegate(other.address))
+                    .to.emit(token, 'DelegateChanged')
+                    .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
+                });
+
+                it('`to` has the correct voting power', async () => {
+                  expect(await token.getVotes(to.address)).to.equal(0);
+                });
+                it('`to`s delegate is correctly changed', async () => {
+                  expect(await token.delegates(to.address)).to.equal(
+                    other.address
+                  );
+                });
+                it('`to`s delegate has the correct voting power', async () => {
+                  const delegate = await token.delegates(to.address);
+                  expect(await token.getVotes(delegate)).to.equal(200);
+                });
+              });
+            }
+          );
+
+          context('`to` receives via transfer from `from`', async () => {
+            beforeEach(async () => {
+              await token.depositFor(from.address, 100);
+              await expect(
+                token.connect(from).transfer(to.address, 100)
+              ).to.not.emit(token, 'DelegateChanged');
+            });
+
+            it('`from` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`from`s delegate has not changed', async () => {
+              expect(await token.delegates(from.address)).to.equal(
+                from.address
+              );
+            });
+            it('`from`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(from.address);
+              expect(await token.getVotes(delegate)).to.equal(0);
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(0);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(other.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(200);
+            });
+
+            context('`to` transfers to `other`', async () => {
+              beforeEach(async () => {
+                await expect(
+                  token.connect(to).transfer(other.address, 100)
+                ).to.not.emit(token, 'DelegateChanged');
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(100);
+              });
+            });
+
+            context('`to` delegates to `other`', async () => {
+              beforeEach(async () => {
+                await expect(token.connect(to).delegate(other.address))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate is correctly changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(200);
+              });
+            });
+          });
+        });
+
+        context('`to` has not delegated before', async () => {
+          context(
+            '`to` receives via `depositFor` from `address(0)`',
+            async () => {
+              beforeEach(async () => {
+                await expect(token.depositFor(to.address, 100)).to.not.emit(
+                  token,
+                  'DelegateChanged'
+                );
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(200);
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(to.address);
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(200);
+              });
+
+              context('`to` transfers to `other`', async () => {
+                beforeEach(async () => {
+                  await expect(token.connect(to).transfer(other.address, 100))
+                    .to.emit(token, 'DelegateChanged')
+                    .withArgs(other.address, addressZero, other.address); // the transfer triggers automatic self-delegation for `other`
+                });
+
+                it('`to` has the correct voting power', async () => {
+                  expect(await token.getVotes(to.address)).to.equal(100); // 100 tokens are still left
+                });
+                it('`to`s delegate has not changed', async () => {
+                  expect(await token.delegates(to.address)).to.equal(
+                    to.address
+                  );
+                });
+                it('`to`s delegate has the correct voting power', async () => {
+                  const delegate = await token.delegates(to.address);
+                  expect(await token.getVotes(delegate)).to.equal(100);
+                });
+              });
+
+              context('`to` delegates to `other`', async () => {
+                beforeEach(async () => {
+                  await expect(token.connect(to).delegate(other.address))
+                    .to.emit(token, 'DelegateChanged')
+                    .withArgs(to.address, to.address, other.address); // `to` delegates to `other`
+                });
+
+                it('`to` has the correct voting power', async () => {
+                  expect(await token.getVotes(to.address)).to.equal(0);
+                });
+                it('`to`s delegate is correctly changed', async () => {
+                  expect(await token.delegates(to.address)).to.equal(
+                    other.address
+                  );
+                });
+                it('`to`s delegate has the correct voting power', async () => {
+                  const delegate = await token.delegates(to.address);
+                  expect(await token.getVotes(delegate)).to.equal(200);
+                });
+              });
+            }
+          );
+
+          context('`to` receives via transfer from `from`', async () => {
+            beforeEach(async () => {
+              await token.depositFor(from.address, 100);
+              await expect(
+                token.connect(from).transfer(to.address, 100)
+              ).to.not.emit(token, 'DelegateChanged');
+            });
+
+            it('`from` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(200);
+            });
+            it('`from`s delegate has not changed', async () => {
+              expect(await token.delegates(from.address)).to.equal(
+                from.address
+              );
+            });
+            it('`from`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(from.address);
+              expect(await token.getVotes(delegate)).to.equal(0);
+            });
+
+            it('`to` has the correct voting power', async () => {
+              expect(await token.getVotes(to.address)).to.equal(200);
+            });
+            it('`to`s delegate has not changed', async () => {
+              expect(await token.delegates(to.address)).to.equal(to.address);
+            });
+            it('`to`s delegate has the correct voting power', async () => {
+              const delegate = await token.delegates(to.address);
+              expect(await token.getVotes(delegate)).to.equal(200);
+            });
+
+            context('`to` transfers to `other`', async () => {
+              beforeEach(async () => {
+                await expect(token.connect(to).transfer(other.address, 100))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(other.address, addressZero, other.address);
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(100);
+              });
+              it('`to`s delegate has not changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(to.address);
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(100);
+              });
+            });
+
+            context('`to` delegates to `other`', async () => {
+              beforeEach(async () => {
+                await expect(token.connect(to).delegate(other.address))
+                  .to.emit(token, 'DelegateChanged')
+                  .withArgs(to.address, to.address, other.address); // `to` delegates to `other`
+              });
+
+              it('`to` has the correct voting power', async () => {
+                expect(await token.getVotes(to.address)).to.equal(0);
+              });
+              it('`to`s delegate is correctly changed', async () => {
+                expect(await token.delegates(to.address)).to.equal(
+                  other.address
+                );
+              });
+              it('`to`s delegate has the correct voting power', async () => {
+                const delegate = await token.delegates(to.address);
+                expect(await token.getVotes(delegate)).to.equal(200);
+              });
+            });
+          });
+        });
+      });
     });
   });
 });

--- a/packages/contracts/test/token/erc20/governance-wrapped-erc20.ts
+++ b/packages/contracts/test/token/erc20/governance-wrapped-erc20.ts
@@ -542,7 +542,7 @@ describe('GovernanceWrappedERC20', function () {
             });
 
             it('`from` has the correct voting power', async () => {
-              expect(await token.getVotes(to.address)).to.equal(0);
+              expect(await token.getVotes(from.address)).to.equal(0);
             });
             it('`from`s delegate has not changed', async () => {
               expect(await token.delegates(from.address)).to.equal(
@@ -599,7 +599,7 @@ describe('GovernanceWrappedERC20', function () {
             });
 
             it('`from` has the correct voting power', async () => {
-              expect(await token.getVotes(to.address)).to.equal(100);
+              expect(await token.getVotes(from.address)).to.equal(0);
             });
             it('`from`s delegate has not changed', async () => {
               expect(await token.delegates(from.address)).to.equal(
@@ -686,7 +686,6 @@ describe('GovernanceWrappedERC20', function () {
                   await expect(token.connect(to).delegate(other.address))
                     .to.emit(token, 'DelegateChanged')
                     .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
-                  //toDelegate = other.address;
                 });
 
                 it('`to` has the correct voting power', async () => {
@@ -713,7 +712,7 @@ describe('GovernanceWrappedERC20', function () {
             });
 
             it('`from` has the correct voting power', async () => {
-              expect(await token.getVotes(to.address)).to.equal(0);
+              expect(await token.getVotes(from.address)).to.equal(0);
             });
             it('`from`s delegate has not changed', async () => {
               expect(await token.delegates(from.address)).to.equal(
@@ -758,7 +757,6 @@ describe('GovernanceWrappedERC20', function () {
                 await expect(token.connect(to).delegate(other.address))
                   .to.emit(token, 'DelegateChanged')
                   .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
-                //toDelegate = other.address;
               });
 
               it('`to` has the correct voting power', async () => {
@@ -847,7 +845,7 @@ describe('GovernanceWrappedERC20', function () {
             });
 
             it('`from` has the correct voting power', async () => {
-              expect(await token.getVotes(to.address)).to.equal(200);
+              expect(await token.getVotes(from.address)).to.equal(0);
             });
             it('`from`s delegate has not changed', async () => {
               expect(await token.delegates(from.address)).to.equal(

--- a/packages/contracts/test/token/erc20/governance-wrapped-erc20.ts
+++ b/packages/contracts/test/token/erc20/governance-wrapped-erc20.ts
@@ -30,6 +30,7 @@ const addressZero = ethers.constants.AddressZero;
 let from: SignerWithAddress;
 let to: SignerWithAddress;
 let other: SignerWithAddress;
+let toDelegate: string;
 
 describe('GovernanceWrappedERC20', function () {
   let signers: SignerWithAddress[];
@@ -322,13 +323,13 @@ describe('GovernanceWrappedERC20', function () {
 
       // verify that past votes are correct
       expect(
-        await governanceToken.getPastVotes(signers[0].address, tx1.blockNumber)
+        await governanceToken.getPastVotes(signers[0].address, tx1.blockNumber!)
       ).to.eq(0);
       expect(
-        await governanceToken.getPastVotes(signers[1].address, tx1.blockNumber)
+        await governanceToken.getPastVotes(signers[1].address, tx1.blockNumber!)
       ).to.eq(balanceSigner1.add(balanceSigner0));
       expect(
-        await governanceToken.getPastVotes(signers[2].address, tx1.blockNumber)
+        await governanceToken.getPastVotes(signers[2].address, tx1.blockNumber!)
       ).to.eq(balanceSigner2);
     });
   });
@@ -499,6 +500,7 @@ describe('GovernanceWrappedERC20', function () {
       context('`to` has a zero-balance', async () => {
         beforeEach(async () => {
           expect(await token.balanceOf(to.address)).to.eq(0);
+          toDelegate = addressZero;
         });
 
         context('`to` delegated to `other`', async () => {
@@ -506,6 +508,7 @@ describe('GovernanceWrappedERC20', function () {
             await expect(token.connect(to).delegate(other.address))
               .to.emit(token, 'DelegateChanged')
               .withArgs(to.address, addressZero, other.address);
+            toDelegate = other.address;
           });
 
           context(
@@ -522,13 +525,10 @@ describe('GovernanceWrappedERC20', function () {
                 expect(await token.getVotes(to.address)).to.equal(0);
               });
               it('`to`s delegate has not changed', async () => {
-                expect(await token.delegates(to.address)).to.equal(
-                  other.address
-                );
+                expect(await token.delegates(to.address)).to.equal(toDelegate);
               });
               it('`to`s delegate has the correct voting power', async () => {
-                const delegate = await token.delegates(to.address);
-                expect(await token.getVotes(delegate)).to.equal(100);
+                expect(await token.getVotes(toDelegate)).to.equal(100);
               });
             }
           );
@@ -550,19 +550,18 @@ describe('GovernanceWrappedERC20', function () {
               );
             });
             it('`from`s delegate has the correct voting power', async () => {
-              const delegate = await token.delegates(from.address);
-              expect(await token.getVotes(delegate)).to.equal(0);
+              const fromDelegate = await token.delegates(from.address);
+              expect(await token.getVotes(fromDelegate)).to.equal(0);
             });
 
             it('`to` has the correct voting power', async () => {
               expect(await token.getVotes(to.address)).to.equal(0);
             });
             it('`to`s delegate has not changed', async () => {
-              expect(await token.delegates(to.address)).to.equal(other.address);
+              expect(await token.delegates(to.address)).to.equal(toDelegate);
             });
             it('`to`s delegate has the correct voting power', async () => {
-              const delegate = await token.delegates(to.address);
-              expect(await token.getVotes(delegate)).to.equal(100);
+              expect(await token.getVotes(toDelegate)).to.equal(100);
             });
           });
         });
@@ -575,17 +574,17 @@ describe('GovernanceWrappedERC20', function () {
                 await expect(token.depositFor(to.address, 100))
                   .to.emit(token, 'DelegateChanged')
                   .withArgs(to.address, addressZero, to.address); // the mint triggers automatic self-delegation
+                toDelegate = to.address;
               });
 
               it('`to` has the correct voting power', async () => {
                 expect(await token.getVotes(to.address)).to.equal(100);
               });
               it('`to`s delegate has not changed', async () => {
-                expect(await token.delegates(to.address)).to.equal(to.address);
+                expect(await token.delegates(to.address)).to.equal(toDelegate);
               });
               it('`to`s delegate has the correct voting power', async () => {
-                const delegate = await token.delegates(to.address);
-                expect(await token.getVotes(delegate)).to.equal(100);
+                expect(await token.getVotes(toDelegate)).to.equal(100);
               });
             }
           );
@@ -596,6 +595,7 @@ describe('GovernanceWrappedERC20', function () {
               await expect(token.connect(from).transfer(to.address, 100))
                 .to.emit(token, 'DelegateChanged')
                 .withArgs(to.address, addressZero, to.address); // the transfer triggers automatic self-delegation
+              toDelegate = to.address;
             });
 
             it('`from` has the correct voting power', async () => {
@@ -607,19 +607,18 @@ describe('GovernanceWrappedERC20', function () {
               );
             });
             it('`from`s delegate has the correct voting power', async () => {
-              const delegate = await token.delegates(from.address);
-              expect(await token.getVotes(delegate)).to.equal(0);
+              const fromDelegate = await token.delegates(from.address);
+              expect(await token.getVotes(fromDelegate)).to.equal(0);
             });
 
             it('`to` has the correct voting power', async () => {
               expect(await token.getVotes(to.address)).to.equal(100);
             });
             it('`to`s delegate has not changed', async () => {
-              expect(await token.delegates(to.address)).to.equal(to.address);
+              expect(await token.delegates(to.address)).to.equal(toDelegate);
             });
             it('`to`s delegate has the correct voting power', async () => {
-              const delegate = await token.delegates(to.address);
-              expect(await token.getVotes(delegate)).to.equal(100);
+              expect(await token.getVotes(toDelegate)).to.equal(100);
             });
           });
         });
@@ -630,6 +629,7 @@ describe('GovernanceWrappedERC20', function () {
           await expect(token.depositFor(to.address, 100))
             .to.emit(token, 'DelegateChanged')
             .withArgs(to.address, addressZero, to.address);
+          toDelegate = to.address;
           expect(await token.balanceOf(to.address)).to.eq(100);
         });
 
@@ -638,6 +638,7 @@ describe('GovernanceWrappedERC20', function () {
             await expect(token.connect(to).delegate(other.address))
               .to.emit(token, 'DelegateChanged')
               .withArgs(to.address, to.address, other.address); // this changes the delegate from himself (`to`) to `other`
+            toDelegate = other.address;
           });
 
           context(
@@ -654,13 +655,10 @@ describe('GovernanceWrappedERC20', function () {
                 expect(await token.getVotes(to.address)).to.equal(0);
               });
               it('`to`s delegate has not changed', async () => {
-                expect(await token.delegates(to.address)).to.equal(
-                  other.address
-                );
+                expect(await token.delegates(to.address)).to.equal(toDelegate);
               });
               it('`to`s delegate has the correct voting power', async () => {
-                const delegate = await token.delegates(to.address);
-                expect(await token.getVotes(delegate)).to.equal(200);
+                expect(await token.getVotes(toDelegate)).to.equal(200);
               });
 
               context('`to` transfers to `other`', async () => {
@@ -675,12 +673,11 @@ describe('GovernanceWrappedERC20', function () {
                 });
                 it('`to`s delegate has not changed', async () => {
                   expect(await token.delegates(to.address)).to.equal(
-                    other.address
+                    toDelegate
                   );
                 });
                 it('`to`s delegate has the correct voting power', async () => {
-                  const delegate = await token.delegates(to.address);
-                  expect(await token.getVotes(delegate)).to.equal(100);
+                  expect(await token.getVotes(toDelegate)).to.equal(100);
                 });
               });
 
@@ -689,6 +686,7 @@ describe('GovernanceWrappedERC20', function () {
                   await expect(token.connect(to).delegate(other.address))
                     .to.emit(token, 'DelegateChanged')
                     .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
+                  //toDelegate = other.address;
                 });
 
                 it('`to` has the correct voting power', async () => {
@@ -700,8 +698,7 @@ describe('GovernanceWrappedERC20', function () {
                   );
                 });
                 it('`to`s delegate has the correct voting power', async () => {
-                  const delegate = await token.delegates(to.address);
-                  expect(await token.getVotes(delegate)).to.equal(200);
+                  expect(await token.getVotes(toDelegate)).to.equal(200);
                 });
               });
             }
@@ -724,8 +721,8 @@ describe('GovernanceWrappedERC20', function () {
               );
             });
             it('`from`s delegate has the correct voting power', async () => {
-              const delegate = await token.delegates(from.address);
-              expect(await token.getVotes(delegate)).to.equal(0);
+              const fromDelegate = await token.delegates(from.address);
+              expect(await token.getVotes(fromDelegate)).to.equal(0);
             });
 
             it('`to` has the correct voting power', async () => {
@@ -735,8 +732,7 @@ describe('GovernanceWrappedERC20', function () {
               expect(await token.delegates(to.address)).to.equal(other.address);
             });
             it('`to`s delegate has the correct voting power', async () => {
-              const delegate = await token.delegates(to.address);
-              expect(await token.getVotes(delegate)).to.equal(200);
+              expect(await token.getVotes(toDelegate)).to.equal(200);
             });
 
             context('`to` transfers to `other`', async () => {
@@ -750,13 +746,10 @@ describe('GovernanceWrappedERC20', function () {
                 expect(await token.getVotes(to.address)).to.equal(0);
               });
               it('`to`s delegate has not changed', async () => {
-                expect(await token.delegates(to.address)).to.equal(
-                  other.address
-                );
+                expect(await token.delegates(to.address)).to.equal(toDelegate);
               });
               it('`to`s delegate has the correct voting power', async () => {
-                const delegate = await token.delegates(to.address);
-                expect(await token.getVotes(delegate)).to.equal(100);
+                expect(await token.getVotes(toDelegate)).to.equal(100);
               });
             });
 
@@ -765,19 +758,17 @@ describe('GovernanceWrappedERC20', function () {
                 await expect(token.connect(to).delegate(other.address))
                   .to.emit(token, 'DelegateChanged')
                   .withArgs(to.address, other.address, other.address); // `to` re-delegates to `other` again
+                //toDelegate = other.address;
               });
 
               it('`to` has the correct voting power', async () => {
                 expect(await token.getVotes(to.address)).to.equal(0);
               });
               it('`to`s delegate is correctly changed', async () => {
-                expect(await token.delegates(to.address)).to.equal(
-                  other.address
-                );
+                expect(await token.delegates(to.address)).to.equal(toDelegate);
               });
               it('`to`s delegate has the correct voting power', async () => {
-                const delegate = await token.delegates(to.address);
-                expect(await token.getVotes(delegate)).to.equal(200);
+                expect(await token.getVotes(toDelegate)).to.equal(200);
               });
             });
           });
@@ -798,11 +789,10 @@ describe('GovernanceWrappedERC20', function () {
                 expect(await token.getVotes(to.address)).to.equal(200);
               });
               it('`to`s delegate has not changed', async () => {
-                expect(await token.delegates(to.address)).to.equal(to.address);
+                expect(await token.delegates(to.address)).to.equal(toDelegate);
               });
               it('`to`s delegate has the correct voting power', async () => {
-                const delegate = await token.delegates(to.address);
-                expect(await token.getVotes(delegate)).to.equal(200);
+                expect(await token.getVotes(toDelegate)).to.equal(200);
               });
 
               context('`to` transfers to `other`', async () => {
@@ -817,12 +807,11 @@ describe('GovernanceWrappedERC20', function () {
                 });
                 it('`to`s delegate has not changed', async () => {
                   expect(await token.delegates(to.address)).to.equal(
-                    to.address
+                    toDelegate
                   );
                 });
                 it('`to`s delegate has the correct voting power', async () => {
-                  const delegate = await token.delegates(to.address);
-                  expect(await token.getVotes(delegate)).to.equal(100);
+                  expect(await token.getVotes(toDelegate)).to.equal(100);
                 });
               });
 
@@ -831,6 +820,7 @@ describe('GovernanceWrappedERC20', function () {
                   await expect(token.connect(to).delegate(other.address))
                     .to.emit(token, 'DelegateChanged')
                     .withArgs(to.address, to.address, other.address); // `to` delegates to `other`
+                  toDelegate = other.address;
                 });
 
                 it('`to` has the correct voting power', async () => {
@@ -838,12 +828,11 @@ describe('GovernanceWrappedERC20', function () {
                 });
                 it('`to`s delegate is correctly changed', async () => {
                   expect(await token.delegates(to.address)).to.equal(
-                    other.address
+                    toDelegate
                   );
                 });
                 it('`to`s delegate has the correct voting power', async () => {
-                  const delegate = await token.delegates(to.address);
-                  expect(await token.getVotes(delegate)).to.equal(200);
+                  expect(await token.getVotes(toDelegate)).to.equal(200);
                 });
               });
             }
@@ -866,19 +855,18 @@ describe('GovernanceWrappedERC20', function () {
               );
             });
             it('`from`s delegate has the correct voting power', async () => {
-              const delegate = await token.delegates(from.address);
-              expect(await token.getVotes(delegate)).to.equal(0);
+              const fromDelegate = await token.delegates(from.address);
+              expect(await token.getVotes(fromDelegate)).to.equal(0);
             });
 
             it('`to` has the correct voting power', async () => {
               expect(await token.getVotes(to.address)).to.equal(200);
             });
             it('`to`s delegate has not changed', async () => {
-              expect(await token.delegates(to.address)).to.equal(to.address);
+              expect(await token.delegates(to.address)).to.equal(toDelegate);
             });
             it('`to`s delegate has the correct voting power', async () => {
-              const delegate = await token.delegates(to.address);
-              expect(await token.getVotes(delegate)).to.equal(200);
+              expect(await token.getVotes(toDelegate)).to.equal(200);
             });
 
             context('`to` transfers to `other`', async () => {
@@ -892,11 +880,10 @@ describe('GovernanceWrappedERC20', function () {
                 expect(await token.getVotes(to.address)).to.equal(100);
               });
               it('`to`s delegate has not changed', async () => {
-                expect(await token.delegates(to.address)).to.equal(to.address);
+                expect(await token.delegates(to.address)).to.equal(toDelegate);
               });
               it('`to`s delegate has the correct voting power', async () => {
-                const delegate = await token.delegates(to.address);
-                expect(await token.getVotes(delegate)).to.equal(100);
+                expect(await token.getVotes(toDelegate)).to.equal(100);
               });
             });
 
@@ -905,19 +892,17 @@ describe('GovernanceWrappedERC20', function () {
                 await expect(token.connect(to).delegate(other.address))
                   .to.emit(token, 'DelegateChanged')
                   .withArgs(to.address, to.address, other.address); // `to` delegates to `other`
+                toDelegate = other.address;
               });
 
               it('`to` has the correct voting power', async () => {
                 expect(await token.getVotes(to.address)).to.equal(0);
               });
               it('`to`s delegate is correctly changed', async () => {
-                expect(await token.delegates(to.address)).to.equal(
-                  other.address
-                );
+                expect(await token.delegates(to.address)).to.equal(toDelegate);
               });
               it('`to`s delegate has the correct voting power', async () => {
-                const delegate = await token.delegates(to.address);
-                expect(await token.getVotes(delegate)).to.equal(200);
+                expect(await token.getVotes(toDelegate)).to.equal(200);
               });
             });
           });

--- a/packages/contracts/test/token/erc20/governance-wrapped-erc20.ts
+++ b/packages/contracts/test/token/erc20/governance-wrapped-erc20.ts
@@ -497,7 +497,7 @@ describe('GovernanceWrappedERC20', function () {
     });
 
     context('exhaustive tests', async () => {
-      context('`to` has a zero-balance', async () => {
+      context('`to` has a zero balance', async () => {
         beforeEach(async () => {
           expect(await token.balanceOf(to.address)).to.eq(0);
           toDelegate = addressZero;
@@ -624,7 +624,7 @@ describe('GovernanceWrappedERC20', function () {
         });
       });
 
-      context('`to` has a non-zero-balance', async () => {
+      context('`to` has a non-zero balance', async () => {
         beforeEach(async () => {
           await expect(token.depositFor(to.address, 100))
             .to.emit(token, 'DelegateChanged')


### PR DESCRIPTION
## Description

Added more tests after the discovery that was fixed in #285 

Task: [APP-1865](https://aragonassociation.atlassian.net/browse/APP-1865)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.

[APP-1865]: https://aragonassociation.atlassian.net/browse/APP-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
```
   afterTokenTransfer
      ...
      exhaustive tests
        `to` has a zero-balance
          `to` delegated to `other`
            `to` receives via mint from `address(0)`
              ✓ `to` has the correct voting power
              ✓ `to`s delegate has not changed
              ✓ `to`s delegate has the correct voting power
            `to` receives via transfer from `from`
              ✓ `from` has the correct voting power
              ✓ `from`s delegate has not changed
              ✓ `from`s delegate has the correct voting power
              ✓ `to` has the correct voting power
              ✓ `to`s delegate has not changed
              ✓ `to`s delegate has the correct voting power
          `to` has not delegated before
            `to` receives via mint from `address(0)`
              ✓ `to` has the correct voting power
              ✓ `to`s delegate has not changed
              ✓ `to`s delegate has the correct voting power
            `to` receives via transfer from `from`
              ✓ `from` has the correct voting power
              ✓ `from`s delegate has not changed
              ✓ `from`s delegate has the correct voting power
              ✓ `to` has the correct voting power
              ✓ `to`s delegate has not changed
              ✓ `to`s delegate has the correct voting power
        `to` has a non-zero-balance
          `to` delegated to `other`
            `to` receives via mint from `address(0)`
              ✓ `to` has the correct voting power
              ✓ `to`s delegate has not changed
              ✓ `to`s delegate has the correct voting power
              `to` transfers to `other`
                ✓ `to` has the correct voting power
                ✓ `to`s delegate has not changed
                ✓ `to`s delegate has the correct voting power
              `to` delegates to `other`
                ✓ `to` has the correct voting power
                ✓ `to`s delegate is correctly changed
                ✓ `to`s delegate has the correct voting power
            `to` receives via transfer from `from`
              ✓ `from` has the correct voting power
              ✓ `from`s delegate has not changed
              ✓ `from`s delegate has the correct voting power
              ✓ `to` has the correct voting power
              ✓ `to`s delegate has not changed
              ✓ `to`s delegate has the correct voting power
              `to` transfers to `other`
                ✓ `to` has the correct voting power
                ✓ `to`s delegate has not changed
                ✓ `to`s delegate has the correct voting power
              `to` delegates to `other`
                ✓ `to` has the correct voting power
                ✓ `to`s delegate is correctly changed
                ✓ `to`s delegate has the correct voting power
          `to` has not delegated before
            `to` receives via mint from `address(0)`
              ✓ `to` has the correct voting power
              ✓ `to`s delegate has not changed
              ✓ `to`s delegate has the correct voting power
              `to` transfers to `other`
                ✓ `to` has the correct voting power
                ✓ `to`s delegate has not changed
                ✓ `to`s delegate has the correct voting power
              `to` delegates to `other`
                ✓ `to` has the correct voting power
                ✓ `to`s delegate is correctly changed
                ✓ `to`s delegate has the correct voting power
            `to` receives via transfer from `from`
              ✓ `from` has the correct voting power
              ✓ `from`s delegate has not changed
              ✓ `from`s delegate has the correct voting power
              ✓ `to` has the correct voting power
              ✓ `to`s delegate has not changed
              ✓ `to`s delegate has the correct voting power
              `to` transfers to `other`
                ✓ `to` has the correct voting power
                ✓ `to`s delegate has not changed
                ✓ `to`s delegate has the correct voting power
              `to` delegates to `other`
                ✓ `to` has the correct voting power
                ✓ `to`s delegate is correctly changed
                ✓ `to`s delegate has the correct voting power
```