### PR TITLE
move to dev dependency

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/osx-artifacts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The Aragon OSx Solidity contracts",
   "main": "dist/bundle-cjs.js",
   "module": "dist/bundle-esm.js",
@@ -73,9 +73,7 @@
     "tmp-promise": "^3.0.3",
     "ts-node": "^8.1.0",
     "typechain": "^5.2.0",
-    "typescript": "^4.4.4"
-  },
-  "dependencies": {
+    "typescript": "^4.4.4",
     "@ensdomains/ens-contracts": "0.0.11",
     "@opengsn/contracts": "2.2.6",
     "@openzeppelin/contracts": "4.8.1",

--- a/packages/contracts/src/package.json
+++ b/packages/contracts/src/package.json
@@ -14,5 +14,10 @@
   "bugs": {
     "url": "https://github.com/aragon/osx/issues"
   },
-  "homepage": "https://github.com/aragon/osx#readme"
+  "homepage": "https://github.com/aragon/osx#readme",
+  "dependencies": {
+    "@ensdomains/ens-contracts": "0.0.11",
+    "@openzeppelin/contracts": "4.8.1",
+    "@openzeppelin/contracts-upgradeable": "4.8.1"
+  }
 }

--- a/packages/contracts/src/package.json
+++ b/packages/contracts/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/osx",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The Aragon OSx Solidity contracts",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

After doing this, I realized one thing. If you install `@aragon/osx`, it's true, it brings the contracts in the node_modules, but they won't work unless consumer of our package installs `openzeppelin packages` by himself. Isn't the whole idea why dev would install our package to build on top of it ? 

Maybe in the `packages/contracts/src/package.json`, we should put OZ packages in the `dependencies` . 

@brickpop @mathewmeconry 

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.