### PR TITLE
F/split linting

### DIFF
--- a/packages/subgraph/src/dao/dao_v1_0_0.ts
+++ b/packages/subgraph/src/dao/dao_v1_0_0.ts
@@ -29,6 +29,10 @@ import {
   handleERC1155Received,
 } from '../utils/tokens/erc1155';
 import {handleNativeDeposit} from '../utils/tokens/eth';
+import {
+  generateTransactionActionsDeterministicId,
+  generateTransactionActionsEntityId,
+} from './ids';
 import {handleAction, updateProposalWithFailureMap} from './utils';
 import {
   generateDaoEntityId,
@@ -36,10 +40,6 @@ import {
   generateStandardCallbackEntityId,
 } from '@aragon/osx-commons-subgraph';
 import {BigInt, Bytes, store} from '@graphprotocol/graph-ts';
-import {
-  generateTransactionActionsDeterministicId,
-  generateTransactionActionsEntityId,
-} from './ids';
 
 export function handleMetadataSet(event: MetadataSet): void {
   let daoId = generateDaoEntityId(event.address);

--- a/packages/subgraph/src/dao/dao_v1_3_0.ts
+++ b/packages/subgraph/src/dao/dao_v1_3_0.ts
@@ -3,12 +3,12 @@ import {
   Executed,
   ExecutedActionsStruct,
 } from '../../generated/templates/DaoTemplateV1_3_0/DAO';
-import {handleAction} from './utils';
-import {generateDaoEntityId} from '@aragon/osx-commons-subgraph';
 import {
   generateTransactionActionsDeterministicId,
   generateTransactionActionsEntityId,
 } from './ids';
+import {handleAction} from './utils';
+import {generateDaoEntityId} from '@aragon/osx-commons-subgraph';
 
 export function handleExecuted(event: Executed): void {
   let transactionActionsEntityId = generateTransactionActionsEntityId(

--- a/packages/subgraph/src/dao/utils.ts
+++ b/packages/subgraph/src/dao/utils.ts
@@ -23,12 +23,12 @@ import {handleERC20Action} from '../utils/tokens/erc20';
 import {handleERC721Action} from '../utils/tokens/erc721';
 import {handleERC1155Action} from '../utils/tokens/erc1155';
 import {handleNativeAction} from '../utils/tokens/eth';
-import {generateDaoEntityId} from '@aragon/osx-commons-subgraph';
-import {BigInt} from '@graphprotocol/graph-ts';
 import {
   generateTransactionActionEntityId,
   generateDeterministicActionId,
 } from './ids';
+import {generateDaoEntityId} from '@aragon/osx-commons-subgraph';
+import {BigInt} from '@graphprotocol/graph-ts';
 
 // AssemblyScript struggles having multiple return types. Due to this,
 // The below seems most effective way.

--- a/packages/subgraph/tests/constants.ts
+++ b/packages/subgraph/tests/constants.ts
@@ -1,8 +1,8 @@
+import {generateTransactionActionsEntityId} from '../src/dao/ids';
 import {
   generatePluginEntityId,
   generateProposalEntityId,
 } from '@aragon/osx-commons-subgraph';
-import {generateTransactionActionsEntityId} from '../src/dao/ids';
 import {Address, BigInt, Bytes} from '@graphprotocol/graph-ts';
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';

--- a/packages/subgraph/tests/dao/dao_v1_3_0.test.ts
+++ b/packages/subgraph/tests/dao/dao_v1_3_0.test.ts
@@ -62,7 +62,7 @@ import {
   createERC20TokenCalls,
   createERC1155TokenCalls,
 } from '@aragon/osx-commons-subgraph';
-import {ethereum, Bytes, Address, BigInt, log} from '@graphprotocol/graph-ts';
+import {ethereum, Bytes, Address, BigInt} from '@graphprotocol/graph-ts';
 import {
   describe,
   test,

--- a/packages/subgraph/tests/dao/dao_v1_3_0.test.ts
+++ b/packages/subgraph/tests/dao/dao_v1_3_0.test.ts
@@ -1,5 +1,5 @@
 import {
-  TransactionActions as TransactionActions,
+  TransactionActions,
   ERC721Balance,
   TransactionAction,
 } from '../../generated/schema';

--- a/packages/subgraph/tests/dao/utils.ts
+++ b/packages/subgraph/tests/dao/utils.ts
@@ -437,11 +437,16 @@ export function encodeWithFunctionSelector(
   // when the emitted event contains at least 1 dynamic type.
   let index = isDynamic == true ? 66 : 2;
 
-  let calldata = ethereum
-    .encode(ethereum.Value.fromTuple(changetype<ethereum.Tuple>(tuple)))!
-    .toHexString()
-    .substring(index);
+  let encoded = ethereum.encode(
+    ethereum.Value.fromTuple(changetype<ethereum.Tuple>(tuple))
+  );
 
+  if (!encoded)
+    throw new Error(
+      'encodeWithFunctionSelector::Could not encode ethereum tuple'
+    );
+
+  let calldata = encoded.toHexString().substring(index);
   let functionData = funcSelector.concat(calldata);
 
   return Bytes.fromHexString(functionData);

--- a/packages/subgraph/tests/dao/utils.ts
+++ b/packages/subgraph/tests/dao/utils.ts
@@ -9,7 +9,7 @@ import {
   CallbackReceived,
   NewURI,
 } from '../../generated/templates/DaoTemplateV1_0_0/DAO';
-import {ethereum, Bytes, Address, BigInt} from '@graphprotocol/graph-ts';
+import {ethereum, Bytes, Address, BigInt, log} from '@graphprotocol/graph-ts';
 import {createMockedFunction, newMockEvent} from 'matchstick-as/assembly/index';
 
 // events
@@ -441,12 +441,14 @@ export function encodeWithFunctionSelector(
     ethereum.Value.fromTuple(changetype<ethereum.Tuple>(tuple))
   );
 
+  // warning to satisfy eslint but not introduce a breaking change
   if (!encoded)
-    throw new Error(
-      'encodeWithFunctionSelector::Could not encode ethereum tuple'
+    log.warning(
+      'encodeWithFunctionSelector::Could not encode ethereum tuple',
+      []
     );
 
-  let calldata = encoded.toHexString().substring(index);
+  let calldata = (encoded as Bytes).toHexString().substring(index);
   let functionData = funcSelector.concat(calldata);
 
   return Bytes.fromHexString(functionData);

--- a/packages/subgraph/tests/registry/daoRegistry.test.ts
+++ b/packages/subgraph/tests/registry/daoRegistry.test.ts
@@ -74,6 +74,9 @@ describe('DAORegistry', () => {
     );
 
     const daoEntity = Dao.load(denylistedEntityId);
-    assert.assertNull(daoEntity!.subdomain);
+
+    if (!daoEntity) throw new Error('daoEntity is null');
+
+    assert.assertNull(daoEntity.subdomain);
   });
 });

--- a/packages/subgraph/tests/token/governance-erc20.test.ts
+++ b/packages/subgraph/tests/token/governance-erc20.test.ts
@@ -17,7 +17,6 @@ import {getBalanceOf} from '../dao/utils';
 import {ExtendedTokenVotingMember} from '../helpers/extended-schema';
 import {
   createNewDelegateChangedEvent,
-  createNewERC20TransferEvent,
   createNewERC20TransferEventWithAddress,
   createTokenVotingMember,
   getDelegatee,
@@ -27,7 +26,7 @@ import {
   generateEntityIdFromAddress,
   generatePluginEntityId,
 } from '@aragon/osx-commons-subgraph';
-import {Address, BigInt, DataSourceContext, log} from '@graphprotocol/graph-ts';
+import {Address, BigInt, DataSourceContext} from '@graphprotocol/graph-ts';
 import {
   assert,
   afterEach,
@@ -610,8 +609,6 @@ describe('Governance ERC20', () => {
     test("It should initialize with the user's existing voting power and delegation, if she has any", () => {
       // constants
       const STARTING_BALANCE = '10';
-      const TRANSFER = '3';
-      const REMAINING = '7';
 
       // mocked calls
       getBalanceOf(
@@ -637,16 +634,6 @@ describe('Governance ERC20', () => {
       const memberEntityIdFromSecondPlugin = generateMemberEntityId(
         pluginAddressSecond,
         Address.fromString(fromAddressHexString)
-      );
-
-      const memberEntityIdTo = generateMemberEntityId(
-        pluginAddressSecond,
-        Address.fromString(toAddressHexString)
-      );
-
-      const memberEntityIdToSecondPlugin = generateMemberEntityId(
-        pluginAddressSecond,
-        Address.fromString(toAddressHexString)
       );
 
       // delegate to self

--- a/packages/subgraph/tsconfig.json
+++ b/packages/subgraph/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "@graphprotocol/graph-ts/types/tsconfig.base.json",
-  "include": ["src"]
+  "include": ["src", "types/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/subgraph/tsconfig.json
+++ b/packages/subgraph/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@graphprotocol/graph-ts/types/tsconfig.base.json",
-  "include": ["src", "types/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Description

This PR merges as follows:

```mermaid
flowchart LR
    fsplit_linting("f/split-linting")  --> fsplit_transaction_actions("f/split-transaction-actions") --> fsplit_subgraph("f/split-subgraph") --> fsplit("f/split") --> develop
    other_prs("{other prs}") --> fsplit_subgraph
```

We are staging these PRs to make reviewing and readability easier but all achieve the same goal: deprecating plugins in OSx core.

## Summary of PRs:

- [x] Remove Proposals from Executions, Transfer entities and add deterministic IDs 
- [ ] Address linting issues ${\color{Red}<-- This PR}$
- [ ] Remove Plugin data from the Subgraph
- [ ] Rename TransactionActions back to Actions
- [ ] Move ID generation to OSx Commons if needed

## This PR

Fixes eslint and prettier warnings in OSx related to the subgraph

Task ID: [OS-1218](https://aragonassociation.atlassian.net/browse/OS-1218)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [ ] I have updated the Subgraph and added a QA URL to the description of this PR.



[OS-1199]: https://aragonassociation.atlassian.net/browse/OS-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OS-1218]: https://aragonassociation.atlassian.net/browse/OS-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ