### PR TITLE
Subgraph: Helpers for Introspection Query

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -1,3 +1,13 @@
+# This is just for generating introspection query purposes.
+" Byte array, represented as a hexadecimal string. Commonly used for Ethereum hashes and addresses. "
+scalar Bytes
+" Large integers. Used for Ethereum's `uint32`, `int64`, `uint64`, ..., `uint25`6 types. Note: Everything below `uint32`, such as `int32`, `uint24` or `int8` is represented as `i32`. "
+scalar BigInt
+" Query type, required to generate introspection query. "
+type Query @entity {
+  id: ID!
+}
+
 # Types
 
 # Token


### PR DESCRIPTION
## Description

To generate the documentation for Subgraph, we are going to use the introspection query, which will read from the schema.graphql itself because the API Endpoint introduces a lot of redundant information.

To do so, we need to declare the scalars Bytes and BigInt that don't exist in GraphQL (the comments are optional, I added so if someone reaches them in the documentation).

And also we need to initialize a Query type, again the comments are optional.

Task ID: [OS-1136](https://aragonassociation.atlassian.net/browse/OS-1136)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.


[OS-1136]: https://aragonassociation.atlassian.net/browse/OS-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ