### PR TITLE
Fix: typos and formatting issues on documentation

### DIFF
--- a/packages/contracts/docs/osx/01-how-it-works/01-core/03-plugins/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/01-core/03-plugins/index.md
@@ -29,7 +29,7 @@ Lern more about the different [plugin types](../../../02-how-to-guides/02-plugin
 
 This raises questions on how the DAO manages plugins and who actually owns plugins.
 
-### How does the DAO manage a Plugin?
+### How Does the DAO Manage a Plugin?
 
 A DAO manages plugins and interactions between them. In more detail, its permission manager:
 

--- a/packages/contracts/docs/osx/01-how-it-works/01-core/03-plugins/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/01-core/03-plugins/index.md
@@ -29,15 +29,13 @@ Lern more about the different [plugin types](../../../02-how-to-guides/02-plugin
 
 This raises questions on how the DAO manages plugins and who actually owns plugins.
 
-### How does the DAO Manage a Plugin?
+### How does the DAO manage a Plugin?
 
 A DAO manages plugins and interactions between them. In more detail, its permission manager:
 
 - enables the plugin installation process through the granting and revoking of permissions for the DAO
 - authorizes calls to plugin functions carrying the `auth` modifier
-- authorizes calls to DAO functions, for example, the `execute` function allowing for acting as the DAO
-
-by checking if the caller `hasPermission`.
+- authorizes calls to DAO functions, for example the `execute` function, allowing to act as the DAO
 
 <div class="center-column">
 

--- a/packages/contracts/docs/osx/01-how-it-works/01-core/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/01-core/index.md
@@ -26,8 +26,6 @@ In a nutshell, your Aragon OSx DAO consists of three pieces:
 
 The underlying smart contracts constitute **the core contracts** of the Aragon OSx DAO framework.
 
-The following graphic shows how an exemplary DAO setup, where the
-
 <div class="center-column">
 
 ![Schematic depiction of the interaction between the DAO, the PermissionManager, and a Plugin contract.](dao-plugin.drawio.svg)

--- a/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/01-plugin-repo/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/01-plugin-repo/index.md
@@ -47,10 +47,10 @@ function createVersion(
 
 The function receives four input arguments:
 
-a) The `_release` number to create the build for. If the release number exists already (e.g., release `1`), it is registered as the latest build (e.g., `1.3` if the previous build was `1.2`). If it is a new release number, the build number is `1` (e.g., `2.1`).
-b) The address of `PluginSetup` contract internally referencing the implementation contract (to copy, proxy, or clone from it) and taking care of [installing, updating to, and uninstalling](../02-plugin-setup/index.md) this specific version.
-c) The `_buildMetadata` URI pointing to a JSON file containing the UI data, setup data, and change description for this specific version.
-d) The `_releaseMetadata` URI pointing to a JSON file containing the plugin name, description, as well as optional data such as images to be shown in the aragonApp frontend.
+1. The `_release` number to create the build for. If the release number exists already (e.g., release `1`), it is registered as the latest build (e.g., `1.3` if the previous build was `1.2`). If it is a new release number, the build number is `1` (e.g., `2.1`).
+2. The address of `PluginSetup` contract internally referencing the implementation contract (to copy, proxy, or clone from it) and taking care of [installing, updating to, and uninstalling](../02-plugin-setup/index.md) this specific version.
+3. The `_buildMetadata` URI pointing to a JSON file containing the UI data, setup data, and change description for this specific version.
+4. The `_releaseMetadata` URI pointing to a JSON file containing the plugin name, description, as well as optional data such as images to be shown in the aragonApp frontend.
 
 Other functions present in the contract allow you to query previous versions and to update the release metadata. For more details visit the [`PluginRepo` reference guide entry](../../../../03-reference-guide/framework/plugin/repo/PluginRepo.md).
 

--- a/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/index.md
+++ b/packages/contracts/docs/osx/01-how-it-works/02-framework/02-plugin-management/index.md
@@ -19,17 +19,17 @@ In the following, we learn what a plugin consists of.
 
 ### What Does a Plugin Consist Of?
 
-An Aragon OSx Plugin consist of:
+An Aragon OSx Plugin consists of:
 
 - The `PluginSetup` contract
 
-  - referencing the `Plugin` implementation internally and
+  - referencing the `Plugin` implementation internally
   - containing the setup instruction to install, update, and uninstall it to an existing DAO
 
 - A metadata URI pointing to a `JSON` file containing the
 
-- AragonApp frontend information
-- Information needed for the setup ABI
+  - AragonApp frontend information
+  - Information needed for the setup ABI
 
 - A version tag consisting of a
 

--- a/packages/contracts/docs/osx/02-how-to-guides/01-dao/04-managing-plugins/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/01-dao/04-managing-plugins/index.md
@@ -40,7 +40,7 @@ If you do that, nobody would be able to create proposals and execute actions on 
 
 A very important thing to consider when operating your DAO is to make sure that you do not lock it - meaning, you allow it into a state where the DAO cannot execute actions anymore.
 
-The accidental loss of the permission to execute actions on your DAO, [the `EXECUTION_PERMISSION_ID`] permission](../../../01-how-it-works/01-core/02-permissions/index.md#permissions-native-to-the-dao-contract) this incapacitates your DAO. If this happens, you are not able to withdraw funds or act through the DAO, unless you have the `ROOT_PERMISSION_ID` on the DAO.
+The accidental loss of the permission to execute actions on your DAO ([the `EXECUTION_PERMISSION_ID` permission](../../../01-how-it-works/01-core/02-permissions/index.md#permissions-native-to-the-dao-contract)) incapacitates your DAO. If this happens, you are not able to withdraw funds or act through the DAO, unless you have the `ROOT_PERMISSION_ID` on the DAO.
 
 :::danger
 Do not interact directly with the smart contracts unless you know exactly what you are doing, **especially if this involves granting or revoking permissions**. Instead, use the Aragon App or Aragon SDK for creating and managing your DAO and interacting with the smart contracts.

--- a/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
+++ b/packages/contracts/docs/osx/02-how-to-guides/02-plugin-development/index.md
@@ -191,7 +191,7 @@ If you want to review how to publish your plugin in more depth, review our [How 
 
 ### Next Steps
 
-Congratulations 🎉! You HAve developed a plugin that every Aragon DAO will be able to use.
+Congratulations 🎉! You have developed a plugin that every Aragon DAO will be able to use.
 
 Currently, it is not doing much. Let's change this by adding additional functionality. You check out our [existing plugins](https://github.com/aragon/osx/tree/develop/packages/contracts/src/plugins) as inspiration.
 


### PR DESCRIPTION
## Description

As I was reading the [OSx documentation](https://devs.aragon.org/docs/osx/), I found some small typos and formatting issues that have been fixed on this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
