### PR TITLE
F/split transfer actions

### DIFF
--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Temp entity `TransactionAction` created while plugins (with actions) still live inside OSx. Includes `deterministicId` and swaps `proposal` foreign key in place of `transactionAction`
 - The `deterministicId` and `Id` fields now include the `daoAddress` inside executeActions
 - Renamed the `handleTokenTransfer` inside the `handleAction` to better reflect the fact that it checks _all_ actions.
+- Renamed `proposal` to `transactionActions` in ERC20Transfer, ERC721Transfer, ERC1155Transfer and NativeTransfer
 
 ## 1.4.1
 

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -288,8 +288,8 @@ type ERC20Transfer implements TokenTransfer @entity(immutable: true) {
   " The Ethereum address receiving the ERC20 tokens. "
   to: Bytes!
 
-  " The associated DAO proposal, if applicable. Using the DAO `deposit` function there's no need for proposal. "
-  proposal: IProposal
+  " The associated DAO transaction, if applicable. If deposited Using the DAO `deposit` function then will be empty "
+  transactionActions: TransactionActions
 
   " The type of transfer (External, Withdraw, Deposit) from the DAO's POV. "
   type: TransferType!
@@ -323,8 +323,8 @@ type ERC721Transfer implements TokenTransfer @entity(immutable: true) {
   " The Ethereum address receiving the ERC721 token. "
   to: Bytes!
 
-  " The associated DAO proposal, if applicable. Using the DAO `deposit` function there's no need for proposal. "
-  proposal: IProposal
+  " The associated DAO transaction, if applicable. If deposited Using the DAO `deposit` function then will be empty "
+  transactionActions: TransactionActions
 
   " The type of transfer (External, Withdraw, Deposit) from the DAO's POV. "
   type: TransferType!
@@ -364,8 +364,8 @@ type ERC1155Transfer implements TokenTransfer @entity(immutable: true) {
   " The Ethereum address receiving the tokens. "
   to: Bytes!
 
-  " The associated DAO proposal, if applicable. Using the DAO `deposit` function there's no need for proposal. "
-  proposal: IProposal
+  " The associated DAO transaction, if applicable. If deposited Using the DAO `deposit` function then will be empty "
+  transactionActions: TransactionActions
 
   " The type of transfer (External, Withdraw, Deposit) from the DAO's POV. "
   type: TransferType!
@@ -399,8 +399,8 @@ type NativeTransfer implements TokenTransfer @entity(immutable: true) {
   " The reference describing the deposit reason. "
   reference: String!
 
-  " The associated DAO proposal, if applicable. Using the DAO `deposit` function there's no need for proposal. "
-  proposal: IProposal
+  " The associated DAO transaction, if applicable. If deposited Using the DAO `deposit` function then will be empty "
+  transactionActions: TransactionActions
 
   " The type of transfer (External, Withdraw, Deposit) from the DAO's POV. "
   type: TransferType!

--- a/packages/subgraph/src/dao/dao_v1_0_0.ts
+++ b/packages/subgraph/src/dao/dao_v1_0_0.ts
@@ -40,7 +40,6 @@ import {
   generateTransactionActionsDeterministicId,
   generateTransactionActionsEntityId,
 } from './ids';
-import {stringToBytes} from '../utils/bytes';
 
 export function handleMetadataSet(event: MetadataSet): void {
   let daoId = generateDaoEntityId(event.address);

--- a/packages/subgraph/src/dao/utils.ts
+++ b/packages/subgraph/src/dao/utils.ts
@@ -70,10 +70,10 @@ export function updateProposalWithFailureMap(
 export function handleAction<
   T extends ExecutedActionsStruct,
   R extends Executed
->(action: T, transactionActionId: string, index: i32, event: R): void {
+>(action: T, transactionActionsId: string, index: i32, event: R): void {
   let actionEntity = getOrCreateActionEntity(
     action,
-    transactionActionId,
+    transactionActionsId,
     index,
     event
   );
@@ -86,14 +86,14 @@ export function handleAction<
       action.to,
       action.value,
       'Native Token Withdraw',
-      transactionActionId,
+      transactionActionsId,
       index,
       event
     );
     return;
   }
 
-  checkForAndHandleTokenTransfers(action, transactionActionId, index, event);
+  checkForAndHandleTokenTransfers(action, transactionActionsId, index, event);
 }
 
 function getOrCreateActionEntity<
@@ -140,14 +140,14 @@ function getOrCreateActionEntity<
  * Determines if the action is an ERC20, ERC721 or ERC1155 transfer and calls the appropriate handler if so.
  * Does nothing if the action is not a recognised token transfer.
  * @param action the action to validate
- * @param proposalId TODO: change this
+ * @param transactionActionsId TODO: change this
  * @param actionIndex the index number of the action inside the executed batch
  * @param event the Executed event emitting the event
  */
 function checkForAndHandleTokenTransfers<
   T extends ExecutedActionsStruct,
   R extends Executed
->(action: T, proposalId: string, actionIndex: i32, event: R): void {
+>(action: T, transactionActionsId: string, actionIndex: i32, event: R): void {
   const methodSig = getMethodSignature(action.data);
 
   let handledByErc721: bool = false;
@@ -158,7 +158,7 @@ function checkForAndHandleTokenTransfers<
       action.to,
       event.address,
       action.data,
-      proposalId,
+      transactionActionsId,
       actionIndex,
       event
     );
@@ -169,7 +169,7 @@ function checkForAndHandleTokenTransfers<
       action.to,
       event.address,
       action.data,
-      proposalId,
+      transactionActionsId,
       actionIndex,
       event
     );
@@ -179,7 +179,7 @@ function checkForAndHandleTokenTransfers<
     handleERC20Action(
       action.to,
       event.address,
-      proposalId,
+      transactionActionsId,
       action.data,
       actionIndex,
       event

--- a/packages/subgraph/src/dao/utils.ts
+++ b/packages/subgraph/src/dao/utils.ts
@@ -9,7 +9,7 @@ import {
   Executed,
   ExecutedActionsStruct,
 } from '../../generated/templates/DaoTemplateV1_0_0/DAO';
-import {getMethodSignature, stringToBytes} from '../utils/bytes';
+import {getMethodSignature} from '../utils/bytes';
 import {
   ERC721_transferFrom,
   ERC721_safeTransferFromNoData,
@@ -24,7 +24,7 @@ import {handleERC721Action} from '../utils/tokens/erc721';
 import {handleERC1155Action} from '../utils/tokens/erc1155';
 import {handleNativeAction} from '../utils/tokens/eth';
 import {generateDaoEntityId} from '@aragon/osx-commons-subgraph';
-import {BigInt, Bytes, log} from '@graphprotocol/graph-ts';
+import {BigInt} from '@graphprotocol/graph-ts';
 import {
   generateTransactionActionEntityId,
   generateDeterministicActionId,

--- a/packages/subgraph/src/utils/tokens/erc1155.ts
+++ b/packages/subgraph/src/utils/tokens/erc1155.ts
@@ -198,7 +198,7 @@ export function handleERC1155Action(
   token: Address,
   dao: Address,
   data: Bytes,
-  proposalId: string,
+  transactionActionsId: string,
   actionIndex: number,
   event: ethereum.Event
 ): bool {
@@ -228,7 +228,7 @@ export function handleERC1155Action(
       tuple,
       dao,
       token,
-      proposalId,
+      transactionActionsId,
       event,
       actionIndex
     );
@@ -237,7 +237,7 @@ export function handleERC1155Action(
       tuple,
       dao,
       token,
-      proposalId,
+      transactionActionsId,
       event,
       actionIndex
     );
@@ -262,7 +262,7 @@ function handleERC1155SingleTransfer(
   tuple: ethereum.Tuple,
   dao: Address,
   token: Address,
-  proposalId: string,
+  transactionActionsId: string,
   event: ethereum.Event,
   actionIndex: number
 ): void {
@@ -286,7 +286,7 @@ function handleERC1155SingleTransfer(
     token,
     tokenId,
     amount,
-    proposalId,
+    transactionActionsId,
     event.transaction.hash,
     event.block.timestamp
   );
@@ -338,7 +338,7 @@ function createErc1155Transfer(
   token: Address,
   tokenId: BigInt,
   amount: BigInt,
-  proposalId: string | null,
+  transactionActionsId: string | null,
   txHash: Bytes,
   timestamp: BigInt
 ): void {
@@ -353,7 +353,7 @@ function createErc1155Transfer(
   transfer.token = tokenEntityId;
   transfer.amount = amount;
   transfer.tokenId = tokenId;
-  transfer.proposal = proposalId;
+  transfer.transactionActions = transactionActionsId;
   transfer.txHash = txHash;
   transfer.createdAt = timestamp;
   // check the transfer type

--- a/packages/subgraph/src/utils/tokens/erc20.ts
+++ b/packages/subgraph/src/utils/tokens/erc20.ts
@@ -170,7 +170,7 @@ export function updateERC20Balance(
 export function handleERC20Action(
   token: Address,
   dao: Address,
-  proposalId: string,
+  transactionActionsId: string,
   data: Bytes,
   actionIndex: number,
   event: ethereum.Event
@@ -234,7 +234,7 @@ export function handleERC20Action(
   transfer.txHash = event.transaction.hash;
   transfer.createdAt = event.block.timestamp;
   transfer.token = tokenAddress as string;
-  transfer.proposal = proposalId;
+  transfer.transactionActions = transactionActionsId;
 
   // If from/to both aren't equal to dao, it means
   // dao must have been approved for the `tokenId`

--- a/packages/subgraph/src/utils/tokens/erc721.ts
+++ b/packages/subgraph/src/utils/tokens/erc721.ts
@@ -141,7 +141,7 @@ export function handleERC721Action(
   token: Address,
   dao: Address,
   data: Bytes,
-  proposalId: string,
+  transactionActionsId: string,
   actionIndex: number,
   event: ethereum.Event
 ): bool {
@@ -165,7 +165,7 @@ export function handleERC721Action(
     contract,
     dao,
     event,
-    proposalId,
+    transactionActionsId,
     actionIndex
   );
 
@@ -226,7 +226,7 @@ function createERC721Transfer(
   contract: ERC721Contract,
   dao: Address,
   event: ethereum.Event,
-  proposalId: string,
+  transactionActionsId: string,
   actionIndex: number
 ): ERC721Transfer {
   let transferEntityId = generateTransferEntityId(
@@ -241,7 +241,7 @@ function createERC721Transfer(
   transfer.dao = daoEntityId;
   transfer.token = contract.id;
   transfer.tokenId = tuple[2].toBigInt();
-  transfer.proposal = proposalId;
+  transfer.transactionActions = transactionActionsId;
   transfer.txHash = event.transaction.hash;
   transfer.createdAt = event.block.timestamp;
 

--- a/packages/subgraph/src/utils/tokens/eth.ts
+++ b/packages/subgraph/src/utils/tokens/eth.ts
@@ -73,7 +73,7 @@ export function handleNativeAction(
   to: Address,
   amount: BigInt,
   reference: string,
-  proposalId: string,
+  transactionActionsId: string,
   actionIndex: number,
   event: ethereum.Event
 ): void {
@@ -93,7 +93,7 @@ export function handleNativeAction(
   transfer.reference = reference;
   transfer.txHash = event.transaction.hash;
   transfer.createdAt = event.block.timestamp;
-  transfer.proposal = proposalId;
+  transfer.transactionActions = transactionActionsId;
   transfer.type = 'Withdraw';
   transfer.save();
 

--- a/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
+++ b/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
@@ -595,7 +595,6 @@ test('Run AddresslistVoting (handleMembersAdded) mappings with mock event', () =
     'id',
     memberEntityId
   );
-  const voter = AddresslistVotingVoter.load(memberEntityId);
   assert.fieldEquals(
     'AddresslistVotingVoter',
     memberEntityId,

--- a/packages/subgraph/tests/constants.ts
+++ b/packages/subgraph/tests/constants.ts
@@ -2,7 +2,8 @@ import {
   generatePluginEntityId,
   generateProposalEntityId,
 } from '@aragon/osx-commons-subgraph';
-import {Address, BigInt} from '@graphprotocol/graph-ts';
+import {generateTransactionActionsEntityId} from '../src/dao/ids';
+import {Address, BigInt, Bytes} from '@graphprotocol/graph-ts';
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 export const ADDRESS_ONE = '0x0000000000000000000000000000000000000001';
@@ -61,6 +62,7 @@ export const ZERO_BYTES32 =
   '0x0000000000000000000000000000000000000000000000000000000000000000';
 export const ONE_BYTES32 =
   '0x0000000000000000000000000000000000000000000000000000000000000001';
+
 export const HALF_UINT256_BYTES32 =
   '0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 export const MAX_UINT256_BYTES32 =
@@ -73,6 +75,14 @@ export const PLUGIN_SETUP_ID =
   '0xfb3fd2c4cd4e19944dd3f8437e67476240cd9e3efb2294ebd10c59c8f1d6817c';
 export const APPLIED_PLUGIN_SETUP_ID =
   '0x00000000cd4e19944dd3f8437e67476240cd9e3efb2294ebd10c59c8f1d6817c';
+
+export const TRANSACTION_ACTIONS_ENTITY_ID = generateTransactionActionsEntityId(
+  Address.fromString(DAO_ADDRESS),
+  Address.fromString(CONTRACT_ADDRESS),
+  Bytes.fromHexString(ONE_BYTES32),
+  Bytes.fromHexString(HALF_UINT256_BYTES32),
+  BigInt.fromString('1')
+);
 
 export const PROPOSAL_ENTITY_ID = generateProposalEntityId(
   Address.fromString(CONTRACT_ADDRESS),

--- a/packages/subgraph/tests/dao/dao_v1_0_0.test.ts
+++ b/packages/subgraph/tests/dao/dao_v1_0_0.test.ts
@@ -1,9 +1,7 @@
 import {
-  Action,
   ERC721Balance,
   TransactionAction,
   TransactionActions,
-  TransactionActions as TransactionActionsProposal,
 } from '../../generated/schema';
 import {Executed} from '../../generated/templates/DaoTemplateV1_0_0/DAO';
 import {
@@ -81,12 +79,9 @@ import {
   encodeWithFunctionSelector,
 } from './utils';
 import {
-  generateActionEntityId,
   generateBalanceEntityId,
   generateDaoEntityId,
-  generateProposalEntityId,
   generateTokenIdBalanceEntityId,
-  generateTransactionActionsProposalEntityId,
   generateTransferEntityId,
   createDummyAction,
   createERC20TokenCalls,
@@ -1101,17 +1096,13 @@ describe('handleExecuted', () => {
         );
 
         handleExecuted(event);
-
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromByteArray(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
 
         let txHash = event.transaction.hash;
         let logIndex = event.transactionLogIndex;
@@ -1152,8 +1143,8 @@ describe('handleExecuted', () => {
         eq(
           'ERC20Transfer',
           transferEntityId,
-          'proposal',
-          transactionActionsProposalEntityId
+          'transactionActions',
+          transactionActionsEntityId
         );
         eq('ERC20Transfer', transferEntityId, 'type', 'Withdraw');
         eq('ERC20Transfer', transferEntityId, 'txHash', txHash.toHexString());
@@ -1226,16 +1217,13 @@ describe('handleExecuted', () => {
 
         handleExecuted(event);
 
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromUnsignedBytes(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
 
         let txHash = event.transaction.hash;
         let logIndex = event.transactionLogIndex;
@@ -1271,8 +1259,8 @@ describe('handleExecuted', () => {
         eq(
           'ERC20Transfer',
           transferId,
-          'proposal',
-          transactionActionsProposalEntityId
+          'transactionActions',
+          transactionActionsEntityId
         );
         eq('ERC20Transfer', transferId, 'type', 'Withdraw');
         eq('ERC20Transfer', transferId, 'txHash', txHash.toHexString());
@@ -1374,17 +1362,13 @@ describe('handleExecuted', () => {
 
         handleExecuted(event);
 
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromUnsignedBytes(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
-
         // check ERC721Contract entity
         eq('ERC721Contract', tokenEntityId, 'id', tokenEntityId);
         eq('ERC721Contract', tokenEntityId, 'name', 'name');
@@ -1413,8 +1397,8 @@ describe('handleExecuted', () => {
         eq(
           'ERC721Transfer',
           transferId,
-          'proposal',
-          transactionActionsProposalEntityId
+          'transactionActions',
+          transactionActionsEntityId
         );
         eq('ERC721Transfer', transferId, 'type', 'Withdraw');
         eq('ERC721Transfer', transferId, 'txHash', txHash.toHexString());
@@ -1479,16 +1463,13 @@ describe('handleExecuted', () => {
 
         handleExecuted(event);
 
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromUnsignedBytes(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
 
         // check ERC721Contract entity
         eq('ERC721Contract', tokenEntityId, 'id', tokenEntityId);
@@ -1518,8 +1499,8 @@ describe('handleExecuted', () => {
         eq(
           'ERC721Transfer',
           transferId,
-          'proposal',
-          transactionActionsProposalEntityId
+          'transactionActions',
+          transactionActionsEntityId
         );
         eq('ERC721Transfer', transferId, 'type', 'Withdraw');
         eq('ERC721Transfer', transferId, 'txHash', txHash.toHexString());

--- a/packages/subgraph/tests/dao/dao_v1_3_0.test.ts
+++ b/packages/subgraph/tests/dao/dao_v1_3_0.test.ts
@@ -8,8 +8,8 @@ import {handleExecuted} from '../../src/dao/dao_v1_3_0';
 import {
   generateTransactionActionEntityId,
   generateDeterministicActionId,
-  generateTransactionActionsEntityId,
   generateTransactionActionsDeterministicId,
+  generateTransactionActionsEntityId,
 } from '../../src/dao/ids';
 import {stringToBytes} from '../../src/utils/bytes';
 import {GOVERNANCE_WRAPPED_ERC20_INTERFACE_ID} from '../../src/utils/constants';
@@ -63,7 +63,6 @@ import {
   createDummyAction,
   createERC20TokenCalls,
   createERC1155TokenCalls,
-  generateTransactionActionsProposalEntityId,
 } from '@aragon/osx-commons-subgraph';
 import {ethereum, Bytes, Address, BigInt} from '@graphprotocol/graph-ts';
 import {
@@ -369,17 +368,13 @@ describe('handleExecuted', () => {
 
         handleExecuted(event);
 
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromUnsignedBytes(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
-
         let txHash = event.transaction.hash;
         let logIndex = event.transactionLogIndex;
         let timestamp = event.block.timestamp;
@@ -414,8 +409,8 @@ describe('handleExecuted', () => {
         eq(
           'ERC20Transfer',
           transferId,
-          'proposal',
-          transactionActionsProposalEntityId
+          'transactionActions',
+          transactionActionsEntityId
         );
         eq('ERC20Transfer', transferId, 'type', 'Withdraw');
         eq('ERC20Transfer', transferId, 'txHash', txHash.toHexString());
@@ -485,17 +480,13 @@ describe('handleExecuted', () => {
 
         handleExecuted(event);
 
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromUnsignedBytes(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
-
         let txHash = event.transaction.hash;
         let logIndex = event.transactionLogIndex;
         let timestamp = event.block.timestamp;
@@ -530,8 +521,8 @@ describe('handleExecuted', () => {
         eq(
           'ERC20Transfer',
           transferId,
-          'proposal',
-          transactionActionsProposalEntityId
+          'transactionActions',
+          transactionActionsEntityId
         );
         eq('ERC20Transfer', transferId, 'type', 'Withdraw');
         eq('ERC20Transfer', transferId, 'txHash', txHash.toHexString());
@@ -635,16 +626,13 @@ describe('handleExecuted', () => {
 
         handleExecuted(event);
 
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromUnsignedBytes(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
 
         // check ERC721Contract entity
         eq('ERC721Contract', tokenEntityId, 'id', tokenEntityId);
@@ -674,8 +662,8 @@ describe('handleExecuted', () => {
         eq(
           'ERC721Transfer',
           transferId,
-          'proposal',
-          transactionActionsProposalEntityId
+          'transactionActions',
+          transactionActionsEntityId
         );
         eq('ERC721Transfer', transferId, 'type', 'Withdraw');
         eq('ERC721Transfer', transferId, 'txHash', txHash.toHexString());
@@ -742,17 +730,13 @@ describe('handleExecuted', () => {
 
         handleExecuted(event);
 
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromUnsignedBytes(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
-
         // check ERC721Contract entity
         eq('ERC721Contract', tokenEntityId, 'id', tokenEntityId);
         eq('ERC721Contract', tokenEntityId, 'name', TOKEN_NAME);
@@ -781,8 +765,8 @@ describe('handleExecuted', () => {
         eq(
           'ERC721Transfer',
           transferId,
-          'proposal',
-          transactionActionsProposalEntityId
+          'transactionActions',
+          transactionActionsEntityId
         );
         eq('ERC721Transfer', transferId, 'type', 'Withdraw');
         eq('ERC721Transfer', transferId, 'txHash', txHash.toHexString());
@@ -899,23 +883,20 @@ describe('handleExecuted', () => {
           0,
           0
         );
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromUnsignedBytes(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
         assert.entityCount('ERC1155Transfer', 1);
         let erc1155Transfer = new ExtendedERC1155Transfer().withDefaultValues();
         erc1155Transfer.id = transferId;
         erc1155Transfer.amount = amount;
         erc1155Transfer.from = Address.fromHexString(daoEntityId);
         erc1155Transfer.to = Address.fromHexString(ADDRESS_THREE);
-        erc1155Transfer.proposal = transactionActionsProposalEntityId;
+        erc1155Transfer.transactionActions = transactionActionsEntityId;
         erc1155Transfer.type = 'Withdraw';
         erc1155Transfer.txHash = txHash;
         erc1155Transfer.createdAt = timestamp;
@@ -1027,16 +1008,13 @@ describe('handleExecuted', () => {
         // check ERC1155Transfer entity
         let txHash = event.transaction.hash;
         let logIndex = event.transactionLogIndex;
-        let proposalEntityId = generateProposalEntityId(
+        let transactionActionsEntityId = generateTransactionActionsEntityId(
+          event.address,
           event.params.actor,
-          BigInt.fromUnsignedBytes(event.params.callId)
+          event.params.callId,
+          event.transaction.hash,
+          event.transactionLogIndex
         );
-        let transactionActionsProposalEntityId =
-          generateTransactionActionsProposalEntityId(
-            proposalEntityId,
-            event.transaction.hash,
-            event.transactionLogIndex
-          );
         for (let i = 0; i < tokenIds.length; i++) {
           let erc1155Transfer =
             new ExtendedERC1155Transfer().withDefaultValues();
@@ -1051,7 +1029,7 @@ describe('handleExecuted', () => {
           erc1155Transfer.from = Address.fromHexString(daoEntityId);
           erc1155Transfer.to = Address.fromHexString(ADDRESS_THREE);
           erc1155Transfer.tokenId = tokenIds[i];
-          erc1155Transfer.proposal = transactionActionsProposalEntityId;
+          erc1155Transfer.transactionActions = transactionActionsEntityId;
           erc1155Transfer.type = 'Withdraw';
           erc1155Transfer.txHash = txHash;
           erc1155Transfer.createdAt = timestamp;

--- a/packages/subgraph/tests/dao/dao_v1_3_0.test.ts
+++ b/packages/subgraph/tests/dao/dao_v1_3_0.test.ts
@@ -11,7 +11,6 @@ import {
   generateTransactionActionsDeterministicId,
   generateTransactionActionsEntityId,
 } from '../../src/dao/ids';
-import {stringToBytes} from '../../src/utils/bytes';
 import {GOVERNANCE_WRAPPED_ERC20_INTERFACE_ID} from '../../src/utils/constants';
 import {
   generateERC1155TransferEntityId,
@@ -57,7 +56,6 @@ import {
 import {
   generateBalanceEntityId,
   generateDaoEntityId,
-  generateProposalEntityId,
   generateTokenIdBalanceEntityId,
   generateTransferEntityId,
   createDummyAction,
@@ -73,7 +71,6 @@ import {
   clearStore,
   assert,
   beforeAll,
-  log,
 } from 'matchstick-as';
 
 const eq = assert.fieldEquals;

--- a/packages/subgraph/tests/helpers/method-classes.ts
+++ b/packages/subgraph/tests/helpers/method-classes.ts
@@ -79,6 +79,7 @@ import {
   ADDRESS_THREE,
   ADDRESS_ZERO,
   ADDRESS_FOUR,
+  TRANSACTION_ACTIONS_ENTITY_ID,
 } from '../constants';
 import {
   createCallbackReceivedEvent,
@@ -247,7 +248,7 @@ class ERC1155TransferMethods extends ERC1155Transfer {
     this.tokenId = BigInt.zero();
     this.from = Address.fromHexString(ADDRESS_ONE);
     this.to = Address.fromHexString(DAO_ADDRESS);
-    this.proposal = 'null';
+    this.transactionActions = 'null';
     this.type = 'Deposit';
     this.txHash = Bytes.empty();
     this.createdAt = BigInt.fromString(CREATED_AT);
@@ -309,7 +310,7 @@ class ERC721TransferMethods extends ERC721Transfer {
     this.tokenId = BigInt.zero();
     this.from = Address.fromHexString(ADDRESS_ONE);
     this.to = Address.fromHexString(DAO_ADDRESS);
-    this.proposal = PROPOSAL_ENTITY_ID;
+    this.transactionActions = TRANSACTION_ACTIONS_ENTITY_ID;
     this.type = 'Deposit';
     this.txHash = Bytes.empty();
     this.createdAt = BigInt.fromString(CREATED_AT);
@@ -427,7 +428,7 @@ class ERC20TransferMethods extends ERC20Transfer {
     this.amount = BigInt.zero();
     this.from = Address.fromHexString(ADDRESS_ONE);
     this.to = Address.fromHexString(DAO_ADDRESS);
-    this.proposal = PROPOSAL_ENTITY_ID;
+    this.transactionActions = TRANSACTION_ACTIONS_ENTITY_ID;
     this.type = 'Deposit';
     this.txHash = Bytes.empty();
     this.createdAt = BigInt.fromString(CREATED_AT);
@@ -447,7 +448,7 @@ class NativeTransferMethods extends NativeTransfer {
     this.from = Address.fromHexString(ADDRESS_ONE);
     this.to = Address.fromHexString(DAO_ADDRESS);
     this.reference = 'Native Deposit';
-    this.proposal = PROPOSAL_ENTITY_ID;
+    this.transactionActions = TRANSACTION_ACTIONS_ENTITY_ID;
     this.type = 'Deposit';
     this.txHash = Bytes.empty();
     this.createdAt = BigInt.fromString(CREATED_AT);


### PR DESCRIPTION
## Description

This PR merges as follows:

```mermaid
flowchart LR
    fsplit_transfer_actions("f/split-transfer-actions") --> fsplit_transaction_actions("f/split-transaction-actions") --> fsplit_subgraph("f/split-subgraph") --> fsplit("f/split") --> develop
    other_prs("{other prs}") --> fsplit_subgraph
```

We are staging these PRs to make reviewing and readability easier but all achieve the same goal: deprecating plugins in OSx core.

## Summary of PRs:

- [ ] Remove Proposals from Executions and add deterministic IDs 
- [ ] Remove Proposals from ERCXXX transfer entitites ${\color{Red}<-- This PR}$
- [ ] Remove Plugin data from the Subgraph
- [ ] Rename TransactionActions back to Actions
- [ ] Move ID generation to OSx Commons if needed

## This PR

- Removes the concept of 'proposals' from the ERC20, ERC721, ERC1155 and NativeTransfer Entities
- Bind instead to the `TransactionActions` entity defined to replace proposals 
- Fixes tests and add linting

Task ID: [OS-1209](https://aragonassociation.atlassian.net/browse/OS-1209)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [ ] I have updated the Subgraph and added a QA URL to the description of this PR.
