### PR TITLE
feat: less restrictive solidity compiler pragmas

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed the solidity compiler pragma from `0.8.17` to `^0.8.8` for all files.
 - Improved type safety by using `abi.encodeCall` instead of `abi.encodeWithSelector` and the more explicit bracket syntax for permissions.
 - Bumped OpenZeppelin dependencies to `4.9.3`.
 - Refactored the fallback in the `isGranted` function in `PermissionManager` to make conditions mutually exclusive: Specific conditions answering `false` do not fall back to generic caller conditions (`_who: ANY_ADDR`) or generic target conditions (`_where: ANY_ADDR`).

--- a/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/01-initialization.md
+++ b/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/01-initialization.md
@@ -29,7 +29,7 @@ In this case, the compiler will force you to write a `constructor` function call
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {Plugin, IDAO} from '@aragon/osx/core/plugin/Plugin.sol';
 
@@ -57,7 +57,7 @@ To deploy our plugin via the [minimal clones pattern (ERC-1167)](https://eips.et
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {PluginCloneable, IDAO} from '@aragon/osx/core/plugin/PluginCloneable.sol';
 

--- a/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/03-setup.md
+++ b/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/03-setup.md
@@ -41,7 +41,7 @@ Each `PluginSetup` contract is deployed only once and we will publish a separate
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {PluginSetup, IPluginSetup} from '@aragon/osx/framework/plugin/setup/PluginSetup.sol';
 import {SimpleAdmin} from './SimpleAdmin.sol';
@@ -227,7 +227,7 @@ Now, it's time to wrap up everything together. You should have a contract that l
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {Clones} from '@openzeppelin/contracts/proxy/Clones.sol';
 

--- a/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/index.md
+++ b/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/03-non-upgradeable-plugin/index.md
@@ -85,7 +85,7 @@ Then, inside of the file, add the functionality:
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {Plugin, IDAO} from '@aragon/osx/core/plugin/Plugin.sol';
 
@@ -122,7 +122,7 @@ In the `prepareInstallation()` function here then, we will grant the `GREET_PERM
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {PluginSetup} from '@aragon/osx/framework/plugin/setup/PluginSetup.sol';
 import {PermissionLib} from '@aragon/osx/core/permission/PermissionLib.sol';

--- a/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/01-initialization.md
+++ b/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/01-initialization.md
@@ -14,7 +14,7 @@ This has to be called - otherwise, anyone else could call the plugin's initializ
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {PluginUUPSUpgradeable, IDAO} '@aragon/osx/core/plugin/PluginUUPSUpgradeable.sol';
 

--- a/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/03-setup.md
+++ b/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/03-setup.md
@@ -12,7 +12,7 @@ Before building the Plugin Setup contract, make sure you have the logic for your
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {IDAO, PluginUUPSUpgradeable} from '@aragon/osx/core/plugin/PluginUUPSUpgradeable.sol';
 
@@ -53,7 +53,7 @@ Similarly, the `prepareUninstallation()` function takes in a `payload`.
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {PermissionLib} from '@aragon/osx/core/permission/PermissionLib.sol';
 import {PluginSetup, IPluginSetup} from '@aragon/osx/framework/plugin/setup/PluginSetup.sol';

--- a/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/05-updating-versions.md
+++ b/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/04-upgradeable-plugin/05-updating-versions.md
@@ -14,7 +14,7 @@ Firstly, you want to create the new build implementation contract the plugin sho
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {IDAO, PluginUUPSUpgradeable} from '@aragon/osx/core/plugin/PluginUUPSUpgradeable.sol';
 
@@ -61,7 +61,7 @@ In contrast to the original build 1, build 2 requires two input arguments: `uint
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {PermissionLib} from '@aragon/osx/core/permission/PermissionLib.sol';
 import {PluginSetup, IPluginSetup} from '@aragon/osx/framework/plugin/setup/PluginSetup.sol';
@@ -159,7 +159,7 @@ In this third build, for example, we are modifying the bytecode of the plugin.
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {IDAO, PluginUUPSUpgradeable} from '@aragon/osx/core/plugin/PluginUUPSUpgradeable.sol';
 
@@ -234,7 +234,7 @@ With each new build implementation, we will need to udate the Plugin Setup contr
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {PermissionLib} from '@aragon/osx/core/permission/PermissionLib.sol';
 import {PluginSetup, IPluginSetup} from '@aragon/osx/framework/plugin/setup/PluginSetup.sol';

--- a/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/index.md
+++ b/packages/contracts/docs/developer-portal/02-how-to-guides/02-plugin-development/index.md
@@ -76,7 +76,7 @@ Inside the `GreeterPlugin.sol`, we want to:
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {Plugin, IDAO} from '@aragon/osx/core/plugin/Plugin.sol';
 
@@ -105,7 +105,7 @@ Inside the file, we'll add the `prepareInstallation` and `prepareUninstallation`
 
 ```solidity
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {PermissionLib} from '@aragon/osx/core/permission/PermissionLib.sol';
 import {PluginSetup} from '@aragon/osx/framework/plugin/setup/PluginSetup.sol';

--- a/packages/contracts/docs/developer-portal/index.md
+++ b/packages/contracts/docs/developer-portal/index.md
@@ -37,7 +37,7 @@ Then, to use the contracts within your project, **import the contracts** through
 
 ```solidity title="MyCoolPlugin.sol"
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity 0.8.17;
+pragma solidity 0.8.21;
 
 import {Plugin, IDAO} from '@aragon/osx/core/plugin/Plugin.sol';
 

--- a/packages/contracts/src/core/dao/DAO.sol
+++ b/packages/contracts/src/core/dao/DAO.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165StorageUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/packages/contracts/src/core/dao/IEIP4824.sol
+++ b/packages/contracts/src/core/dao/IEIP4824.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 /// @title EIP-4824 Common Interfaces for DAOs
 /// @dev See https://eips.ethereum.org/EIPS/eip-4824

--- a/packages/contracts/src/core/utils/BitMap.sol
+++ b/packages/contracts/src/core/utils/BitMap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 /// @param bitmap The `uint256` representation of bits.
 /// @param index The index number to check whether 1 or 0 is set.

--- a/packages/contracts/src/core/utils/CallbackHandler.sol
+++ b/packages/contracts/src/core/utils/CallbackHandler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 /// @title CallbackHandler
 /// @author Aragon Association - 2022-2023

--- a/packages/contracts/src/framework/dao/DAOFactory.sol
+++ b/packages/contracts/src/framework/dao/DAOFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/packages/contracts/src/framework/dao/DAORegistry.sol
+++ b/packages/contracts/src/framework/dao/DAORegistry.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {ProtocolVersion} from "../../utils/protocol/ProtocolVersion.sol";
 import {IDAO} from "../../core/dao/IDAO.sol";

--- a/packages/contracts/src/framework/plugin/repo/IPluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/IPluginRepo.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 /// @title IPluginRepo
 /// @author Aragon Association - 2022-2023

--- a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier:    AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";

--- a/packages/contracts/src/framework/plugin/repo/PluginRepoFactory.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepoFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/packages/contracts/src/framework/plugin/repo/PluginRepoRegistry.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepoRegistry.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {ProtocolVersion} from "../../../utils/protocol/ProtocolVersion.sol";
 import {IDAO} from "../../../core/dao/IDAO.sol";

--- a/packages/contracts/src/framework/plugin/setup/PluginSetupProcessor.sol
+++ b/packages/contracts/src/framework/plugin/setup/PluginSetupProcessor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 

--- a/packages/contracts/src/framework/plugin/setup/PluginSetupProcessorHelpers.sol
+++ b/packages/contracts/src/framework/plugin/setup/PluginSetupProcessorHelpers.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PermissionLib} from "../../../core/permission/PermissionLib.sol";
 import {PluginRepo} from "../repo/PluginRepo.sol";

--- a/packages/contracts/src/framework/utils/InterfaceBasedRegistry.sol
+++ b/packages/contracts/src/framework/utils/InterfaceBasedRegistry.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC165CheckerUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165CheckerUpgradeable.sol";

--- a/packages/contracts/src/framework/utils/RegistryUtils.sol
+++ b/packages/contracts/src/framework/utils/RegistryUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 /// @notice Validates that a subdomain name is composed only from characters in the allowed character set:
 /// - the lowercase letters `a-z`

--- a/packages/contracts/src/framework/utils/TokenFactory.sol
+++ b/packages/contracts/src/framework/utils/TokenFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/packages/contracts/src/framework/utils/ens/ENSMigration.sol
+++ b/packages/contracts/src/framework/utils/ens/ENSMigration.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This is a migration file as suggested here https://docs.ens.domains/deploying-ens-on-a-private-chain#migration-file-example to compile the contracts and make their artifacts available in our tests.
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "@ensdomains/ens-contracts/contracts/registry/ENSRegistry.sol";
 import "@ensdomains/ens-contracts/contracts/resolvers/PublicResolver.sol";

--- a/packages/contracts/src/framework/utils/ens/ENSSubdomainRegistrar.sol
+++ b/packages/contracts/src/framework/utils/ens/ENSSubdomainRegistrar.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
 import "@ensdomains/ens-contracts/contracts/resolvers/Resolver.sol";

--- a/packages/contracts/src/plugins/counter-example/MultiplyHelper.sol
+++ b/packages/contracts/src/plugins/counter-example/MultiplyHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PluginUUPSUpgradeable} from "../../core/plugin/PluginUUPSUpgradeable.sol";
 

--- a/packages/contracts/src/plugins/counter-example/v1/CounterV1.sol
+++ b/packages/contracts/src/plugins/counter-example/v1/CounterV1.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PluginUUPSUpgradeable} from "../../../core/plugin/PluginUUPSUpgradeable.sol";
 import {MultiplyHelper} from "../MultiplyHelper.sol";

--- a/packages/contracts/src/plugins/counter-example/v1/CounterV1PluginSetup.sol
+++ b/packages/contracts/src/plugins/counter-example/v1/CounterV1PluginSetup.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/packages/contracts/src/plugins/counter-example/v2/CounterV2.sol
+++ b/packages/contracts/src/plugins/counter-example/v2/CounterV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PluginUUPSUpgradeable} from "../../../core/plugin/PluginUUPSUpgradeable.sol";
 import {MultiplyHelper} from "../MultiplyHelper.sol";

--- a/packages/contracts/src/plugins/counter-example/v2/CounterV2PluginSetup.sol
+++ b/packages/contracts/src/plugins/counter-example/v2/CounterV2PluginSetup.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/packages/contracts/src/plugins/governance/admin/Admin.sol
+++ b/packages/contracts/src/plugins/governance/admin/Admin.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {SafeCastUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 

--- a/packages/contracts/src/plugins/governance/admin/AdminSetup.sol
+++ b/packages/contracts/src/plugins/governance/admin/AdminSetup.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVoting.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVoting.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {SafeCastUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 

--- a/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVotingSetup.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVotingSetup.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {IDAO} from "../../../../core/dao/IDAO.sol";
 import {DAO} from "../../../../core/dao/DAO.sol";

--- a/packages/contracts/src/plugins/governance/majority-voting/token/TokenVoting.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/token/TokenVoting.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {IVotesUpgradeable} from "@openzeppelin/contracts-upgradeable/governance/utils/IVotesUpgradeable.sol";
 import {SafeCastUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";

--- a/packages/contracts/src/plugins/governance/majority-voting/token/TokenVotingSetup.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/token/TokenVotingSetup.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/packages/contracts/src/plugins/governance/multisig/IMultisig.sol
+++ b/packages/contracts/src/plugins/governance/multisig/IMultisig.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {IDAO} from "../../../core/dao/IDAO.sol";
 

--- a/packages/contracts/src/plugins/governance/multisig/Multisig.sol
+++ b/packages/contracts/src/plugins/governance/multisig/Multisig.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {SafeCastUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 

--- a/packages/contracts/src/plugins/governance/multisig/MultisigSetup.sol
+++ b/packages/contracts/src/plugins/governance/multisig/MultisigSetup.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {IDAO} from "../../../core/dao/IDAO.sol";
 import {DAO} from "../../../core/dao/DAO.sol";

--- a/packages/contracts/src/plugins/placeholder-version/PlaceholderSetup.sol
+++ b/packages/contracts/src/plugins/placeholder-version/PlaceholderSetup.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PermissionLib} from "../../core/permission/PermissionLib.sol";
 import {PluginSetup, IPluginSetup} from "../../framework/plugin/setup/PluginSetup.sol";

--- a/packages/contracts/src/plugins/token/IMerkleDistributor.sol
+++ b/packages/contracts/src/plugins/token/IMerkleDistributor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import {ERC20WrapperUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20WrapperUpgradeable.sol";

--- a/packages/contracts/src/plugins/token/IMerkleMinter.sol
+++ b/packages/contracts/src/plugins/token/IMerkleMinter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 

--- a/packages/contracts/src/plugins/token/MerkleDistributor.sol
+++ b/packages/contracts/src/plugins/token/MerkleDistributor.sol
@@ -2,7 +2,7 @@
 
 // Copied and modified from: https://github.com/Uniswap/merkle-distributor/blob/master/contracts/MerkleDistributor.sol
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {SafeERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";

--- a/packages/contracts/src/plugins/token/MerkleMinter.sol
+++ b/packages/contracts/src/plugins/token/MerkleMinter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";

--- a/packages/contracts/src/test/Migration.sol
+++ b/packages/contracts/src/test/Migration.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 /*
  * @title Migration

--- a/packages/contracts/src/test/dao/ActionExecute.sol
+++ b/packages/contracts/src/test/dao/ActionExecute.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 /// @notice A dummy contract to test if DAO can successfully execute an action
 contract ActionExecute {

--- a/packages/contracts/src/test/dao/CallbackHandlerHelperMock.sol
+++ b/packages/contracts/src/test/dao/CallbackHandlerHelperMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {CallbackHandler} from "../../core/utils/CallbackHandler.sol";
 

--- a/packages/contracts/src/test/dao/DAOMock.sol
+++ b/packages/contracts/src/test/dao/DAOMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/packages/contracts/src/test/dao/GasConsumerHelper.sol
+++ b/packages/contracts/src/test/dao/GasConsumerHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 /// @notice This contract is used for testing to consume gas.
 contract GasConsumer {

--- a/packages/contracts/src/test/permission/ParameterScopingPermissionConditionTest.sol
+++ b/packages/contracts/src/test/permission/ParameterScopingPermissionConditionTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PermissionCondition} from "../../core/permission/PermissionCondition.sol";
 import {TestPlugin} from "../plugin/PluginTest.sol";

--- a/packages/contracts/src/test/permission/PermissionConditionMock.sol
+++ b/packages/contracts/src/test/permission/PermissionConditionMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "../../core/permission/PermissionCondition.sol";
 

--- a/packages/contracts/src/test/permission/PermissionManagerTest.sol
+++ b/packages/contracts/src/test/permission/PermissionManagerTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/packages/contracts/src/test/plugin/AddresslistMock.sol
+++ b/packages/contracts/src/test/plugin/AddresslistMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "../../plugins/utils/Addresslist.sol";
 

--- a/packages/contracts/src/test/plugin/AdminCloneFactory.sol
+++ b/packages/contracts/src/test/plugin/AdminCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/packages/contracts/src/test/plugin/Clonable/PluginCloneableMock.sol
+++ b/packages/contracts/src/test/plugin/Clonable/PluginCloneableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PluginCloneable} from "../../../core/plugin/PluginCloneable.sol";
 import {IDAO} from "../../../core/dao/IDAO.sol";

--- a/packages/contracts/src/test/plugin/Clonable/PluginCloneableSetupMock.sol
+++ b/packages/contracts/src/test/plugin/Clonable/PluginCloneableSetupMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PermissionLib} from "../../../core/permission/PermissionLib.sol";
 import {IDAO} from "../../../core/dao/IDAO.sol";

--- a/packages/contracts/src/test/plugin/Constructable/PluginMock.sol
+++ b/packages/contracts/src/test/plugin/Constructable/PluginMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Plugin} from "../../../core/plugin/Plugin.sol";
 import {IDAO} from "../../../core/dao/IDAO.sol";

--- a/packages/contracts/src/test/plugin/MajorityVotingMock.sol
+++ b/packages/contracts/src/test/plugin/MajorityVotingMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "../../plugins/governance/majority-voting/MajorityVotingBase.sol";
 

--- a/packages/contracts/src/test/plugin/PluginMockData.sol
+++ b/packages/contracts/src/test/plugin/PluginMockData.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PermissionLib} from "../../core/permission/PermissionLib.sol";
 import {createERC1967Proxy} from "../../utils/Proxy.sol";

--- a/packages/contracts/src/test/plugin/PluginTest.sol
+++ b/packages/contracts/src/test/plugin/PluginTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PluginUUPSUpgradeable} from "../../core/plugin/PluginUUPSUpgradeable.sol";
 import {IDAO} from "../../core/dao/IDAO.sol";

--- a/packages/contracts/src/test/plugin/SharedPluginTest.sol
+++ b/packages/contracts/src/test/plugin/SharedPluginTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/packages/contracts/src/test/plugin/UUPSUpgradeable/PluginUUPSUpgradeableMock.sol
+++ b/packages/contracts/src/test/plugin/UUPSUpgradeable/PluginUUPSUpgradeableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PluginUUPSUpgradeable} from "../../../core/plugin/PluginUUPSUpgradeable.sol";
 import {IDAO} from "../../../core/dao/IDAO.sol";

--- a/packages/contracts/src/test/plugin/UUPSUpgradeable/PluginUUPSUpgradeableSetupMock.sol
+++ b/packages/contracts/src/test/plugin/UUPSUpgradeable/PluginUUPSUpgradeableSetupMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {PermissionLib} from "../../../core/permission/PermissionLib.sol";
 import {IDAO} from "../../../core/dao/IDAO.sol";

--- a/packages/contracts/src/test/token/GovernanceERC20Mock.sol
+++ b/packages/contracts/src/test/token/GovernanceERC20Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {GovernanceERC20} from "../../token/ERC20/governance/GovernanceERC20.sol";
 import {IDAO} from "../../core/dao/IDAO.sol";

--- a/packages/contracts/src/test/token/TestERC1155.sol
+++ b/packages/contracts/src/test/token/TestERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 

--- a/packages/contracts/src/test/token/TestERC20.sol
+++ b/packages/contracts/src/test/token/TestERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/contracts/src/test/token/TestERC721.sol
+++ b/packages/contracts/src/test/token/TestERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/packages/contracts/src/test/utils/InterfaceBasedRegistryMock.sol
+++ b/packages/contracts/src/test/utils/InterfaceBasedRegistryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "../../framework/utils/InterfaceBasedRegistry.sol";
 

--- a/packages/contracts/src/test/utils/RatioTest.sol
+++ b/packages/contracts/src/test/utils/RatioTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import "../../plugins/utils/Ratio.sol";
 

--- a/packages/contracts/src/test/utils/RegistryUtilsTest.sol
+++ b/packages/contracts/src/test/utils/RegistryUtilsTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {isSubdomainValid as _isSubdomainValid} from "../../framework/utils/RegistryUtils.sol";
 

--- a/packages/contracts/src/token/ERC20/IERC20MintableUpgradeable.sol
+++ b/packages/contracts/src/token/ERC20/IERC20MintableUpgradeable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 /// @title IERC20MintableUpgradeable
 /// @notice Interface to allow minting of [ERC-20](https://eips.ethereum.org/EIPS/eip-20) tokens.

--- a/packages/contracts/src/token/ERC20/governance/GovernanceERC20.sol
+++ b/packages/contracts/src/token/ERC20/governance/GovernanceERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {IERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20PermitUpgradeable.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/packages/contracts/src/token/ERC20/governance/GovernanceWrappedERC20.sol
+++ b/packages/contracts/src/token/ERC20/governance/GovernanceWrappedERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {ERC20WrapperUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20WrapperUpgradeable.sol";

--- a/packages/contracts/src/token/ERC20/governance/IGovernanceWrappedERC20.sol
+++ b/packages/contracts/src/token/ERC20/governance/IGovernanceWrappedERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";

--- a/packages/contracts/src/utils/protocol/ProtocolVersion.sol
+++ b/packages/contracts/src/utils/protocol/ProtocolVersion.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity 0.8.17;
+pragma solidity ^0.8.8;
 
 import {IProtocolVersion} from "./IProtocolVersion.sol";
 


### PR DESCRIPTION
## Description

Although the compiler pragma is lowered from `pragma solidity 0.8.17;` to `pragma solidity ^0.8.8;`, we will still compile OSx with 0.8.17 and the legacy code generation pipeline (i.e., not with `--viaIR`). The change allows plugin developers to use newer compiler versions and test against all OSx contracts.

Task ID: [OS-720](https://aragonassociation.atlassian.net/browse/OS-720)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [x] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-720]: https://aragonassociation.atlassian.net/browse/OS-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ