### PR TITLE
Feature: Add export of build metadata on contracts-ethers

### DIFF
--- a/packages/contracts-ethers/npm/index.ts
+++ b/packages/contracts-ethers/npm/index.ts
@@ -1,4 +1,12 @@
 import activeContracts from '../../../active_contracts.json';
+import addresslistVotingMetadata from '../../contracts/src/plugins/governance/majority-voting/addresslist/build-metadata.json';
+import tokenVotingMetadata from '../../contracts/src/plugins/governance/majority-voting/token/build-metadata.json';
+import multisigMetadata from '../../contracts/src/plugins/governance/multisig/build-metadata.json';
+import adminMetadata from '../../contracts/src/plugins/governance/admin/build-metadata.json';
 
 export * from '../types/';
 export const activeContractsList = activeContracts;
+export const addresslistVotingBuildMetadata = addresslistVotingMetadata;
+export const tokenVotingBuildMetadata = tokenVotingMetadata;
+export const multisigBuildMetadata = multisigMetadata;
+export const adminBuildMetadata = adminMetadata;


### PR DESCRIPTION
## Description

The SDK has no access to the build metadata on the contracts-ethers package, this PR adds the exports ins a similar way to the active contracts list so it has access

Task: [OS-486](https://aragonassociation.atlassian.net/browse/OS-486)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-486]: https://aragonassociation.atlassian.net/browse/OS-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ