### PR TITLE
chore: bump package.json in readiness for gh workflow

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/osx-subgraph",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The Aragon OSx Subgraph",
   "homepage": "https://github.com/aragon/osx",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Description

Bumps subgraphs package.json to 1.4.1 to address bugs regarding negative token balances and missing delegations.
We will invoke the github action to build and deploy the subgraphs against 1.4.1

[Spike is documented here](https://www.notion.so/aragonorg/Subgraph-Deploy-YAML-fb3d4dc6e86c4f11b64eca89b2011a53?pm=c) explaining a bit more about the deploy process.

Task ID: [OS-1116](https://aragonassociation.atlassian.net/browse/OS-1116)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-1116]: https://aragonassociation.atlassian.net/browse/OS-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ