### PR TITLE
fix typo in fallback value

### DIFF
--- a/packages/contracts/test/deploy/default-env.ts
+++ b/packages/contracts/test/deploy/default-env.ts
@@ -50,7 +50,7 @@ describe('detect network', () => {
 
   it('sets the correct fallbacks for each environment variable', () => {
     expect(daoDomainEnv(network)).to.equal('dao.eth');
-    expect(pluginDomainEnv(network)).to.equal('plugin.eth');
+    expect(pluginDomainEnv(network)).to.equal('plugin.dao.eth');
     expect(managementDaoSubdomainEnv(network)).to.equal('management');
     expect(managementDaoMultisigApproversEnv(network)).to.equal(
       HARDHAT_ACCOUNTS[0].ADDRESS
@@ -63,8 +63,8 @@ describe('detect network', () => {
   it('string interpolates the ENS subdomains', () => {
     const network: Network = {name: 'FakeNet'} as unknown as Network;
     process.env['FAKENET_DAO_ENS_DOMAIN'] = 'mydao.eth';
-    process.env['FAKENET_PLUGIN_ENS_DOMAIN'] = 'myplugin.eth';
+    process.env['FAKENET_PLUGIN_ENS_DOMAIN'] = 'myplugin.dao.eth';
     expect(daoDomainEnv(network)).to.equal('mydao.eth');
-    expect(pluginDomainEnv(network)).to.equal('myplugin.eth');
+    expect(pluginDomainEnv(network)).to.equal('myplugin.dao.eth');
   });
 });

--- a/packages/contracts/utils/environment.ts
+++ b/packages/contracts/utils/environment.ts
@@ -42,7 +42,11 @@ export const daoDomainEnv = (network: Network): string =>
   env(network, `${network.name.toUpperCase()}_DAO_ENS_DOMAIN`, 'dao.eth');
 
 export const pluginDomainEnv = (network: Network): string =>
-  env(network, `${network.name.toUpperCase()}_PLUGIN_ENS_DOMAIN`, 'plugin.eth');
+  env(
+    network,
+    `${network.name.toUpperCase()}_PLUGIN_ENS_DOMAIN`,
+    'plugin.dao.eth'
+  );
 
 export const managementDaoSubdomainEnv = (network: Network): string =>
   env(network, 'MANAGEMENT_DAO_SUBDOMAIN', 'management');


### PR DESCRIPTION
## Description

@Michael-A-Heuer asked me to change `plugin.dao.eth` as a fallback value from `plugin.eth`. This small change was missed in the previous PR and so adding it here. 

Task ID: [OS-1069](https://aragonassociation.atlassian.net/browse/OS-1069)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-1069]: https://aragonassociation.atlassian.net/browse/OS-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ