### PR TITLE
fix: build and release metadata mixups

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -27,6 +27,8 @@ This checklist is seen as a guide to deploy the stack to a new chain.
 - [ ] Set the subdomain to be used of the managing DAO to `MANAGINGDAO_SUBDOMAIN` in `.env`. If you want to use `management.dao.eth` put only `management`
 - [ ] Set the multisig members of the managing DAO as a comma (`,`) separated list to `MANAGINGDAO_MULTISIG_APPROVERS` in `.env`
 - [ ] Set the amount of minimum approvals the managing DAO needs to `MANAGINGDAO_MULTISIG_MINAPPROVALS` in `.env`
+- [ ] If new plugin builds are released
+  - [ ] Double-check that the build- and release-metadata is published correctly by the deploy script and contracts
 
 ## Deployment
 

--- a/UPDATE_CHECKLIST.md
+++ b/UPDATE_CHECKLIST.md
@@ -24,7 +24,7 @@ This checklist is seen as a guide to update the existing deployment.
 - [ ] Copy the managing DAO multisig env variables from `packages/contracts/.env-example` into `packages/contracts/.env`
 - [ ] Follow the version specific tasks in the section `Version tasks`
 - [ ] If new plugin builds are released
-  - [ ] Double-check that the build-metadata was updated correctly for the UI to work correctly
+  - [ ] Double-check that the build- and release-metadata is published and updated correctly by the deploy script and contracts
   - [ ] If the plugin is used by the managing DAO and the new build includes security relevant changes it must be applied immediately
 
 ## Update

--- a/packages/contracts/deploy/helpers.ts
+++ b/packages/contracts/deploy/helpers.ts
@@ -321,14 +321,16 @@ export async function populatePluginRepo(
 
     const placeholderSetup = await getContractAddress('PlaceholderSetup', hre);
 
-    const emptyMetadata = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(''));
+    const emptyJsonObject = ethers.utils.hexlify(
+      ethers.utils.toUtf8Bytes('{}')
+    );
 
     for (let i = 1; i < latestBuildNumber; i++) {
       await createVersion(
         hre.aragonPluginRepos[pluginRepoName],
         placeholderSetup,
         releaseNumber,
-        emptyMetadata,
+        emptyJsonObject,
         ethers.utils.hexlify(
           ethers.utils.toUtf8Bytes(`ipfs://${hre.placeholderBuildCIDPath}`)
         )

--- a/packages/contracts/deploy/helpers.ts
+++ b/packages/contracts/deploy/helpers.ts
@@ -255,8 +255,8 @@ export async function createVersion(
   const tx = await pluginRepo.createVersion(
     releaseNumber,
     pluginSetupContract,
-    releaseMetadata,
-    buildMetadata
+    buildMetadata,
+    releaseMetadata
   );
 
   console.log(`Creating build for release ${releaseNumber} with tx ${tx.hash}`);


### PR DESCRIPTION
## Description

Task ID: [OS-901](https://aragonassociation.atlassian.net/browse/OS-901) (surfaced in spike [OS-899](https://aragonassociation.atlassian.net/browse/OS-899))

**After merging this PR, the `main` branch must be merged into `develop`.**

The inputs to `createVersion` in `packages/contracts/src/framework/plugin/repo/PluginRepo.sol` are as follows:
```solidity
    function createVersion(
        uint8 _release,
        address _pluginSetup,
        bytes calldata _buildMetadata,
        bytes calldata _releaseMetadata
    ) 
```
([see here](https://github.com/aragon/osx/blob/40f342b5906681e0050ec8bb984fc331070b932a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol#L130-L136))

However, it was used here with the arguments being mixed up in the helpers `packages/contracts/deploy/helpers.ts`
```ts
export async function createVersion(
  pluginRepoContract: string,
  pluginSetupContract: string,
  releaseNumber: number,
  releaseMetadata: string,
  buildMetadata: string
): Promise<void> {
  const signers = await ethers.getSigners();

  const PluginRepo = new PluginRepo__factory(signers[0]);
  const pluginRepo = PluginRepo.attach(pluginRepoContract);

  const tx = await pluginRepo.createVersion(
    releaseNumber,
    pluginSetupContract,
    releaseMetadata, // <--- MIX UP
    buildMetadata.   // <--- MIX UP
  );
```
([see here](https://github.com/aragon/osx/blob/40f342b5906681e0050ec8bb984fc331070b932a/packages/contracts/deploy/helpers.ts#L255-L260))


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [x] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-899]: https://aragonassociation.atlassian.net/browse/OS-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OS-901]: https://aragonassociation.atlassian.net/browse/OS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ