### PR TITLE
Amending incorrect build metadata hierarchy

### DIFF
--- a/packages/contracts/src/plugins/governance/admin/build-metadata.json
+++ b/packages/contracts/src/plugins/governance/admin/build-metadata.json
@@ -11,11 +11,11 @@
           "type": "address",
           "description": "The address of the admin account receiving the `EXECUTE_PERMISSION_ID` permission."
         }
-      ],
-      "prepareUninstallation": {
-        "description": "No input is required for the uninstallation.",
-        "inputs": []
-      }
+      ]
+    },
+    "prepareUninstallation": {
+      "description": "No input is required for the uninstallation.",
+      "inputs": []
     }
   }
 }

--- a/packages/contracts/src/plugins/governance/majority-voting/addresslist/build-metadata.json
+++ b/packages/contracts/src/plugins/governance/majority-voting/addresslist/build-metadata.json
@@ -17,13 +17,13 @@
               "internalType": "uint32",
               "name": "supportThreshold",
               "type": "uint32",
-              "description": "The support threshold value. Its value has to be in the interval [0, 10^6] defined by `RATIO_BASE = 10**6`."
+              "description": "The support threshold value. Its value has to be in the interval [0, 10^6] defined by 'RATIO_BASE = 10**6'."
             },
             {
               "internalType": "uint32",
               "name": "minParticipation",
               "type": "uint32",
-              "description": "The minimum participation value. Its value has to be in the interval [0, 10^6] defined by `RATIO_BASE = 10**6`."
+              "description": "The minimum participation value. Its value has to be in the interval [0, 10^6] defined by 'RATIO_BASE = 10**6'."
             },
             {
               "internalType": "uint64",
@@ -49,17 +49,17 @@
           "type": "address[]",
           "description": "The addresses of the initial members to be added."
         }
-      ],
-      "prepareUpdate": {
-        "1": {
-          "description": "No input is required for the update.",
-          "inputs": []
-        }
-      },
-      "prepareUninstallation": {
-        "description": "No input is required for the uninstallation.",
+      ]
+    },
+    "prepareUpdate": {
+      "1": {
+        "description": "No input is required for the update.",
         "inputs": []
       }
+    },
+    "prepareUninstallation": {
+      "description": "No input is required for the uninstallation.",
+      "inputs": []
     }
   }
 }

--- a/packages/contracts/src/plugins/governance/majority-voting/addresslist/build-metadata.json
+++ b/packages/contracts/src/plugins/governance/majority-voting/addresslist/build-metadata.json
@@ -17,13 +17,13 @@
               "internalType": "uint32",
               "name": "supportThreshold",
               "type": "uint32",
-              "description": "The support threshold value. Its value has to be in the interval [0, 10^6] defined by 'RATIO_BASE = 10**6'."
+              "description": "The support threshold value. Its value has to be in the interval [0, 10^6] defined by `RATIO_BASE = 10**6`."
             },
             {
               "internalType": "uint32",
               "name": "minParticipation",
               "type": "uint32",
-              "description": "The minimum participation value. Its value has to be in the interval [0, 10^6] defined by 'RATIO_BASE = 10**6'."
+              "description": "The minimum participation value. Its value has to be in the interval [0, 10^6] defined by `RATIO_BASE = 10**6`."
             },
             {
               "internalType": "uint64",

--- a/packages/contracts/src/plugins/governance/majority-voting/token/build-metadata.json
+++ b/packages/contracts/src/plugins/governance/majority-voting/token/build-metadata.json
@@ -89,17 +89,17 @@
           "type": "tuple",
           "description": "The token mint settings struct containing the `receivers` and `amounts`."
         }
-      ],
-      "prepareUpdate": {
-        "1": {
-          "description": "No input is required for the update.",
-          "inputs": []
-        }
-      },
-      "prepareUninstallation": {
-        "description": "No input is required for the uninstallation.",
+      ]
+    },
+    "prepareUpdate": {
+      "1": {
+        "description": "No input is required for the update.",
         "inputs": []
       }
+    },
+    "prepareUninstallation": {
+      "description": "No input is required for the uninstallation.",
+      "inputs": []
     }
   }
 }

--- a/packages/contracts/src/plugins/governance/multisig/build-metadata.json
+++ b/packages/contracts/src/plugins/governance/multisig/build-metadata.json
@@ -31,17 +31,17 @@
           "type": "tuple",
           "description": "The inital multisig settings."
         }
-      ],
-      "prepareUpdate": {
-        "1": {
-          "description": "No input is required for the update.",
-          "inputs": []
-        }
-      },
-      "prepareUninstallation": {
-        "description": "No input is required for the uninstallation.",
+      ]
+    },
+    "prepareUpdate": {
+      "1": {
+        "description": "No input is required for the update.",
         "inputs": []
       }
+    },
+    "prepareUninstallation": {
+      "description": "No input is required for the uninstallation.",
+      "inputs": []
     }
   }
 }


### PR DESCRIPTION
## Description

The `prepareUpdate` and `prepareUninstallation` ABI definition should be alongside `prepareInstallation` and not a child of it.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
