### PR TITLE
Support different time tracking via ERC6372 in TokenVoting plugin

### DIFF
--- a/packages/contracts/src/plugins/governance/majority-voting/MajorityVotingBase.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/MajorityVotingBase.sol
@@ -148,14 +148,14 @@ abstract contract MajorityVotingBase is
     /// @param supportThreshold The support threshold value. The value has to be in the interval [0, 10^6] defined by `RATIO_BASE = 10**6`.
     /// @param startDate The start date of the proposal vote.
     /// @param endDate The end date of the proposal vote.
-    /// @param snapshotBlock The number of the block prior to the proposal creation.
+    /// @param snapshotTimepoint The timepoint at which the voting power is queried.
     /// @param minVotingPower The minimum voting power needed.
     struct ProposalParameters {
         VotingMode votingMode;
         uint32 supportThreshold;
         uint64 startDate;
         uint64 endDate;
-        uint64 snapshotBlock;
+        uint64 snapshotTimepoint;
         uint256 minVotingPower;
     }
 
@@ -326,7 +326,7 @@ abstract contract MajorityVotingBase is
     ) public view virtual returns (bool) {
         Proposal storage proposal_ = proposals[_proposalId];
 
-        uint256 noVotesWorstCase = totalVotingPower(proposal_.parameters.snapshotBlock) -
+        uint256 noVotesWorstCase = totalVotingPower(proposal_.parameters.snapshotTimepoint) -
             proposal_.tally.yes -
             proposal_.tally.abstain;
 
@@ -376,10 +376,10 @@ abstract contract MajorityVotingBase is
         return votingSettings.votingMode;
     }
 
-    /// @notice Returns the total voting power checkpointed for a specific block number.
-    /// @param _blockNumber The block number.
+    /// @notice Returns the total voting power checkpointed for a specific timepoint.
+    /// @param _timepoint The timepoint.
     /// @return The total voting power.
-    function totalVotingPower(uint256 _blockNumber) public view virtual returns (uint256);
+    function totalVotingPower(uint256 _timepoint) public view virtual returns (uint256);
 
     /// @notice Returns all information for a proposal vote by its ID.
     /// @param _proposalId The ID of the proposal.

--- a/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVoting.sol
+++ b/packages/contracts/src/plugins/governance/majority-voting/addresslist/AddresslistVoting.sol
@@ -76,8 +76,8 @@ contract AddresslistVoting is IMembership, Addresslist, MajorityVotingBase {
     }
 
     /// @inheritdoc MajorityVotingBase
-    function totalVotingPower(uint256 _blockNumber) public view override returns (uint256) {
-        return addresslistLengthAtBlock(_blockNumber);
+    function totalVotingPower(uint256 _timepoint) public view override returns (uint256) {
+        return addresslistLengthAtBlock(_timepoint);
     }
 
     /// @inheritdoc MajorityVotingBase
@@ -94,9 +94,9 @@ contract AddresslistVoting is IMembership, Addresslist, MajorityVotingBase {
             revert ProposalCreationForbidden(_msgSender());
         }
 
-        uint64 snapshotBlock;
+        uint64 snapshotTimepoint;
         unchecked {
-            snapshotBlock = block.number.toUint64() - 1; // The snapshot block must be mined already to protect the transaction against backrunning transactions causing census changes.
+            snapshotTimepoint = block.number.toUint64() - 1; // The snapshot block must be mined already to protect the transaction against backrunning transactions causing census changes.
         }
 
         (_startDate, _endDate) = _validateProposalDates(_startDate, _endDate);
@@ -115,11 +115,11 @@ contract AddresslistVoting is IMembership, Addresslist, MajorityVotingBase {
 
         proposal_.parameters.startDate = _startDate;
         proposal_.parameters.endDate = _endDate;
-        proposal_.parameters.snapshotBlock = snapshotBlock;
+        proposal_.parameters.snapshotTimepoint = snapshotTimepoint;
         proposal_.parameters.votingMode = votingMode();
         proposal_.parameters.supportThreshold = supportThreshold();
         proposal_.parameters.minVotingPower = _applyRatioCeiled(
-            totalVotingPower(snapshotBlock),
+            totalVotingPower(snapshotTimepoint),
             minParticipation()
         );
 
@@ -207,7 +207,7 @@ contract AddresslistVoting is IMembership, Addresslist, MajorityVotingBase {
         }
 
         // The voter has no voting power.
-        if (!isListedAtBlock(_account, proposal_.parameters.snapshotBlock)) {
+        if (!isListedAtBlock(_account, proposal_.parameters.snapshotTimepoint)) {
             return false;
         }
 


### PR DESCRIPTION
## Description

Allow time tracking other than block number in `TokenVoting` plugin via [ERC6372](https://eips.ethereum.org/EIPS/eip-6372).

Related forum thread: https://forum.aragon.org/t/supporting-erc-6372/4274

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
