### PR TITLE
Improve index naming

### DIFF
--- a/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/01-plugin-repo/01-plugin-repo-creation.md
+++ b/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/01-plugin-repo/01-plugin-repo-creation.md
@@ -2,7 +2,7 @@
 title: Publishing a Plugin
 ---
 
-## The Plugin Repo Creation Process
+## To Create a PluginRepo is to Publish a Plugin
 
 To be available for installation in the Aragon OSx framework, a `PluginRepo` must be created for each plugin. The `PluginRepo` creation process is handled by:
 

--- a/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/01-plugin-repo/01-plugin-repo-creation.md
+++ b/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/01-plugin-repo/01-plugin-repo-creation.md
@@ -2,7 +2,7 @@
 title: Publishing a Plugin
 ---
 
-## To Create a PluginRepo is to Publish a Plugin
+## Start publishing your Plugin by creating a PluginRepo
 
 To be available for installation in the Aragon OSx framework, a `PluginRepo` must be created for each plugin. The `PluginRepo` creation process is handled by:
 

--- a/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/02-plugin-setup/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/02-plugin-setup/index.md
@@ -1,5 +1,5 @@
 ---
-title: The Plugin Contracts
+title: Installing Plugins
 ---
 
 ## The Smart Contracts Behind Plugins

--- a/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/index.md
@@ -1,8 +1,8 @@
 ---
-title: Managing Plugins
+title: Plugins
 ---
 
-## Managing Plugins
+## Plugins
 
 As mentioned earlier, plugins built by Aragon and third-party developers can be added and removed from your DAO to adapt it to your needs.
 

--- a/packages/contracts/docs/osx/01-how-it-works/02-framework/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/02-framework/index.md
@@ -1,8 +1,8 @@
 ---
-title: Framework
+title: Framework - How Everything Connects
 ---
 
-## The Infrastructure Running the Araong OSx Protocol
+## The Infrastructure Running the Aragon OSx Protocol
 
 The Aragon OSx protocol is composed of **framework-related contracts** creating and managing the **core contracts**. This includes the
 
@@ -20,7 +20,7 @@ An overview of the involved contracts and their interactions is shown below:
 
 ![](aragon-os-infrastructure-core-overview.drawio.svg)
 
-<p class="caption"> 
+<p class="caption">
   Overview of the framework and core contracts of the Aragon OSx protocol.
 </p>
 

--- a/packages/contracts/docs/osx/01-how-it-works/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/index.md
@@ -7,13 +7,12 @@ title: How It Works
 The Aragon OSx protocol is a DAO framework structured as follows:
 
 <div class="center-column">
-<!-- TODO: Update this image and remove the "DAO framework" narrative -->
-![](./aragon-os-framework-overview.drawio.svg)
-<!-- TODO: edit this entire page based on image -->
-<p class="caption">
-  Overview of the Aragon OSx protocol with its structural components and their responsibilities: the governance layer constituted by the framework DAO, the code layer including the framework and core contracts, which depends on external libraries and services.
-</p>
-
+  <!-- TODO: Update this image and remove the "DAO framework" narrative -->
+  ![](./aragon-os-framework-overview.drawio.svg)
+  <!-- TODO: edit this entire page based on image -->
+  <p class="caption">
+    Overview of the Aragon OSx protocol with its structural components and their responsibilities: the governance layer constituted by the framework DAO, the code layer including the framework and core contracts, which depends on external libraries and services.
+  </p>
 </div>
 
 ### Code Layer

--- a/packages/contracts/docs/osx/02-how-to-guides/01-dao/03-protocol-upgrades.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/01-dao/03-protocol-upgrades.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade your DAO to future Aragon OSx Protocol Versions
+title: Upgrade your DAO to future Aragon OSx Versions
 ---
 
 ## Upgrading to Future Aragon OSx Protocol Versions

--- a/packages/contracts/docs/osx/02-how-to-guides/01-dao/04-managing-plugins/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/01-dao/04-managing-plugins/index.md
@@ -1,5 +1,5 @@
 ---
-title: Manage the plugins installed in your DAO
+title: Manage your DAO's Plugins
 ---
 
 ## How to manage the Plugins within your DAO

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/01-best-practices.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/01-best-practices.md
@@ -1,5 +1,5 @@
 ---
-title: Before starting
+title: Before Starting
 ---
 
 ## Advice for Developing a Plugin

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/01-initialization.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/01-initialization.md
@@ -1,5 +1,5 @@
 ---
-title: Initializing Non-Upgradeable Plugins
+title: Initialization
 ---
 
 ## How to Initialize Non-Upgradeable Plugins

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/02-implementation.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/02-implementation.md
@@ -1,5 +1,5 @@
 ---
-title: Building a Non-Upgradeable Plugin contract
+title: Building the Plugin Implementation Contract
 ---
 
 ## How to Build a Non-Upgradeable Plugin

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/03-setup.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/03-setup.md
@@ -1,5 +1,5 @@
 ---
-title: Building a Plugin Setup contract for a Non-Upgradeable Plugin
+title: Building the Plugin Setup Contract
 ---
 
 ## What is the Plugin Setup contract?

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/index.md
@@ -1,6 +1,8 @@
 ---
-title: Get Started with Non-Upgradeable Plugins
+title: Non-Upgradeable Plugins
 ---
+
+## Get Started with Non-Upgradeable Plugins
 
 A Non-Upgradeable Plugin is a Plugin built on smart contracts that cannot be upgraded. This may or may not be what you want.
 

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/01-initialization.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/01-initialization.md
@@ -1,5 +1,5 @@
 ---
-title: Intializing an Upgradeable Plugin
+title: Intialization
 ---
 
 ## How to Initialize Upgradeable Plugins

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/02-implementation.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/02-implementation.md
@@ -1,5 +1,5 @@
 ---
-title: Building an Upgradeable Plugin
+title: The Plugin Implementation Contract
 ---
 
 ## How to build an Upgradeable Plugin implementation contract

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/03-setup.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/03-setup.md
@@ -1,5 +1,5 @@
 ---
-title: Building the Plugin Setup contract for Upgradeable Plugins
+title: The Plugin Setup Contract
 ---
 
 ## How to build the Plugin Setup Contract for Upgradeable Plugins

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/04-subsequent-builds.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/04-subsequent-builds.md
@@ -1,5 +1,5 @@
 ---
-title: Subsequent Builds for Upgradeable Plugins
+title: Subsequent Builds
 ---
 
 ## How to create a subsequent build to an Upgradeable Plugin

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/05-updating-versions.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/05-updating-versions.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrading an Upgradeable Plugin
+title: Upgrade the Plugin
 ---
 
 ## How to upgrade an Upgradeable Plugin

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/index.md
@@ -1,5 +1,5 @@
 ---
-title: What are Upgradeable Plugins?
+title: Upgradeable Plugins
 ---
 
 ## How to develop an Upgradeable Plugin

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/05-governance-plugins/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/05-governance-plugins/index.md
@@ -1,5 +1,5 @@
 ---
-title: Building Governance Plugins
+title: Governance Plugins
 ---
 
 ## How to Build a Governance Plugin

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/07-publication/01-versioning.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/07-publication/01-versioning.md
@@ -1,5 +1,5 @@
 ---
-title: Adding a new version of your plugin
+title: New Plugin Version
 ---
 
 ## How to add a new version of your plugin

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/07-publication/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/07-publication/index.md
@@ -1,5 +1,5 @@
 ---
-title: Publishing a plugin into Aragon's plugin registry
+title: Publication of your Plugin into Aragon OSx
 ---
 
 ## How to publish a plugin into Aragon's plugin registry

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
@@ -1,8 +1,8 @@
 ---
-title: Get Started with Developing your Plugin
+title: Get Started with your DAO Plugin
 ---
 
-# Plugin Development Quickstart Guide
+## Plugin Development Quickstart Guide
 
 Plugins are how we extend the functionality for DAOs. In Aragon OSx, everything a DAO can do is based on Plugin functionality enabled through permissions.
 

--- a/packages/contracts/docs/osx/03-reference-guide/index.md
+++ b/packages/contracts/docs/osx/03-reference-guide/index.md
@@ -1,5 +1,5 @@
 ---
-title: Reference
+title: Reference Guide
 ---
 
 ## Reference Guide

--- a/packages/contracts/docs/osx/index.md
+++ b/packages/contracts/docs/osx/index.md
@@ -46,6 +46,12 @@ contract MyCoolPlugin is Plugin {
 }
 ```
 
+## Customize your DAO
+
+DAO Plugins are the best way to customize your DAO. These are modular extendable pieces of software which you can install or uninstall from your DAO as it evolves and grows.
+
+To learn more about plugins, check out our guide [here](./02-how-to-guides/02-plugin-development/index.md).
+
 ### Walkthrough
 
 This documentation is divided into conceptual and practical sections as well as the reference guide.


### PR DESCRIPTION
## Description

Based on previous reviews and how the Developer Portal is showcasing names, I've decided to go back to the short naming conventions we had before. 

Additionally, I've improved the titles so they're consistent across plugin types.

Task: [DX-56](https://aragonassociation.atlassian.net/jira/software/projects/DX/boards/56?selectedIssue=DX-56)

## Type of change

Documentation

[DX-56]: https://aragonassociation.atlassian.net/browse/DX-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ