### PR TITLE
ERC-165 support for PermissionConditions

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Revert with an error if the `grantWithCondition` function in `PermissionManager` is called with a condition address that is not a `IPermissionCondition` implementation.
-- Revert with an error if the `applySingleTargetPermissions` function in `PermissionManager` is called with `PermissionLib.Operation.GrantWithCondition`.
+- Revert with errors (`ConditionNotAContract`, `ConditionInterfacNotSupported`) if the `grantWithCondition` function in `PermissionManager` is called with a condition address that is not a `IPermissionCondition` implementation.
+- Revert with an error (`GrantWithConditionNotSupported`) if the `applySingleTargetPermissions` function in `PermissionManager` is called with `PermissionLib.Operation.GrantWithCondition`.
 - Fixed logic bug in the `TokenVoting` and `AddresslistVoting` implementations that caused the `createProposal` function to emit the unvalidated `_startDate` and `_endDate` input arguments (that both can be zero) in the `ProposalCreated` event instead of the validated ones.
 - Changed the `createProposal` functions in `Multisig` to allow creating proposals when the `_msgSender()` is listed in the current block.
 - Changed the `createProposal` functions in `AddresslistVoting` to allow creating proposals when the `_msgSender()` is listed in the current block.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `PermissionConditionBase` to have ERC-165 support for `IPermissionCondition` implementations.
 - Inherit `ProtocolVersion` and `ERC165` in `DAOFactory`.
 - Inherit `ProtocolVersion` in `DAO`.
 - Added a `nonReentrant` modifier to the `execute` function in the `DAO` contract.
@@ -16,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Revert with an error if the `grantWithCondition` function in `PermissionManager` is called with a condition that is not a contract.
+- Revert with an error if the `grantWithCondition` function in `PermissionManager` is called with an condition address that is not a `IPermissionCondition` implementation.
 - Fixed logic bug in the `TokenVoting` and `AddresslistVoting` implementations that caused the `createProposal` function to emit the unvalidated `_startDate` and `_endDate` input arguments (that both can be zero) in the `ProposalCreated` event instead of the validated ones.
 - Changed the `createProposal` functions in `Multisig` to allow creating proposals when the `_msgSender()` is listed in the current block.
 - Changed the `createProposal` functions in `AddresslistVoting` to allow creating proposals when the `_msgSender()` is listed in the current block.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Revert with an error if the `grantWithCondition` function in `PermissionManager` is called with a condition that is not a contract.
 - Fixed logic bug in the `TokenVoting` and `AddresslistVoting` implementations that caused the `createProposal` function to emit the unvalidated `_startDate` and `_endDate` input arguments (that both can be zero) in the `ProposalCreated` event instead of the validated ones.
 - Changed the `createProposal` functions in `Multisig` to allow creating proposals when the `_msgSender()` is listed in the current block.
 - Changed the `createProposal` functions in `AddresslistVoting` to allow creating proposals when the `_msgSender()` is listed in the current block.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Revert with an error if the `grantWithCondition` function in `PermissionManager` is called with an condition address that is not a `IPermissionCondition` implementation.
+- Revert with an error if the `grantWithCondition` function in `PermissionManager` is called with a condition address that is not a `IPermissionCondition` implementation.
 - Fixed logic bug in the `TokenVoting` and `AddresslistVoting` implementations that caused the `createProposal` function to emit the unvalidated `_startDate` and `_endDate` input arguments (that both can be zero) in the `ProposalCreated` event instead of the validated ones.
 - Changed the `createProposal` functions in `Multisig` to allow creating proposals when the `_msgSender()` is listed in the current block.
 - Changed the `createProposal` functions in `AddresslistVoting` to allow creating proposals when the `_msgSender()` is listed in the current block.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `PermissionConditionBase` to have ERC-165 support for `IPermissionCondition` implementations.
+- Added `PermissionCondition` and `PermissionConditionUpgradeable` to have ERC-165 support for `IPermissionCondition` implementations.
 - Inherit `ProtocolVersion` and `ERC165` in `DAOFactory` and `PluginRepoFactory`.
 - Inherit `ProtocolVersion` in `DAO` and `PluginRepo`.
 - Added a `nonReentrant` modifier to the `execute` function in the `DAO` contract.

--- a/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/01-conditions.md
+++ b/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/01-conditions.md
@@ -173,7 +173,7 @@ In another use-case, we might want to make sure that the `sendCoins` function ca
 ```solidity title="PriceOracleCondition.sol"
 import '@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol';
 
-contract PriceOracleCondition is PermissionConditionx {
+contract PriceOracleCondition is PermissionCondition {
   AggregatorV3Interface internal priceFeed;
 
   // Network: Goerli

--- a/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/01-conditions.md
+++ b/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/01-conditions.md
@@ -5,7 +5,7 @@ title: Conditions
 ## Permission Conditions
 
 Permission conditions relay the decision if an authorized call is permitted to another contract.
-This contract must inherit from `PermissionConditionBase` and implement the `IPermissionCondition` interface.
+This contract must inherit from `PermissionCondition` and implement the `IPermissionCondition` interface.
 
 ```solidity title="@aragon/osx/core/permission/IPermissionCondition.sol"
 interface IPermissionCondition {
@@ -84,7 +84,7 @@ Let’s imagine that we want to make sure that `_amount` is not more than `1 ETH
 We can realize this requirement by deploying a `ParameterConstraintCondition` condition.
 
 ```solidity title="ParameterConstraintCondition.sol"
-contract ParameterConstraintCondition is PermissionConditionBase {
+contract ParameterConstraintCondition is PermissionCondition {
 	uint256 internal maxValue;
 
 	constructor(uint256 _maxValue) {
@@ -112,7 +112,7 @@ Now, after granting the `SEND_COINS_PERMISSION_ID` permission to `_where` and `_
 In another use-case, we might want to make sure that the `sendCoins` can only be called after a certain date. This would look as following:
 
 ```solidity title="TimeCondition.sol"
-contract TimeCondition is PermissionConditionBase {
+contract TimeCondition is PermissionCondition {
   uint256 internal date;
 
   constructor(uint256 _date) {
@@ -143,7 +143,7 @@ interface IProofOfHumanity {
   function isRegistered(address _submissionID) external view returns (bool);
 }
 
-contract ProofOfHumanityCondition is PermissionConditionBase {
+contract ProofOfHumanityCondition is PermissionCondition {
   IProofOfHumanity internal registry;
 
   constructor(IProofOfHumanity _registry) {
@@ -173,7 +173,7 @@ In another use-case, we might want to make sure that the `sendCoins` function ca
 ```solidity title="PriceOracleCondition.sol"
 import '@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol';
 
-contract PriceOracleCondition is PermissionConditionBase {
+contract PriceOracleCondition is PermissionConditionx {
   AggregatorV3Interface internal priceFeed;
 
   // Network: Goerli

--- a/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/01-conditions.md
+++ b/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/01-conditions.md
@@ -5,7 +5,7 @@ title: Conditions
 ## Permission Conditions
 
 Permission conditions relay the decision if an authorized call is permitted to another contract.
-This contract must implement the `IPermissionCondition` interface.
+This contract must inherit from `PermissionConditionBase` and implement the `IPermissionCondition` interface.
 
 ```solidity title="@aragon/osx/core/permission/IPermissionCondition.sol"
 interface IPermissionCondition {
@@ -84,7 +84,7 @@ Let’s imagine that we want to make sure that `_amount` is not more than `1 ETH
 We can realize this requirement by deploying a `ParameterConstraintCondition` condition.
 
 ```solidity title="ParameterConstraintCondition.sol"
-contract ParameterConstraintCondition is IPermissionCondition {
+contract ParameterConstraintCondition is PermissionConditionBase {
 	uint256 internal maxValue;
 
 	constructor(uint256 _maxValue) {
@@ -112,7 +112,7 @@ Now, after granting the `SEND_COINS_PERMISSION_ID` permission to `_where` and `_
 In another use-case, we might want to make sure that the `sendCoins` can only be called after a certain date. This would look as following:
 
 ```solidity title="TimeCondition.sol"
-contract TimeCondition is IPermissionCondition {
+contract TimeCondition is PermissionConditionBase {
   uint256 internal date;
 
   constructor(uint256 _date) {
@@ -143,7 +143,7 @@ interface IProofOfHumanity {
   function isRegistered(address _submissionID) external view returns (bool);
 }
 
-contract ProofOfHumanityCondition is IPermissionCondition {
+contract ProofOfHumanityCondition is PermissionConditionBase {
   IProofOfHumanity internal registry;
 
   constructor(IProofOfHumanity _registry) {
@@ -173,7 +173,7 @@ In another use-case, we might want to make sure that the `sendCoins` function ca
 ```solidity title="PriceOracleCondition.sol"
 import '@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol';
 
-contract PriceOracleCondition is IPermissionCondition {
+contract PriceOracleCondition is PermissionConditionBase {
   AggregatorV3Interface internal priceFeed;
 
   // Network: Goerli

--- a/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/index.md
@@ -104,7 +104,7 @@ function grantWithCondition(
   address _where,
   address _who,
   bytes32 _permissionId,
-  PermissionConditionBase _condition
+  PermissionCondition _condition
 ) external auth(_where, ROOT_PERMISSION_ID) {}
 ```
 

--- a/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/index.md
@@ -97,7 +97,7 @@ Exceptions are, again, the [DAO creation](../../02-framework/01-dao-creation/ind
 
 #### Granting Permission with Conditions
 
-Aragon OSx supports relaying the authorization of a function call to another contract inheriting from the `PermissionConditionBase` interface. This works by granting the permission with the `grantWithCondition` function
+Aragon OSx supports relaying the authorization of a function call to another contract inheriting from the `IPermissionCondition` interface. This works by granting the permission with the `grantWithCondition` function
 
 ```solidity title="@aragon/osx/core/permission/PermissionManager.sol"
 function grantWithCondition(

--- a/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/01-core/02-permissions/index.md
@@ -97,14 +97,14 @@ Exceptions are, again, the [DAO creation](../../02-framework/01-dao-creation/ind
 
 #### Granting Permission with Conditions
 
-Aragon OSx supports relaying the authorization of a function call to another contract inheriting from the `IPermissionCondition` interface. This works by granting the permission with the `grantWithCondition` function
+Aragon OSx supports relaying the authorization of a function call to another contract inheriting from the `PermissionConditionBase` interface. This works by granting the permission with the `grantWithCondition` function
 
 ```solidity title="@aragon/osx/core/permission/PermissionManager.sol"
 function grantWithCondition(
   address _where,
   address _who,
   bytes32 _permissionId,
-  IPermissionCondition _condition
+  PermissionConditionBase _condition
 ) external auth(_where, ROOT_PERMISSION_ID) {}
 ```
 

--- a/packages/contracts/src/core/permission/PermissionCondition.sol
+++ b/packages/contracts/src/core/permission/PermissionCondition.sol
@@ -7,8 +7,8 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IPermissionCondition} from "./IPermissionCondition.sol";
 
 /// @title PermissionCondition
-/// @author Aragon Association - 2021-2023
-/// @notice An abstract contract to inherit from and to be be implemented to support more customary permissions depending on on- or off-chain state, e.g., by querying token ownershop or a secondary condition, respectively.
+/// @author Aragon Association - 2023
+/// @notice An abstract contract for non-upgradeable contracts instantiated via the `new` keyword  to inherit from to support customary permissions depending on arbitrary on-chain state.
 abstract contract PermissionCondition is ERC165, IPermissionCondition {
     /// @notice Checks if an interface is supported by this or its parent contract.
     /// @param _interfaceId The ID of the interface.

--- a/packages/contracts/src/core/permission/PermissionCondition.sol
+++ b/packages/contracts/src/core/permission/PermissionCondition.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.8;
+
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+import {IPermissionCondition} from "./IPermissionCondition.sol";
+
+/// @title PermissionCondition
+/// @author Aragon Association - 2021-2023
+/// @notice An abstract contract to inherit from and to be be implemented to support more customary permissions depending on on- or off-chain state, e.g., by querying token ownershop or a secondary condition, respectively.
+abstract contract PermissionCondition is ERC165, IPermissionCondition {
+    /// @notice Checks if an interface is supported by this or its parent contract.
+    /// @param _interfaceId The ID of the interface.
+    /// @return Returns `true` if the interface is supported.
+    function supportsInterface(bytes4 _interfaceId) public view override returns (bool) {
+        return
+            _interfaceId == type(IPermissionCondition).interfaceId ||
+            super.supportsInterface(_interfaceId);
+    }
+}

--- a/packages/contracts/src/core/permission/PermissionConditionBase.sol
+++ b/packages/contracts/src/core/permission/PermissionConditionBase.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.8;
+
+import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
+
+import {IPermissionCondition} from "./IPermissionCondition.sol";
+
+/// @title PermissionConditionBase
+/// @author Aragon Association - 2021-2023
+/// @notice An abstract contract to inherit from and to be be implemented to support more customary permissions depending on on- or off-chain state, e.g., by querying token ownershop or a secondary condition, respectively.
+abstract contract PermissionConditionBase is ERC165Upgradeable, IPermissionCondition {
+    /// @notice Checks if an interface is supported by this or its parent contract.
+    /// @param _interfaceId The ID of the interface.
+    /// @return Returns `true` if the interface is supported.
+    function supportsInterface(bytes4 _interfaceId) public view override returns (bool) {
+        return
+            _interfaceId == type(IPermissionCondition).interfaceId ||
+            super.supportsInterface(_interfaceId);
+    }
+}

--- a/packages/contracts/src/core/permission/PermissionConditionUpgdaeable.sol
+++ b/packages/contracts/src/core/permission/PermissionConditionUpgdaeable.sol
@@ -6,10 +6,10 @@ import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/intro
 
 import {IPermissionCondition} from "./IPermissionCondition.sol";
 
-/// @title PermissionCondition
-/// @author Aragon Association - 2021-2023
-/// @notice An abstract contract to inherit from and to be be implemented to support more customary permissions depending on on- or off-chain state, e.g., by querying token ownershop or a secondary condition, respectively.
-abstract contract PermissionCondition is ERC165Upgradeable, IPermissionCondition {
+/// @title PermissionConditionUpgradeable
+/// @author Aragon Association - 2023
+/// @notice An abstract contract for upgradeable or cloneable contracts to inherit from and to support customary permissions depending on arbitrary on-chain state.
+abstract contract PermissionConditionUpgradeable is ERC165Upgradeable, IPermissionCondition {
     /// @notice Checks if an interface is supported by this or its parent contract.
     /// @param _interfaceId The ID of the interface.
     /// @return Returns `true` if the interface is supported.

--- a/packages/contracts/src/core/permission/PermissionConditionUpgdaeable.sol
+++ b/packages/contracts/src/core/permission/PermissionConditionUpgdaeable.sol
@@ -6,10 +6,10 @@ import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/intro
 
 import {IPermissionCondition} from "./IPermissionCondition.sol";
 
-/// @title PermissionConditionBase
+/// @title PermissionCondition
 /// @author Aragon Association - 2021-2023
 /// @notice An abstract contract to inherit from and to be be implemented to support more customary permissions depending on on- or off-chain state, e.g., by querying token ownershop or a secondary condition, respectively.
-abstract contract PermissionConditionBase is ERC165Upgradeable, IPermissionCondition {
+abstract contract PermissionCondition is ERC165Upgradeable, IPermissionCondition {
     /// @notice Checks if an interface is supported by this or its parent contract.
     /// @param _interfaceId The ID of the interface.
     /// @return Returns `true` if the interface is supported.

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -218,10 +218,11 @@ abstract contract PermissionManager is Initializable {
         _grant(address(this), _initialOwner, ROOT_PERMISSION_ID);
     }
 
-    /// @notice This method is used in the public `grant` method of the permission manager.
+    /// @notice This method is used in the external `grant` method of the permission manager.
     /// @param _where The address of the target contract for which `_who` receives permission.
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.
+    /// @dev Note, that granting permissions with `_who` or `_where` equal to `ANY_ADDR` does not replace other permissions with specific `_who` and `_where` addresses that exist in parallel.
     function _grant(address _where, address _who, bytes32 _permissionId) internal virtual {
         if (_where == ANY_ADDR || _who == ANY_ADDR) {
             revert AnyAddressDisallowedForWhoAndWhere();
@@ -239,7 +240,7 @@ abstract contract PermissionManager is Initializable {
         }
     }
 
-    /// @notice This method is used in the internal `_grant` method of the permission manager.
+    /// @notice This method is used in the external `grantWithCondition` method of the permission manager.
     /// @param _where The address of the target contract for which `_who` receives permission.
     /// @param _who The address (EOA or contract) owning the permission.
     /// @param _permissionId The permission identifier.

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -252,6 +252,10 @@ abstract contract PermissionManager is Initializable {
         bytes32 _permissionId,
         PermissionConditionBase _condition
     ) internal virtual {
+        if (!address(_condition).isContract()) {
+            revert ConditionInvalid(_condition);
+        }
+
         if (!_condition.supportsInterface(type(IPermissionCondition).interfaceId)) {
             revert ConditionInvalid(_condition);
         }

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -66,13 +66,13 @@ abstract contract PermissionManager is Initializable {
     /// @param here The address of the context in which the permission is granted.
     /// @param where The address of the target contract for which `_who` receives permission.
     /// @param who The address (EOA or contract) receiving the permission.
-    /// @param condition The address `ALLOW_FLAG` for regular permissions or, alternatively, the `PermissionCondition` to be used.
+    /// @param condition The address `ALLOW_FLAG` for regular permissions or, alternatively, the `PermissionConditionBase` contract implementation to be used.
     event Granted(
         bytes32 indexed permissionId,
         address indexed here,
         address where,
         address indexed who,
-        PermissionConditionBase condition
+        address condition
     );
 
     /// @notice Emitted when a permission `permission` is revoked in the context `here` from the address `_who` for the contract `_where`.
@@ -236,13 +236,7 @@ abstract contract PermissionManager is Initializable {
         if (currentFlag == UNSET_FLAG) {
             permissionsHashed[permHash] = ALLOW_FLAG;
 
-            emit Granted(
-                _permissionId,
-                msg.sender,
-                _where,
-                _who,
-                PermissionConditionBase(ALLOW_FLAG)
-            );
+            emit Granted(_permissionId, msg.sender, _where, _who, ALLOW_FLAG);
         }
     }
 
@@ -284,7 +278,7 @@ abstract contract PermissionManager is Initializable {
         if (currentCondition == UNSET_FLAG) {
             permissionsHashed[permHash] = newCondition;
 
-            emit Granted(_permissionId, msg.sender, _where, _who, _condition);
+            emit Granted(_permissionId, msg.sender, _where, _who, newCondition);
         } else if (currentCondition != newCondition) {
             // Revert if `permHash` is already granted, but uses a different condition.
             // If we don't revert, we either should:

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -236,8 +236,6 @@ abstract contract PermissionManager is Initializable {
             permissionsHashed[permHash] = ALLOW_FLAG;
 
             emit Granted(_permissionId, msg.sender, _where, _who, IPermissionCondition(ALLOW_FLAG));
-        } else {
-            // TODO https://aragonassociation.atlassian.net/browse/OS-159
         }
     }
 

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -50,9 +50,13 @@ abstract contract PermissionManager is Initializable {
         address newCondition
     );
 
-    /// @notice Thrown if an address is not a condition.
+    /// @notice Thrown if a condition address is not a contract.
     /// @param condition The address that is not a contract.
-    error ConditionInvalid(PermissionConditionBase condition);
+    error ConditionNotAContract(PermissionConditionBase condition);
+
+    /// @notice Thrown if a condition contract does not support the `IPermissionCondition` interface.
+    /// @param condition The address that is not a contract.
+    error ConditionInterfacNotSupported(PermissionConditionBase condition);
 
     /// @notice Thrown for `ROOT_PERMISSION_ID` or `EXECUTE_PERMISSION_ID` permission grants where `who` or `where` is `ANY_ADDR`.
 
@@ -258,11 +262,11 @@ abstract contract PermissionManager is Initializable {
         PermissionConditionBase _condition
     ) internal virtual {
         if (!address(_condition).isContract()) {
-            revert ConditionInvalid(_condition);
+            revert ConditionNotAContract(_condition);
         }
 
         if (!_condition.supportsInterface(type(IPermissionCondition).interfaceId)) {
-            revert ConditionInvalid(_condition);
+            revert ConditionInterfacNotSupported(_condition);
         }
 
         if (_where == ANY_ADDR && _who == ANY_ADDR) {

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -261,8 +261,10 @@ abstract contract PermissionManager is Initializable {
         }
 
         if (_where == ANY_ADDR || _who == ANY_ADDR) {
-            bool isRestricted = isPermissionRestrictedForAnyAddr(_permissionId);
-            if (_permissionId == ROOT_PERMISSION_ID || isRestricted) {
+            if (
+                _permissionId == ROOT_PERMISSION_ID ||
+                isPermissionRestrictedForAnyAddr(_permissionId)
+            ) {
                 revert PermissionsForAnyAddressDisallowed();
             }
         }

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -128,9 +128,6 @@ abstract contract PermissionManager is Initializable {
         bytes32 _permissionId,
         PermissionConditionBase _condition
     ) external virtual auth(ROOT_PERMISSION_ID) {
-        if (_condition.supportsInterface(type(IPermissionCondition).interfaceId)) {
-            revert ConditionInvalid(_condition);
-        }
         _grantWithCondition(_where, _who, _permissionId, _condition);
     }
 
@@ -261,7 +258,7 @@ abstract contract PermissionManager is Initializable {
         bytes32 _permissionId,
         PermissionConditionBase _condition
     ) internal virtual {
-        if (!address(_condition).isContract()) {
+        if (!_condition.supportsInterface(type(IPermissionCondition).interfaceId)) {
             revert ConditionInvalid(_condition);
         }
 

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -225,7 +225,7 @@ abstract contract PermissionManager is Initializable {
     /// @dev Note, that granting permissions with `_who` or `_where` equal to `ANY_ADDR` does not replace other permissions with specific `_who` and `_where` addresses that exist in parallel.
     function _grant(address _where, address _who, bytes32 _permissionId) internal virtual {
         if (_where == ANY_ADDR || _who == ANY_ADDR) {
-            revert AnyAddressDisallowedForWhoAndWhere();
+            revert PermissionsForAnyAddressDisallowed();
         }
 
         bytes32 permHash = permissionHash(_where, _who, _permissionId);

--- a/packages/contracts/src/test/permission/ParameterScopingPermissionConditionTest.sol
+++ b/packages/contracts/src/test/permission/ParameterScopingPermissionConditionTest.sol
@@ -2,10 +2,10 @@
 
 pragma solidity 0.8.17;
 
-import {PermissionConditionBase} from "../../core/permission/PermissionConditionBase.sol";
+import {PermissionCondition} from "../../core/permission/PermissionCondition.sol";
 import {TestPlugin} from "../plugin/PluginTest.sol";
 
-contract TestParameterScopingPermissionCondition is PermissionConditionBase {
+contract TestParameterScopingPermissionCondition is PermissionCondition {
     bytes4 public constant ADD_PERMISSIONED_SELECTOR = TestPlugin.addPermissioned.selector;
 
     function getSelector(bytes memory _data) public pure returns (bytes4 sig) {

--- a/packages/contracts/src/test/permission/ParameterScopingPermissionConditionTest.sol
+++ b/packages/contracts/src/test/permission/ParameterScopingPermissionConditionTest.sol
@@ -2,10 +2,10 @@
 
 pragma solidity 0.8.17;
 
-import {IPermissionCondition} from "../../core/permission/IPermissionCondition.sol";
+import {PermissionConditionBase} from "../../core/permission/PermissionConditionBase.sol";
 import {TestPlugin} from "../plugin/PluginTest.sol";
 
-contract TestParameterScopingPermissionCondition is IPermissionCondition {
+contract TestParameterScopingPermissionCondition is PermissionConditionBase {
     bytes4 public constant ADD_PERMISSIONED_SELECTOR = TestPlugin.addPermissioned.selector;
 
     function getSelector(bytes memory _data) public pure returns (bytes4 sig) {

--- a/packages/contracts/src/test/permission/PermissionConditionMock.sol
+++ b/packages/contracts/src/test/permission/PermissionConditionMock.sol
@@ -2,9 +2,9 @@
 
 pragma solidity 0.8.17;
 
-import "../../core/permission/IPermissionCondition.sol";
+import "../../core/permission/PermissionConditionBase.sol";
 
-contract PermissionConditionMock is IPermissionCondition {
+contract PermissionConditionMock is PermissionConditionBase {
     bool internal _hasPermissionsResult = true;
 
     function isGranted(

--- a/packages/contracts/src/test/permission/PermissionConditionMock.sol
+++ b/packages/contracts/src/test/permission/PermissionConditionMock.sol
@@ -2,9 +2,9 @@
 
 pragma solidity 0.8.17;
 
-import "../../core/permission/PermissionConditionBase.sol";
+import "../../core/permission/PermissionCondition.sol";
 
-contract PermissionConditionMock is PermissionConditionBase {
+contract PermissionConditionMock is PermissionCondition {
     bool internal _hasPermissionsResult = true;
 
     function isGranted(

--- a/packages/contracts/src/test/plugin/SharedPluginTest.sol
+++ b/packages/contracts/src/test/plugin/SharedPluginTest.sol
@@ -4,13 +4,13 @@ pragma solidity 0.8.17;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-import {IPermissionCondition} from "../../core/permission/IPermissionCondition.sol";
+import {PermissionConditionBase} from "../../core/permission/PermissionConditionBase.sol";
 import {PluginUUPSUpgradeable} from "../../core/plugin/PluginUUPSUpgradeable.sol";
 import {DaoUnauthorized} from "../../core/utils/auth.sol";
 import {IDAO} from "../../core/dao/IDAO.sol";
 
 /// @notice A test Plugin that manages permission to internal objects by associating their IDs with specific DAOs. Only the DAO for which the object was created has the permission to perform ID-gated actions on them.
-/// @dev This is realized by asking a `IPermissionCondition` that must be authorized in the DAO's permission manager.
+/// @dev This is realized by asking a `PermissionConditionBase` that must be authorized in the DAO's permission manager.
 contract TestSharedPlugin is PluginUUPSUpgradeable {
     bytes32 public constant ID_GATED_ACTION_PERMISSION_ID = keccak256("ID_GATED_ACTION_PERMISSION");
 
@@ -51,7 +51,7 @@ contract TestSharedPlugin is PluginUUPSUpgradeable {
     }
 
     /// @notice Executes something if the `id` parameter is authorized by the DAO associated through `ownedIds`.
-    ///         This is done by asking a `IPermissionCondition` that must be authorized in the DAO's permission manager via `grantWithCondition` and the `ID_GATED_ACTION_PERMISSION_ID`.
+    ///         This is done by asking a `PermissionConditionBase` that must be authorized in the DAO's permission manager via `grantWithCondition` and the `ID_GATED_ACTION_PERMISSION_ID`.
     /// @param _id The ID that is associated with a specific DAO
     function idGatedAction(uint256 _id) external sharedAuth(_id, ID_GATED_ACTION_PERMISSION_ID) {
         // do something
@@ -59,7 +59,7 @@ contract TestSharedPlugin is PluginUUPSUpgradeable {
 }
 
 /// @notice The condition associated with `TestSharedPlugin`
-contract TestIdGatingCondition is IPermissionCondition {
+contract TestIdGatingCondition is PermissionConditionBase {
     uint256 public allowedId;
 
     constructor(uint256 _id) {

--- a/packages/contracts/src/test/plugin/SharedPluginTest.sol
+++ b/packages/contracts/src/test/plugin/SharedPluginTest.sol
@@ -4,13 +4,13 @@ pragma solidity 0.8.17;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-import {PermissionConditionBase} from "../../core/permission/PermissionConditionBase.sol";
+import {PermissionCondition} from "../../core/permission/PermissionCondition.sol";
 import {PluginUUPSUpgradeable} from "../../core/plugin/PluginUUPSUpgradeable.sol";
 import {DaoUnauthorized} from "../../core/utils/auth.sol";
 import {IDAO} from "../../core/dao/IDAO.sol";
 
 /// @notice A test Plugin that manages permission to internal objects by associating their IDs with specific DAOs. Only the DAO for which the object was created has the permission to perform ID-gated actions on them.
-/// @dev This is realized by asking a `PermissionConditionBase` that must be authorized in the DAO's permission manager.
+/// @dev This is realized by asking a `PermissionCondition` that must be authorized in the DAO's permission manager.
 contract TestSharedPlugin is PluginUUPSUpgradeable {
     bytes32 public constant ID_GATED_ACTION_PERMISSION_ID = keccak256("ID_GATED_ACTION_PERMISSION");
 
@@ -59,7 +59,7 @@ contract TestSharedPlugin is PluginUUPSUpgradeable {
 }
 
 /// @notice The condition associated with `TestSharedPlugin`
-contract TestIdGatingCondition is PermissionConditionBase {
+contract TestIdGatingCondition is PermissionCondition {
     uint256 public allowedId;
 
     constructor(uint256 _id) {

--- a/packages/contracts/src/test/plugin/SharedPluginTest.sol
+++ b/packages/contracts/src/test/plugin/SharedPluginTest.sol
@@ -51,7 +51,7 @@ contract TestSharedPlugin is PluginUUPSUpgradeable {
     }
 
     /// @notice Executes something if the `id` parameter is authorized by the DAO associated through `ownedIds`.
-    ///         This is done by asking a `PermissionConditionBase` that must be authorized in the DAO's permission manager via `grantWithCondition` and the `ID_GATED_ACTION_PERMISSION_ID`.
+    ///         This is done by asking a `PermissionCondition` that must be authorized in the DAO's permission manager via `grantWithCondition` and the `ID_GATED_ACTION_PERMISSION_ID`.
     /// @param _id The ID that is associated with a specific DAO
     function idGatedAction(uint256 _id) external sharedAuth(_id, ID_GATED_ACTION_PERMISSION_ID) {
         // do something

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -183,7 +183,7 @@ describe('Core: PermissionManager', function () {
           ethers.constants.AddressZero
         )
       )
-        .to.be.revertedWithCustomError(pm, 'ConditionInvalid')
+        .to.be.revertedWithCustomError(pm, 'ConditionNotAContract')
         .withArgs(ethers.constants.AddressZero);
     });
 
@@ -200,7 +200,7 @@ describe('Core: PermissionManager', function () {
           nonConditionContract.address
         )
       )
-        .to.be.revertedWithCustomError(pm, 'ConditionInvalid')
+        .to.be.revertedWithCustomError(pm, 'ConditionInterfacNotSupported')
         .withArgs(nonConditionContract.address);
     });
 

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -173,7 +173,7 @@ describe('Core: PermissionManager', function () {
       ).deploy();
     });
 
-    it('reverts if the condition address does not support `IPermissionCondition`', async () => {
+    it('reverts if the condition address is not a contract', async () => {
       await expect(
         pm.grantWithCondition(
           pm.address,

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -7,6 +7,7 @@ import {
   PermissionConditionMock,
   PermissionManagerTest__factory,
   PermissionConditionMock__factory,
+  TestPlugin__factory,
 } from '../../../typechain';
 import {DeployTestPermissionCondition} from '../../test-utils/conditions';
 import {OZ_ERRORS} from '../../test-utils/error';
@@ -184,6 +185,23 @@ describe('Core: PermissionManager', function () {
       )
         .to.be.revertedWithCustomError(pm, 'ConditionInvalid')
         .withArgs(ethers.constants.AddressZero);
+    });
+
+    it('reverts if the condition contract does not support `IPermissionConditon`', async () => {
+      const nonConditionContract = await new TestPlugin__factory(
+        signers[0]
+      ).deploy();
+
+      await expect(
+        pm.grantWithCondition(
+          pm.address,
+          otherSigner.address,
+          ADMIN_PERMISSION_ID,
+          nonConditionContract.address
+        )
+      )
+        .to.be.revertedWithCustomError(pm, 'ConditionInvalid')
+        .withArgs(nonConditionContract.address);
     });
 
     it('should add permission', async () => {

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -101,7 +101,7 @@ describe('Core: PermissionManager', function () {
     it('reverts if both `_who == ANY_ADDR` and `_where == ANY_ADDR', async () => {
       await expect(
         pm.grant(ANY_ADDR, ANY_ADDR, ROOT_PERMISSION_ID)
-      ).to.be.revertedWithCustomError(pm, 'AnyAddressDisallowedForWhoAndWhere');
+      ).to.be.revertedWithCustomError(pm, 'PermissionsForAnyAddressDisallowed');
     });
 
     it('reverts if permissionId is restricted and `_who == ANY_ADDR` or `_where == ANY_ADDR`', async () => {
@@ -121,14 +121,14 @@ describe('Core: PermissionManager', function () {
       }
     });
 
-    it('reverts if permissionId is not restricted and`_who == ANY_ADDR` or `_where == ANY_ADDR` and condition is not present', async () => {
+    it('reverts if permissionId is not restricted and`_who == ANY_ADDR` or `_where == ANY_ADDR`', async () => {
       await expect(
         pm.grant(pm.address, ANY_ADDR, ADMIN_PERMISSION_ID)
-      ).to.be.revertedWithCustomError(pm, 'ConditionNotPresentForAnyAddress');
+      ).to.be.revertedWithCustomError(pm, 'PermissionsForAnyAddressDisallowed');
 
       await expect(
         pm.grant(ANY_ADDR, pm.address, ADMIN_PERMISSION_ID)
-      ).to.be.revertedWithCustomError(pm, 'ConditionNotPresentForAnyAddress');
+      ).to.be.revertedWithCustomError(pm, 'PermissionsForAnyAddressDisallowed');
     });
 
     it('should emit Granted', async () => {
@@ -468,20 +468,25 @@ describe('Core: PermissionManager', function () {
 
     it('should grant with condition', async () => {
       const signers = await ethers.getSigners();
+
+      const conditionMock2 = await new PermissionConditionMock__factory(
+        signers[0]
+      ).deploy();
+
       await pm.grant(pm.address, signers[0].address, ADMIN_PERMISSION_ID);
       const bulkItems: MultiTargetPermission[] = [
         {
           operation: Operation.GrantWithCondition,
           where: signers[1].address,
           who: signers[0].address,
-          condition: signers[3].address,
+          condition: conditionMock.address,
           permissionId: ADMIN_PERMISSION_ID,
         },
         {
           operation: Operation.GrantWithCondition,
           where: signers[2].address,
           who: signers[0].address,
-          condition: signers[4].address,
+          condition: conditionMock2.address,
           permissionId: ADMIN_PERMISSION_ID,
         },
       ];

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -6,6 +6,7 @@ import {
   PermissionManagerTest,
   PermissionConditionMock,
   PermissionManagerTest__factory,
+  PermissionConditionMock__factory,
 } from '../../../typechain';
 import {DeployTestPermissionCondition} from '../../test-utils/conditions';
 import {OZ_ERRORS} from '../../test-utils/error';
@@ -28,6 +29,8 @@ const ALLOW_FLAG = ethers.utils.getAddress(
 
 const addressZero = ethers.constants.AddressZero;
 const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff';
+
+let conditionMock: PermissionConditionMock;
 
 interface SingleTargetPermission {
   operation: Operation;
@@ -164,19 +167,38 @@ describe('Core: PermissionManager', function () {
   });
 
   describe('grantWithCondition', () => {
+    before(async () => {
+      conditionMock = await new PermissionConditionMock__factory(
+        signers[0]
+      ).deploy();
+    });
+
+    it('reverts if the condition address does not support `IPermissionCondition`', async () => {
+      await expect(
+        pm.grantWithCondition(
+          pm.address,
+          otherSigner.address,
+          ADMIN_PERMISSION_ID,
+          ethers.constants.AddressZero
+        )
+      )
+        .to.be.revertedWithCustomError(pm, 'ConditionInvalid')
+        .withArgs(ethers.constants.AddressZero);
+    });
+
     it('should add permission', async () => {
       await pm.grantWithCondition(
         pm.address,
         otherSigner.address,
         ADMIN_PERMISSION_ID,
-        ALLOW_FLAG
+        conditionMock.address
       );
       const permission = await pm.getAuthPermission(
         pm.address,
         otherSigner.address,
         ADMIN_PERMISSION_ID
       );
-      expect(permission).to.be.equal(ALLOW_FLAG);
+      expect(permission).to.be.equal(conditionMock.address);
     });
 
     it('should emit Granted', async () => {
@@ -185,7 +207,7 @@ describe('Core: PermissionManager', function () {
           pm.address,
           otherSigner.address,
           ADMIN_PERMISSION_ID,
-          ALLOW_FLAG
+          conditionMock.address
         )
       ).to.emit(pm, 'Granted');
     });
@@ -196,7 +218,7 @@ describe('Core: PermissionManager', function () {
           pm.address,
           ANY_ADDR,
           ADMIN_PERMISSION_ID,
-          pm.address // not condition, but enough for the call to succeed.
+          conditionMock.address
         )
       ).to.emit(pm, 'Granted');
 
@@ -205,7 +227,7 @@ describe('Core: PermissionManager', function () {
           ANY_ADDR,
           pm.address,
           ADMIN_PERMISSION_ID,
-          pm.address // not condition, but enough for the call to succeed.
+          conditionMock.address
         )
       ).to.emit(pm, 'Granted');
     });
@@ -215,14 +237,14 @@ describe('Core: PermissionManager', function () {
         pm.address,
         otherSigner.address,
         ADMIN_PERMISSION_ID,
-        ALLOW_FLAG
+        conditionMock.address
       );
       await expect(
         pm.grantWithCondition(
           pm.address,
           otherSigner.address,
           ADMIN_PERMISSION_ID,
-          ALLOW_FLAG
+          conditionMock.address
         )
       ).to.not.emit(pm, 'Granted');
     });
@@ -232,16 +254,19 @@ describe('Core: PermissionManager', function () {
         pm.address,
         otherSigner.address,
         ADMIN_PERMISSION_ID,
-        ALLOW_FLAG
+        conditionMock.address
       );
 
-      const newCondition = ownerSigner.address; // different address from what we pass in the previous grantWithCondition
+      const newConditionMock = await new PermissionConditionMock__factory(
+        signers[0]
+      ).deploy();
+
       await expect(
         pm.grantWithCondition(
           pm.address,
           otherSigner.address,
           ADMIN_PERMISSION_ID,
-          newCondition
+          newConditionMock.address
         )
       )
         .to.be.revertedWithCustomError(
@@ -252,29 +277,17 @@ describe('Core: PermissionManager', function () {
           pm.address,
           otherSigner.address,
           ADMIN_PERMISSION_ID,
-          ALLOW_FLAG,
-          newCondition
+          conditionMock.address,
+          newConditionMock.address
         );
     });
 
-    it('should revert when condition is not present for `who == ANY_ADDR` or `where == ANY_ADDR` and permissionId is not restricted', async () => {
-      await expect(
-        pm.grantWithCondition(
-          pm.address,
-          ANY_ADDR,
-          ADMIN_PERMISSION_ID,
-          ALLOW_FLAG
-        )
-      ).to.be.revertedWithCustomError(pm, 'ConditionNotPresentForAnyAddress');
-    });
-
     it('should set PermissionCondition', async () => {
-      const signers = await ethers.getSigners();
       await pm.grantWithCondition(
         pm.address,
         otherSigner.address,
         ADMIN_PERMISSION_ID,
-        signers[2].address
+        conditionMock.address
       );
       expect(
         await pm.getAuthPermission(
@@ -282,7 +295,7 @@ describe('Core: PermissionManager', function () {
           otherSigner.address,
           ADMIN_PERMISSION_ID
         )
-      ).to.be.equal(signers[2].address);
+      ).to.be.equal(conditionMock.address);
     });
 
     it('should not allow grant', async () => {
@@ -293,19 +306,19 @@ describe('Core: PermissionManager', function () {
             pm.address,
             otherSigner.address,
             ADMIN_PERMISSION_ID,
-            ALLOW_FLAG
+            conditionMock.address
           )
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
         .withArgs(pm.address, otherSigner.address, ROOT_PERMISSION_ID);
     });
 
-    it('should not allow for non ROOT', async () => {
+    it('reverts if the caller does not have `ROOT_PERMISSION_ID`', async () => {
       await pm.grantWithCondition(
         pm.address,
         ownerSigner.address,
         ADMIN_PERMISSION_ID,
-        ALLOW_FLAG
+        conditionMock.address
       );
       await expect(
         pm
@@ -314,7 +327,7 @@ describe('Core: PermissionManager', function () {
             pm.address,
             otherSigner.address,
             ROOT_PERMISSION_ID,
-            ALLOW_FLAG
+            conditionMock.address
           )
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')


### PR DESCRIPTION
## Description

Adds ERC-165  (`supportsInterface()`) to `IPermissionCondition` implementations by providing an abstract base class for implementers to inherit from.
This allows detection if a contract provided in `grantWithCondition` is really an `IPermissionCondition` contract. This is an important feature to prevent accidental bricking of the DAO by providing a wrong condition address.

Task: [OS-521](https://aragonassociation.atlassian.net/browse/OS-521)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [x] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-521]: https://aragonassociation.atlassian.net/browse/OS-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ