### PR TITLE
Dops 531 update check user perm gh actions osx

### DIFF
--- a/.github/workflows/comment-triggers.yml
+++ b/.github/workflows/comment-triggers.yml
@@ -11,23 +11,14 @@ jobs:
     name: A job to check user's permission level
     steps:
       - name: Check user permission (write)
-        id: checkw
-        uses: scherermichael-oss/action-has-permission@master
+        id: check-write
+        uses: actions-cool/check-user-permission@v2
         with:
-          required-permission: write
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check user permission (maintain)
-        id: checkm
-        uses: scherermichael-oss/action-has-permission@master
-        with:
-          required-permission: maintain
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          require: 'write'
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Abort
-        if: steps.checkw.outputs.has-permission != '1' && steps.checkm.outputs.has-permission != '1' 
+        if: steps.check-write.outputs.check-result == 'false'
         run: exit 1
-        
   mythx_partial:
     needs: [check_user_permission]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

New Github actions added in comment-triggers.yml to check user permission.

Task: [DOPS-531](https://aragonassociation.atlassian.net/browse/DOPS-531)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[DOPS-531]: https://aragonassociation.atlassian.net/browse/DOPS-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ