### PR TITLE
Fixing npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@ Within this monorepo, you will be able to find 3 individual packages:
 - [Subgraph](https://github.com/aragon/osx/tree/develop/packages/subgraph): contains all code generating our subgraph and event indexing.
 - [Contract-ethers](https://github.com/aragon/osx/tree/develop/packages/contracts-ethers): contains the connection between the ethers package and our contracts.
 
+The contents of this repository are distributed via 3 different NPM packages:
+- `@aragon/osx-contracts`: The source files, including the protocol contracts and interfaces
+- `@aragon/osx-artifacts`: The contracts bytecode and ABI to use the protocol or deploy it
+- `@aragon/osx-ethers`: The TypeScript wrappers to use the protocol or deploy it
+
 For more information on the individual packages, please read the respective `README.md`.
+
+## Audit
+
+The core smart contracts have been audited by [Halborn](https://www.halborn.com/). 
+
+- [Security audit report](./audits/AragonOSx-security-audit-report-halborn.pdf)
+- The commit ID: [cb0621dc5185a73240a6ca33fccc7698f059fdf5](https://github.com/aragon/osx/commit/cb0621dc5185a73240a6ca33fccc7698f059fdf5)
+- February 24th 2023
 
 ## Contributing
 
@@ -100,14 +113,6 @@ You can find all plugins built by the Aragon team [here](https://github.com/arag
 The [Aragon OSx contracts](https://github.com/aragon/osx/tree/develop/packages/contracts) emits events that get indexed within our `subgraph`. This `subgraph`, whose [source code can be found here](https://github.com/aragon/osx/tree/develop/packages/subgraph), is what then fuels the [Aragon SDK](https://github.com/aragon/sdk).
 
 The [contract-ethers](https://github.com/aragon/osx/tree/develop/packages/contracts-ethers) package is the NPM package that provides `ethers.js` wrappers to use the [Aragon OSx contracts](https://github.com/aragon/osx/tree/develop/packages/contracts).
-
-## Audit
-
-The core smart contracts have been audited by [Halborn](https://www.halborn.com/). 
-
-- [Security audit report](./audits/AragonOSx-security-audit-report-halborn.pdf)
-- The commit ID: [cb0621dc5185a73240a6ca33fccc7698f059fdf5](https://github.com/aragon/osx/commit/cb0621dc5185a73240a6ca33fccc7698f059fdf5)
-- February 24th 2023
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Within this monorepo, you will be able to find 3 individual packages:
 - [Contract-ethers](https://github.com/aragon/osx/tree/develop/packages/contracts-ethers): contains the connection between the ethers package and our contracts.
 
 The contents of this repository are distributed via 3 different NPM packages:
-- `@aragon/osx-contracts`: The source files, including the protocol contracts and interfaces
+- `@aragon/osx`: The source files, including the protocol contracts and interfaces
 - `@aragon/osx-artifacts`: The contracts bytecode and ABI to use the protocol or deploy it
-- `@aragon/osx-ethers`: The TypeScript wrappers to use the protocol or deploy it
+- `@aragon/osx-ethers`: The TypeScript wrappers to use the protocol or deploy it using ethers.js
 
 For more information on the individual packages, please read the respective `README.md`.
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -7,7 +7,7 @@ Welcome to the contracts powering the Aragon OSx Protocol!
 yarn add @aragon/osx-artifacts
 
 # import the source files to build on top
-yarn add @aragon/osx-contracts
+yarn add @aragon/osx
 ```
 
 ## Get Started

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -2,6 +2,14 @@
 
 Welcome to the contracts powering the Aragon OSx Protocol!
 
+```sh
+# import the JSON ABI and the bytecode
+yarn add @aragon/osx-artifacts
+
+# import the source files to build on top
+yarn add @aragon/osx-contracts
+```
+
 ## Get Started
 
 To get started running your repository locally, run these commands on the project's root folder in your terminal:

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
@@ -8,7 +8,7 @@ Aragon OSx makes it easy for you to write, maintain, and distribute your own plu
 
 ### Hello, World!
 
-To use the Aragon OSx contracts inside your project, import them with `yarn add @aragon/osx` and start developing your own plugin implementation:
+To use the Aragon OSx contracts inside your project, import them with `yarn add @aragon/osx-contracts` and start developing your own plugin implementation:
 
 <!-- TODO: rename @aragon/core-contracts to @aragon/os-contracts and make sure .sol files are part of the NPM package-->
 

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
@@ -8,7 +8,7 @@ Aragon OSx makes it easy for you to write, maintain, and distribute your own plu
 
 ### Hello, World!
 
-To use the Aragon OSx contracts inside your project, import them with `yarn add @aragon/osx-contracts` and start developing your own plugin implementation:
+To use the Aragon OSx contracts inside your project, import them with `yarn add @aragon/osx` and start developing your own plugin implementation:
 
 <details>
 <summary><code>GreeterPlugin</code></summary>

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
@@ -8,7 +8,7 @@ Aragon OSx makes it easy for you to write, maintain, and distribute your own plu
 
 ### Hello, World!
 
-To use the Aragon OSx contracts inside your project, import them with `yarn add @aragon/core-contracts` and start developing your own plugin implementation:
+To use the Aragon OSx contracts inside your project, import them with `yarn add @aragon/osx` and start developing your own plugin implementation:
 
 <!-- TODO: rename @aragon/core-contracts to @aragon/os-contracts and make sure .sol files are part of the NPM package-->
 

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
@@ -10,8 +10,6 @@ Aragon OSx makes it easy for you to write, maintain, and distribute your own plu
 
 To use the Aragon OSx contracts inside your project, import them with `yarn add @aragon/osx-contracts` and start developing your own plugin implementation:
 
-<!-- TODO: rename @aragon/core-contracts to @aragon/os-contracts and make sure .sol files are part of the NPM package-->
-
 <details>
 <summary><code>GreeterPlugin</code></summary>
 


### PR DESCRIPTION
## Description

The current plugin development docs still had the old package name `@aragon/core-contracts` so devs are getting errors when installing.

Just updated the name to `@aragon/osx-contracts`.

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Documentation update

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [n/a] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [n/a] My changes generate no new warnings.
- [n/a] Any dependent changes have been merged and published in downstream modules.
- [n/a] I ran all tests with success and extended them if necessary.
- [n/a] I have updated the ``CHANGELOG.md`` file in the root folder.
- [n/a] I have tested my code on the test network.