### PR TITLE
Add chai-setup script to consistently import additional matchers 

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -149,12 +149,13 @@ Please replace 'MyContract' with the actual name of your contract, and follow th
 Example of usage in a test:
 
 ```ts
+// chai-setup imports additional matchers used for mocking
+import {expect} from './chai-setup';
 import {
   DAO as DAO_V1_3_0,
   DAO__factory as DAO_V1_3_0_factory,
 } from '@aragon/osx-ethers-v1.3.0/contracts/core/dao/DAO.sol';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
-import {expect} from 'chai';
 import {ethers} from 'hardhat';
 
 describe('Legacy Test Example', function () {

--- a/packages/contracts/test/chai-setup.ts
+++ b/packages/contracts/test/chai-setup.ts
@@ -1,0 +1,10 @@
+/**
+ * Enable additional matchers for chai and smock
+ * import this file in place of chai, i.e:
+ * import {expect} from './chai-setup';
+ **/
+import {smock} from '@defi-wonderland/smock';
+import chai from 'chai';
+
+chai.use(smock.matchers);
+export = chai;

--- a/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
+++ b/packages/contracts/test/framework/plugin/plugin-setup-processor.ts
@@ -28,6 +28,7 @@ import {
   PluginCloneableSetupV1MockBad__factory,
 } from '../../../typechain';
 import {PluginRepoRegisteredEvent} from '../../../typechain/PluginRepoRegistry';
+import {expect} from '../../chai-setup';
 import {deployNewDAO, ZERO_BYTES32} from '../../test-utils/dao';
 import {deployENSSubdomainRegistrar} from '../../test-utils/ens';
 import {deployPluginSetupProcessor} from '../../test-utils/plugin-setup-processor';
@@ -84,7 +85,6 @@ import {
 import {MockContract, smock} from '@defi-wonderland/smock';
 import {anyValue} from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
-import {expect} from 'chai';
 import {BytesLike} from 'ethers';
 import {ethers} from 'hardhat';
 


### PR DESCRIPTION
## Description

Chai requires binding matchers to the global test runner inside hardhat, not doing so leaves certain tests in the PSP to throw due to the matchers not being found.

The fix is to use

chai.use(smock.matchers);

But rather than write in every test file, we should define a setup script:

```ts
/**
 * Enable additional matchers for chai and smock
 * import this file in place of chai, i.e:
 * import {expect} from './chai-setup';
 **/
import {smock} from '@defi-wonderland/smock';
import chai from 'chai';

chai.use(smock.matchers);
export = chai;
```
Which can then be imported in place of Chai, in a consistent manner for all files.

`import {expect} from './chai-setup'`

Note: in theory there is a require field in the mocha config in hardhat. This doesn’t appear to actually run any scripts before the tests fire. Hardhat also exposes fixtures which could be an alternative approach, but since this is a global environment setup, it seems an import script is fine.

Task ID: [OS-1041](https://aragonassociation.atlassian.net/browse/OS-1041)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-1041]: https://aragonassociation.atlassian.net/browse/OS-1041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ