### PR TITLE
ci: updates to latest gh actions except labeler and create-pull-request

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -17,12 +17,12 @@ jobs:
         working-directory: ${{env.working-directory}}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16

--- a/.github/workflows/mythx-changed.yml
+++ b/.github/workflows/mythx-changed.yml
@@ -38,21 +38,21 @@ jobs:
     outputs:
       group_id: ${{ steps.comment_prepare.outputs.group_id }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: refs/pull/${{ inputs.pr_number }}/merge
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - name: Install mythx-cli
         run: pip install mythx-cli
       - name: Changed Files Exporter
         id: files
-        uses: umani/changed-files@v3.3.0
+        uses: umani/changed-files@v4.1.0
         with:
           repo-token: ${{ github.token }}
           pr-number: ${{ inputs.pr_number }}
@@ -78,7 +78,7 @@ jobs:
     steps:
       - name: Comment a pull_request
         if: ${{ inputs.pr_number != '' }}
-        uses: thollander/actions-comment-pull-request@v1
+        uses: thollander/actions-comment-pull-request@v2
         with:
           pr_number: ${{ inputs.pr_number }}
           message: 'Scan started in group [https://dashboard.mythx.io/#/console/analyses/groups/${{ needs.mythx.outputs.group_id }}](https://dashboard.mythx.io/#/console/analyses/groups/${{ needs.mythx.outputs.group_id }})'

--- a/.github/workflows/mythx-full.yml
+++ b/.github/workflows/mythx-full.yml
@@ -34,21 +34,21 @@ jobs:
     outputs:
       group_id: ${{ steps.comment_prepare.outputs.group_id }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ inputs.pr_number != '' }}
         with:
           ref: refs/pull/${{ inputs.pr_number }}/merge
           fetch-depth: 0
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ inputs.pr_number == '' }}
         with:
           fetch-depth: 0
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - name: Install mythx-cli
         run: pip install mythx-cli
       - name: Install deps
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Comment a pull_request
         if: ${{ inputs.pr_number != '' }}
-        uses: thollander/actions-comment-pull-request@v1
+        uses: thollander/actions-comment-pull-request@v2
         with:
           pr_number: ${{ inputs.pr_number }}
           message: 'Scan started in group [https://dashboard.mythx.io/#/console/analyses/groups/${{ needs.mythx.outputs.group_id }}](https://dashboard.mythx.io/#/console/analyses/groups/${{ needs.mythx.outputs.group_id }})'

--- a/.github/workflows/npm-release-reusable.yml
+++ b/.github/workflows/npm-release-reusable.yml
@@ -43,14 +43,14 @@ jobs:
       matrix:
         package: [contracts, contracts-ethers]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: ${{ inputs.ref != '' }}
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: ${{ inputs.ref == '' }}
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16
@@ -81,7 +81,7 @@ jobs:
       - name: updates changelog.md
         run: VERSION=$(cat package.json | jq -r .version)
           sed -i "s/^\#\# \[UPCOMING\]/## [UPCOMING]\n\n\## $VERSION\nOn $(date +'%Y-%m-%d %H:%M:%S')/" "./packages/${{ matrix.package }}/CHANGELOG.md"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.package}}
           path: ./packages/${{ matrix.package }}/
@@ -90,15 +90,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_deploy]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           token: ${{ secrets.ARABOT_PAT }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: packages/contracts/
           name: contracts
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: packages/contracts-ethers/
           name: contracts-ethers

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -14,8 +14,8 @@ jobs:
     outputs:
       run: ${{ steps.checkSrc.outputs.run }}${{ steps.checkLabel.outputs.run }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16

--- a/.github/workflows/subgraph-deploy.yaml
+++ b/.github/workflows/subgraph-deploy.yaml
@@ -24,7 +24,7 @@ jobs:
       environment: ${{ steps.prepare.outputs.environment }}
       matrix: ${{ steps.prepare.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Prepare
         id: prepare
         run: node .github/helpers/subgraph/buildMatrix.js '${{ github.ref }}'
@@ -44,7 +44,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{secrets.ARABOT_PAT}}
 
@@ -78,11 +78,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref || github.ref }}
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16

--- a/.github/workflows/subgraph-tests.yml
+++ b/.github/workflows/subgraph-tests.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       matrix: ${{ steps.prepare.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Prepare
         id: prepare
         run: node .github/helpers/subgraph/buildMatrix.js '${{ github.ref }}'
@@ -29,9 +29,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16
@@ -48,12 +48,12 @@ jobs:
       run:
         working-directory: ${{env.working-directory}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16


### PR DESCRIPTION
## Description

This updates to latest github actions in all OSX workflows, except `actions/labeler@v3` and `peter-evans/create-pull-request@v4` because both actions introduce breaking changes which require more tests.
These changes remove annoying warning messages in Github Actions view about using NodeJS:
* `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20`
* `The following actions uses node12 which is deprecated and will be forced to run on node16`

Task ID: [DOPS-661](https://aragonassociation.atlassian.net/browse/DOPS-661)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[DOPS-661]: https://aragonassociation.atlassian.net/browse/DOPS-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ