### PR TITLE
fix: updated typings in HRE declaration and type errors in helpers

### DIFF
--- a/packages/contracts/deploy/helpers.ts
+++ b/packages/contracts/deploy/helpers.ts
@@ -137,7 +137,9 @@ export function getLatestContractAddress(
 
   const latestNetworkDeployment = getLatestNetworkDeployment(osxNetworkName);
   if (latestNetworkDeployment && contractName in latestNetworkDeployment) {
-    return latestNetworkDeployment[contractName].address;
+    // safe cast due to conditional above, but we return the fallback string anyhow
+    const key = contractName as keyof typeof latestNetworkDeployment;
+    return latestNetworkDeployment[key]?.address ?? '';
   }
   return '';
 }

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -1,6 +1,7 @@
 import networks, {ContractsNetworkConfig} from './networks';
 import {AragonPluginRepos, TestingFork} from './types/hardhat';
 import {NetworkConfigs} from '@aragon/osx-commons-configs';
+import {SupportedNetworks} from '@aragon/osx-commons-configs';
 import '@nomicfoundation/hardhat-chai-matchers';
 import '@nomicfoundation/hardhat-network-helpers';
 import '@nomicfoundation/hardhat-verify';
@@ -9,7 +10,6 @@ import * as dotenv from 'dotenv';
 import 'hardhat-deploy';
 import 'hardhat-gas-reporter';
 import {extendEnvironment, HardhatUserConfig} from 'hardhat/config';
-import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import 'solidity-coverage';
 import 'solidity-docgen';
 
@@ -25,11 +25,11 @@ const accounts = ETH_KEY ? ETH_KEY.split(',') : [];
 // add accounts to network configs
 const hardhatNetworks: NetworkConfigs<HardhatNetworksExtension> = networks;
 for (const network of Object.keys(networks)) {
-  hardhatNetworks[network].accounts = accounts;
+  hardhatNetworks[network as SupportedNetworks].accounts = accounts;
 }
 
 // Extend HardhatRuntimeEnvironment
-extendEnvironment((hre: HardhatRuntimeEnvironment) => {
+extendEnvironment(hre => {
   const aragonPluginRepos: AragonPluginRepos = {
     AddresslistVotingRepoProxy: '',
     TokenVotingRepoProxy: '',

--- a/packages/contracts/networks.ts
+++ b/packages/contracts/networks.ts
@@ -37,8 +37,12 @@ const networkExtensions: NetworkConfigs<ContractsNetworkConfig> = {
     ...networks.arbitrum,
     deploy: ['./deploy/new', './deploy/verification'],
   },
-  arbitrumGoerli: {
-    ...networks.arbitrumGoerli,
+  baseSepolia: {
+    ...networks.baseSepolia,
+    deploy: ['./deploy/new', './deploy/verification'],
+  },
+  arbitrumSepolia: {
+    ...networks.arbitrumSepolia,
     deploy: ['./deploy/new', './deploy/verification'],
   },
 };

--- a/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
+++ b/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
@@ -85,8 +85,12 @@ import {MockContract, smock} from '@defi-wonderland/smock';
 import {anyValue} from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
+import chai from 'chai';
 import {BytesLike} from 'ethers';
 import {ethers} from 'hardhat';
+
+// TODO: this should be the default behaviour
+chai.use(smock.matchers);
 
 const EVENTS = {
   InstallationPrepared: 'InstallationPrepared',

--- a/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
+++ b/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
@@ -85,12 +85,8 @@ import {MockContract, smock} from '@defi-wonderland/smock';
 import {anyValue} from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
-import chai from 'chai';
 import {BytesLike} from 'ethers';
 import {ethers} from 'hardhat';
-
-// TODO: this should be the default behaviour
-chai.use(smock.matchers);
 
 const EVENTS = {
   InstallationPrepared: 'InstallationPrepared',

--- a/packages/contracts/types/hardhat.d.ts
+++ b/packages/contracts/types/hardhat.d.ts
@@ -1,12 +1,17 @@
 import {BigNumberish, BytesLike} from 'ethers';
 
 export type AragonPluginRepos = {
-  'address-list-voting': string;
-  'token-voting': string;
-  // prettier-ignore
-  'admin': string;
-  // prettier-ignore
-  'multisig': string;
+  AddresslistVotingRepoProxy: string;
+  TokenVotingRepoProxy: string;
+  AdminRepoProxy: string;
+  MultisigRepoProxy: string;
+  // DEPRECATED KEYS
+  // 'address-list-voting': string;
+  // 'token-voting': string;
+  // // prettier-ignore
+  // 'admin': string;
+  // // prettier-ignore
+  // 'multisig': string;
   [index: string]: string;
 };
 
@@ -28,8 +33,7 @@ export type TestingFork = {
   activeContracts: any;
 };
 
-
-declare module 'hardhat/types' {
+declare module 'hardhat/types/runtime' {
   interface HardhatRuntimeEnvironment {
     aragonPluginRepos: AragonPluginRepos;
     aragonToVerifyContracts: AragonVerifyEntry[];

--- a/packages/contracts/types/hardhat.d.ts
+++ b/packages/contracts/types/hardhat.d.ts
@@ -5,13 +5,6 @@ export type AragonPluginRepos = {
   TokenVotingRepoProxy: string;
   AdminRepoProxy: string;
   MultisigRepoProxy: string;
-  // DEPRECATED KEYS
-  // 'address-list-voting': string;
-  // 'token-voting': string;
-  // // prettier-ignore
-  // 'admin': string;
-  // // prettier-ignore
-  // 'multisig': string;
   [index: string]: string;
 };
 


### PR DESCRIPTION
## Description

Fixed HRE extension compiler warnings: changed module exports from `hardhat/types` -> `hardhat/types/runtime`. This also fixes type errors in all deploy scripts.

Added casting to fix 2 errors in the HH config and the networks file. I believe these are safe casts but we should discuss about having 2 separate `SupportedNetworks` enums when really we should have 1 coming from the commons. 

Removed Arbitrum Goerli and added base and arb sepolia to the networks, to align with supported networks and thus allow us to correctly index the networks in hardhat.config.

The only oddity was having to add a chai listener for defi wonderland. This was required for me to run the test suite so would appreciate a sanity check on why that might be.

This addresses 2 tickets:

[OS-1037](https://aragonassociation.atlassian.net/browse/OS-1037)
[OS-1038](https://aragonassociation.atlassian.net/browse/OS-1038)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-1037]: https://aragonassociation.atlassian.net/browse/OS-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OS-1038]: https://aragonassociation.atlassian.net/browse/OS-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ