### PR TITLE
fix: specify range of node versions in readme and advise cd into package

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,7 @@ Please do not use the issue tracker for security issues.
 
 Ensure you have Node and Yarn installed.
 
-The latest Node version officially supported by OSx and Hardhat is 16. Node >=19 also works, but is technically unsupported by Hardhat. Use [nvm](https://github.com/nvm-sh/nvm) to switch:
-
-```sh
-nvm install 16
-nvm use 16
-npm i -g yarn
-```
+The latest Node version officially supported by OSx and Hardhat is 16. Node >=19 also works, but is technically unsupported by Hardhat. It's recommended to use a tool such as [nvm](https://github.com/nvm-sh/nvm) to manage different node environments. Please see the relevant documentation for details.
 
 Start by running `yarn install` in the project root in your terminal.
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,21 @@ Please do not use the issue tracker for security issues.
 
 ## Setup
 
+Ensure you have Node and Yarn installed.
+
+The latest Node version officially supported by OSx and Hardhat is 16. Node >=19 also works, but is technically unsupported by Hardhat. Use [nvm](https://github.com/nvm-sh/nvm) to switch:
+
+```sh
+nvm install 16
+nvm use 16
+npm i -g yarn
+```
+
 Start by running `yarn install` in the project root in your terminal.
 
 ### Dependencies
 
-Since the repo is set up as yarn workspace, all the linking is done automatically.
+Since the repo is set up as yarn workspace, all the linking is done automatically. When contributing, we recommend to `cd` into each package, as this mirrors the workflow of the development team.
 
 ## How the Aragon OSx protocol works
 


### PR DESCRIPTION
## Description

Changes in the package README files for new contributors. Full 
 details [here](https://www.notion.so/aragonorg/Notes-on-Running-the-OSx-Repo-for-the-first-time-8db2cef330a84dbeb858726e441d4c3b)

**Warn users about certain node versions:**

_I decided to avoid an `.nvmrc` or any `package.json` engines because dependencies may be updated shortly and I don't want to break downstream users CI pipelines. A readme will suffice for now_

Task ID: [OS-1036](https://aragonassociation.atlassian.net/browse/OS-1036)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-1036]: https://aragonassociation.atlassian.net/browse/OS-1036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ