### PR TITLE
refactor: removed deprecated SignatureValidatorSet event from subgraph

### DIFF
--- a/packages/contracts/test/core/dao/dao.ts
+++ b/packages/contracts/test/core/dao/dao.ts
@@ -76,7 +76,6 @@ const EVENTS = {
   Deposited: 'Deposited',
   Executed: 'Executed',
   NativeTokenDeposited: 'NativeTokenDeposited',
-  SignatureValidatorSet: 'SignatureValidatorSet',
   StandardCallbackRegistered: 'StandardCallbackRegistered',
   CallbackReceived: 'CallbackReceived',
 };

--- a/packages/contracts/utils/event.ts
+++ b/packages/contracts/utils/event.ts
@@ -57,7 +57,6 @@ export const DAO_EVENTS = {
   DEPOSITED: 'Deposited',
   STANDARD_CALLBACK_REGISTERED: 'StandardCallbackRegistered',
   TRUSTED_FORWARDER_SET: 'TrustedForwarderSet',
-  SIGNATURE_VALIDATOR_SET: 'SignatureValidatorSet',
   NEW_URI: 'NewURI',
 };
 

--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed `SignatureValidatorSet` event.
 - Removed `ContractPermissionId` entity.
 
 ## [1.3.0]

--- a/packages/subgraph/manifest/subgraph.placeholder.yaml
+++ b/packages/subgraph/manifest/subgraph.placeholder.yaml
@@ -144,8 +144,8 @@ templates:
           handler: handleTrustedForwarderSet
         - event: StandardCallbackRegistered(bytes4,bytes4,bytes4)
           handler: handleStandardCallbackRegistered
-        - event: SignatureValidatorSet(address)
-          handler: handleSignatureValidatorSet
+        #- event: SignatureValidatorSet(address) # removed in 1.4.0
+        #  handler: handleSignatureValidatorSet
         - event: NewURI(string)
           handler: handleNewURI
   - name: DaoTemplateV1_3_0

--- a/packages/subgraph/manifest/subgraph.placeholder.yaml
+++ b/packages/subgraph/manifest/subgraph.placeholder.yaml
@@ -144,8 +144,6 @@ templates:
           handler: handleTrustedForwarderSet
         - event: StandardCallbackRegistered(bytes4,bytes4,bytes4)
           handler: handleStandardCallbackRegistered
-        #- event: SignatureValidatorSet(address) # removed in 1.4.0
-        #  handler: handleSignatureValidatorSet
         - event: NewURI(string)
           handler: handleNewURI
   - name: DaoTemplateV1_3_0

--- a/packages/subgraph/src/dao/dao_v1_0_0.ts
+++ b/packages/subgraph/src/dao/dao_v1_0_0.ts
@@ -12,7 +12,6 @@ import {
   Granted,
   Revoked,
   TrustedForwarderSet,
-  SignatureValidatorSet,
   StandardCallbackRegistered,
   CallbackReceived,
   NewURI,
@@ -214,17 +213,6 @@ export function handleTrustedForwarderSet(event: TrustedForwarderSet): void {
   let entity = Dao.load(daoId);
   if (entity) {
     entity.trustedForwarder = event.params.forwarder;
-    entity.save();
-  }
-}
-
-export function handleSignatureValidatorSet(
-  event: SignatureValidatorSet
-): void {
-  let daoId = event.address.toHexString();
-  let entity = Dao.load(daoId);
-  if (entity) {
-    entity.signatureValidator = event.params.signatureValidator;
     entity.save();
   }
 }

--- a/packages/subgraph/tests/dao/dao_v1_0_0.test.ts
+++ b/packages/subgraph/tests/dao/dao_v1_0_0.test.ts
@@ -10,7 +10,6 @@ import {
   handleExecuted,
   _handleMetadataSet,
   handleTrustedForwarderSet,
-  handleSignatureValidatorSet,
   handleStandardCallbackRegistered,
   handleCallbackReceived,
   handleNewURI,
@@ -69,7 +68,6 @@ import {
   createNewExecutedEvent,
   createDaoEntityState,
   createTrustedForwarderSetEvent,
-  createSignatureValidatorSetEvent,
   createStandardCallbackRegisteredEvent,
   getSupportsInterface,
   encodeWithFunctionSelector,
@@ -1385,32 +1383,6 @@ test('Run dao (handleTrustedForwarderSet) mappings with mock event', () => {
     'Dao',
     entityID,
     'trustedForwarder',
-    Address.fromString(ADDRESS_ONE).toHexString()
-  );
-
-  clearStore();
-});
-
-test('Run dao (handleSignatureValidatorSet) mappings with mock event', () => {
-  // create state
-  let entityID = Address.fromString(DAO_ADDRESS).toHexString();
-  createDaoEntityState(entityID, ADDRESS_ONE, DAO_TOKEN_ADDRESS);
-
-  let signatureValidator = ADDRESS_ONE;
-
-  let newEvent = createSignatureValidatorSetEvent(
-    signatureValidator,
-    DAO_ADDRESS
-  );
-  // handle event
-  handleSignatureValidatorSet(newEvent);
-
-  // checks
-  assert.fieldEquals('Dao', entityID, 'id', entityID);
-  assert.fieldEquals(
-    'Dao',
-    entityID,
-    'signatureValidator',
     Address.fromString(ADDRESS_ONE).toHexString()
   );
 

--- a/packages/subgraph/tests/dao/utils.ts
+++ b/packages/subgraph/tests/dao/utils.ts
@@ -5,7 +5,6 @@ import {
   Deposited,
   Executed,
   TrustedForwarderSet,
-  SignatureValidatorSet,
   StandardCallbackRegistered,
   CallbackReceived,
   NewURI,
@@ -104,27 +103,6 @@ export function createTrustedForwarderSetEvent(
   newTrustedForwarderSetEvent.parameters.push(trustedForwarderParam);
 
   return newTrustedForwarderSetEvent;
-}
-
-export function createSignatureValidatorSetEvent(
-  signatureValidator: string,
-  contractAddress: string
-): SignatureValidatorSet {
-  let newSignatureValidatorSetEvent = changetype<SignatureValidatorSet>(
-    newMockEvent()
-  );
-
-  newSignatureValidatorSetEvent.address = Address.fromString(contractAddress);
-  newSignatureValidatorSetEvent.parameters = [];
-
-  let trustedForwarderParam = new ethereum.EventParam(
-    'signatureValidator',
-    ethereum.Value.fromAddress(Address.fromString(signatureValidator))
-  );
-
-  newSignatureValidatorSetEvent.parameters.push(trustedForwarderParam);
-
-  return newSignatureValidatorSetEvent;
 }
 
 export function createNewNativeTokenDepositedEvent(


### PR DESCRIPTION
## Description

Task: [OS-724](https://aragonassociation.atlassian.net/browse/OS-724)

## Type of change
See the framework lifecylce in `packages/contracts/docs/framework-lifecycle` to decide what kind of change this pull request is.
<!--- Please delete options that are not relevant. -->

- The `SignatureValidatorSet` was not used anywhere so removal does not qualify as a breaking change

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [x] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-724]: https://aragonassociation.atlassian.net/browse/OS-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ