### PR TITLE
ci(OS-798): use base_ref as default instead of head_ref

### DIFF
--- a/.github/workflows/subgraph-deploy.yaml
+++ b/.github/workflows/subgraph-deploy.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           commit_message: 'Update changelog in subgraph'
           repo: ${{ github.repository }}
-          branch: ${{ github.head_ref || github.ref_name }}
+          branch: ${{ github.base_ref || github.head_ref || github.ref_name }}
           file_pattern: 'packages/subgraph/CHANGELOG.md'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Description

Please include a summary of the change and be sure you follow the contributions rules we do provide [here](./CONTRIBUTIONS.md)

Task ID: [OS-?](https://aragonassociation.atlassian.net/browse/OS-?)

## Type of change

See the framework lifecylce in `packages/contracts/docs/framework-lifecycle` to decide what kind of change this pull request is.

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
