### PR TITLE
OS-385, [M-02] C4arena: Clarifying NatSpec comment for TokenFactory

### DIFF
--- a/packages/contracts/src/framework/utils/TokenFactory.sol
+++ b/packages/contracts/src/framework/utils/TokenFactory.sol
@@ -75,6 +75,7 @@ contract TokenFactory {
     /// @param _mintSettings The token mint settings struct containing the `receivers` and `amounts`.
     /// @return The created `ERC20VotesUpgradeable` compatible token contract.
     /// @return The created `MerkleMinter` contract used to mint the `ERC20VotesUpgradeable` tokens or `address(0)` if an existing token was provided.
+    /// @dev  The `MerkleMinter` proxy deployed in this process is cloned as a [minimal proxy (ERC-1167)](https://eips.ethereum.org/EIPS/eip-1167) to save gas and therefore not upgradeable despite being an `PluginUUPSUpgradeable` implementation.
     function createToken(
         DAO _managingDao,
         TokenConfig calldata _tokenConfig,


### PR DESCRIPTION
## Description

Clarified that `TokenFactory` deploys non-upgradeable `MerkleMinter` contracts by cloning them to save gas, which was raised in the C4arena audit.

Task: [OS-385](https://aragonassociation.atlassian.net/browse/OS-385)

## Type of change

- Documentation

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the test network.