### PR TITLE
fix: fixes vuln in Multisig Plugin

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored the `auth` modifier to always use `where = address(this)` and adapted errors.
 - Use OZ's upgradeable contracts for `PluginCloneable`.
 - Renamed `getDAO()` to `dao()` and changed the `dao` state variable mutability to private.
+- Disallows creating a new proposal in the Multisig plugin in the same block whereas the settings have been changed.
 
 ### Removed
 

--- a/packages/contracts/src/plugins/governance/multisig/Multisig.sol
+++ b/packages/contracts/src/plugins/governance/multisig/Multisig.sol
@@ -60,6 +60,10 @@ contract Multisig is
         uint16 minApprovals;
     }
 
+    /// @notice Keeps track at which the settings has been changed the last time.
+    /// @dev This variable is used to prevent proposal creations from happing in the same block as the settings have been changed.
+    uint64 public lastMultisigSettingsChange;
+
     /// @notice The [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID of the contract.
     bytes4 internal constant MULTISIG_INTERFACE_ID =
         this.initialize.selector ^
@@ -90,7 +94,7 @@ contract Multisig is
     error ApprovalCastForbidden(uint256 proposalId, address sender);
 
     /// @notice Thrown if the proposal execution is forbidden.
-    /// @param proposalId The ID of the proposal.
+    /// @param proposalId The ID of the proposal.s
     error ProposalExecutionForbidden(uint256 proposalId);
 
     /// @notice Thrown if the minimal approvals value is out of bounds (less than 1 or greater than the number of members in the address list).
@@ -212,6 +216,12 @@ contract Multisig is
         uint64 _endDate
     ) external returns (uint256 proposalId) {
         uint64 snapshotBlock = block.number.toUint64() - 1;
+
+        // Revert if the settings have been changed in the same block as this proposal should be created in.
+        // This prevents a malicious party from voting with previous addresses and the new settings.
+        if (lastMultisigSettingsChange > snapshotBlock) {
+            revert ProposalCreationForbidden(_msgSender());
+        }
 
         if (multisigSettings.onlyListed && !isListedAtBlock(_msgSender(), snapshotBlock)) {
             revert ProposalCreationForbidden(_msgSender());
@@ -425,6 +435,7 @@ contract Multisig is
         }
 
         multisigSettings = _multisigSettings;
+        lastMultisigSettingsChange = block.number.toUint64();
 
         emit MultisigSettingsUpdated({
             onlyListed: _multisigSettings.onlyListed,

--- a/packages/contracts/src/plugins/governance/multisig/Multisig.sol
+++ b/packages/contracts/src/plugins/governance/multisig/Multisig.sol
@@ -94,7 +94,7 @@ contract Multisig is
     error ApprovalCastForbidden(uint256 proposalId, address sender);
 
     /// @notice Thrown if the proposal execution is forbidden.
-    /// @param proposalId The ID of the proposal.s
+    /// @param proposalId The ID of the proposal.
     error ProposalExecutionForbidden(uint256 proposalId);
 
     /// @notice Thrown if the minimal approvals value is out of bounds (less than 1 or greater than the number of members in the address list).

--- a/packages/contracts/test/plugins/governance/multisig/multisig.ts
+++ b/packages/contracts/test/plugins/governance/multisig/multisig.ts
@@ -11,6 +11,7 @@ import {
   IMultisig__factory,
   IPlugin__factory,
   IProposal__factory,
+  Multisig,
 } from '../../../../typechain';
 import {
   findEvent,
@@ -61,7 +62,7 @@ export async function approveWithSigners(
 
 describe('Multisig', function () {
   let signers: SignerWithAddress[];
-  let multisig: any;
+  let multisig: Multisig;
   let dao: DAO;
   let dummyActions: any;
   let dummyMetadata: string;
@@ -372,7 +373,7 @@ describe('Multisig', function () {
       await expect(multisig.removeAddresses([signers[0].address]))
         .to.be.revertedWithCustomError(multisig, 'MinApprovalsOutOfBounds')
         .withArgs(
-          (await multisig.addresslistLength()) - 1,
+          (await multisig.addresslistLength()).sub(1),
           multisigSettings.minApprovals
         );
     });
@@ -391,7 +392,7 @@ describe('Multisig', function () {
       await expect(multisig.removeAddresses([signers[2].address]))
         .to.be.revertedWithCustomError(multisig, 'MinApprovalsOutOfBounds')
         .withArgs(
-          (await multisig.addresslistLength()) - 1,
+          (await multisig.addresslistLength()).sub(1),
           multisigSettings.minApprovals
         );
     });
@@ -506,6 +507,56 @@ describe('Multisig', function () {
           [],
           allowFailureMap
         );
+    });
+
+    it('reverts if the multisig settings have been changed in the same block', async () => {
+      await multisig.initialize(
+        dao.address,
+        [signers[0].address], // signers[0] is listed
+        multisigSettings
+      );
+      await dao.grant(
+        multisig.address,
+        dao.address,
+        await multisig.UPDATE_MULTISIG_SETTINGS_PERMISSION_ID()
+      );
+
+      await ethers.provider.send('evm_setAutomine', [false]);
+
+      const endDate = await timestampIn(5000);
+
+      await multisig.connect(signers[0]).createProposal(
+        dummyMetadata,
+        [
+          {
+            to: multisig.address,
+            value: 0,
+            data: multisig.interface.encodeFunctionData(
+              'updateMultisigSettings',
+              [
+                {
+                  onlyListed: false,
+                  minApprovals: 1,
+                },
+              ]
+            ),
+          },
+        ],
+        0,
+        true,
+        true,
+        0,
+        endDate
+      );
+      await expect(
+        multisig
+          .connect(signers[0])
+          .createProposal(dummyMetadata, [], 0, true, true, 0, endDate)
+      )
+        .to.revertedWithCustomError(multisig, 'ProposalCreationForbidden')
+        .withArgs(signers[0].address);
+
+      await ethers.provider.send('evm_setAutomine', [true]);
     });
 
     context('`onlyListed` is set to `false`:', async () => {


### PR DESCRIPTION
## Description
When the Multisig settings and addresses are updated and in the same block another proposal gets created an attacker could trigger a race condition:

Consider the addresses 0x01, 0x02, 0x03 to be a member of the Multisig, and the minApprovals is set to 2 during block 1.
Now 0x03 is considered a bad actor and a proposal is created and approved by 0x01 and 0x02 during block 2 but not yet executed to remove 0x03 from the member list and reduce minApprovals to 1.

0x03 can now swoop in with a MEV sandwich block 3 and execute the proposal and create a new proposal in the same block and auto-execute it resulting in 0x03 taking over the Multisig.

This problem is because `createProposal()` uses the members list from the previous block (2) but the new settings from block 3 resulting in 0x03 still being a member of the Multisig but having already minApprovals set to 1. So 0x03 can create any proposal, approve it and execute it in the same TX.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the test network.