### PR TITLE
ci: correct team-reviewers and use latest actions/checkout worfklow

### DIFF
--- a/.github/workflows/documentation-update.yml
+++ b/.github/workflows/documentation-update.yml
@@ -11,9 +11,10 @@ jobs:
     permissions: read-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install node
-        uses: actions/setup-node@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup nodejs
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16
@@ -22,7 +23,7 @@ jobs:
       - name: Clean the contracts directory
         run: yarn clean
         working-directory: packages/contracts/
-      - name: Generate Docs
+      - name: Generate docs
         run: yarn run docgen
         working-directory: packages/contracts/
       - name: Remove Framework Lifecycle docs
@@ -31,7 +32,7 @@ jobs:
       - name: Format with prettier
         run: yarn run prettier 'packages/contracts/docs/developer-portal/03-reference-guide/**/*.md' --write
       - name: Checkout developer-portal
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: aragon/developer-portal
           ref: staging
@@ -56,4 +57,4 @@ jobs:
           title: Update the Aragon OSx docs
           body: 'Automated update by Github actions (Run: [${{ github.run_id }}](https://github.com/aragon/osx/actions/runs/${{ github.run_id }}))'
           reviewers: ${{ github.actor }}
-          team-reviewers: devrel
+          team-reviewers: Ara-Team-OSX


### PR DESCRIPTION
`osx/.github/workflows/documentation-update.yml` updated

## Description

- `osx/.github/workflows/documentation-update.yml` updated with right teams
- `osx/.github/workflows/documentation-update.yml` updated with latest github actions

Task ID: [DOPS-660](https://aragonassociation.atlassian.net/browse/DOPS-660)

## Type of change

See the framework lifecylce in `packages/contracts/docs/framework-lifecycle` to decide what kind of change this pull request is.

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[DOPS-660]: https://aragonassociation.atlassian.net/browse/DOPS-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ