### PR TITLE
F/OS-1224 Multisig approvers not appearing in past proposals

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -889,7 +889,8 @@ type MultisigPlugin implements IPlugin @entity {
 
 type MultisigApprover @entity {
   """
-  Current Approver of the multisig
+  Current Approver of the multisig. If the approver is removed from the multisig,
+  the entity is not deleted and instead the isActive flag is set to false.
   """
   id: ID! # plugin_address + member_address
   address: Bytes!
@@ -900,10 +901,9 @@ type MultisigApprover @entity {
 
 type MultisigProposalApproval @entity(immutable: true) {
   """
-  An approval for a specific multisig proposal
-  Will typically also be the address of a MultisigApprover
-  But will also store historical approvers if the address
-  was later deleted.
+  An approval of an specific multisig proposal
+  This entity works as a join table between MultisigProposal and MultisigApprover
+  and also stores the timestamp of the approval
   """
   id: ID! # approver + proposal
   approver: MultisigApprover!

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -893,6 +893,7 @@ type MultisigApprover @entity {
   """
   id: ID! # plugin_address + member_address
   address: String # address as string to facilitate filtering by address on the UI
+  proposals: [MultisigProposalApprover!]! @derivedFrom(field: "approver")
   plugin: MultisigPlugin!
 }
 
@@ -907,6 +908,7 @@ type MultisigProposalApprover @entity(immutable: true) {
   address: String! # address as string to facilitate filtering by address on the UI
   plugin: MultisigPlugin!
   proposal: MultisigProposal!
+  approver: MultisigApprover!
   createdAt: BigInt!
 }
 
@@ -934,4 +936,5 @@ type MultisigProposal implements IProposal @entity {
   executionBlockNumber: BigInt
   executionTxHash: Bytes
   approvers: [MultisigProposalApprover!]! @derivedFrom(field: "proposal")
+  
 }

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -900,7 +900,7 @@ type MultisigApprover @entity {
 
 type MultisigProposalApproval @entity(immutable: true) {
   """
-  An approver for a specific multisig proposal
+  An approval for a specific multisig proposal
   Will typically also be the address of a MultisigApprover
   But will also store historical approvers if the address
   was later deleted.

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -892,12 +892,13 @@ type MultisigApprover @entity {
   Current Approver of the multisig
   """
   id: ID! # plugin_address + member_address
-  address: String # address as string to facilitate filtering by address on the UI
-  proposals: [MultisigProposalApprover!]! @derivedFrom(field: "approver")
+  address: Bytes!
+  approvals: [MultisigProposalApproval!]! @derivedFrom(field: "approver")
   plugin: MultisigPlugin!
+  isActive: Boolean!
 }
 
-type MultisigProposalApprover @entity(immutable: true) {
+type MultisigProposalApproval @entity(immutable: true) {
   """
   An approver for a specific multisig proposal
   Will typically also be the address of a MultisigApprover
@@ -905,10 +906,8 @@ type MultisigProposalApprover @entity(immutable: true) {
   was later deleted.
   """
   id: ID! # approver + proposal
-  address: String! # address as string to facilitate filtering by address on the UI
-  plugin: MultisigPlugin!
-  proposal: MultisigProposal!
   approver: MultisigApprover!
+  proposal: MultisigProposal!
   createdAt: BigInt!
 }
 
@@ -928,13 +927,12 @@ type MultisigProposal implements IProposal @entity {
   creationBlockNumber: BigInt!
   snapshotBlock: BigInt!
   minApprovals: Int!
-  approvals: Int
+  approvalCount: Int
   approvalReached: Boolean!
   isSignaling: Boolean!
   executed: Boolean!
   executionDate: BigInt
   executionBlockNumber: BigInt
   executionTxHash: Bytes
-  approvers: [MultisigProposalApprover!]! @derivedFrom(field: "proposal")
-  
+  approvals: [MultisigProposalApproval!]! @derivedFrom(field: "proposal")
 }

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -888,16 +888,24 @@ type MultisigPlugin implements IPlugin @entity {
 }
 
 type MultisigApprover @entity {
+  """
+  Current Approver of the multisig
+  """
   id: ID! # plugin_address + member_address
   address: String # address as string to facilitate filtering by address on the UI
-  proposals: [MultisigProposalApprover!]! @derivedFrom(field: "approver")
   plugin: MultisigPlugin!
 }
 
 type MultisigProposalApprover @entity(immutable: true) {
-  "ApproverProposal for Many-to-Many"
+  """
+  An approver for a specific multisig proposal
+  Will typically also be the address of a MultisigApprover
+  But will also store historical approvers if the address
+  was later deleted.
+  """
   id: ID! # approver + proposal
-  approver: MultisigApprover!
+  address: String! # address as string to facilitate filtering by address on the UI
+  plugin: MultisigPlugin!
   proposal: MultisigProposal!
   createdAt: BigInt!
 }

--- a/packages/subgraph/src/packages/multisig/multisig.ts
+++ b/packages/subgraph/src/packages/multisig/multisig.ts
@@ -17,6 +17,7 @@ import {
 import {generateMemberEntityId, generateVoterEntityId} from '../../utils/ids';
 import {
   generateActionEntityId,
+  generateEntityIdFromAddress,
   generatePluginEntityId,
   generateProposalEntityId,
 } from '@aragon/osx-commons-subgraph';
@@ -102,6 +103,7 @@ export function _handleProposalCreated(
 export function handleApproved(event: Approved): void {
   let memberAddress = event.params.approver;
   let pluginAddress = event.address;
+  let pluginEntityId = generatePluginEntityId(pluginAddress);
   let memberEntityId = generateMemberEntityId(pluginAddress, memberAddress);
   let pluginProposalId = event.params.proposalId;
   let proposalEntityId = generateProposalEntityId(
@@ -117,8 +119,9 @@ export function handleApproved(event: Approved): void {
     MultisigProposalApprover.load(approverProposalId);
   if (!approverProposalEntity) {
     approverProposalEntity = new MultisigProposalApprover(approverProposalId);
-    approverProposalEntity.approver = memberEntityId;
     approverProposalEntity.proposal = proposalEntityId;
+    approverProposalEntity.plugin = pluginEntityId;
+    approverProposalEntity.address = generateEntityIdFromAddress(memberAddress);
   }
   approverProposalEntity.createdAt = event.block.timestamp;
   approverProposalEntity.save();

--- a/packages/subgraph/src/packages/multisig/multisig.ts
+++ b/packages/subgraph/src/packages/multisig/multisig.ts
@@ -17,11 +17,10 @@ import {
 import {generateMemberEntityId, generateVoterEntityId} from '../../utils/ids';
 import {
   generateActionEntityId,
-  generateEntityIdFromAddress,
   generatePluginEntityId,
   generateProposalEntityId,
 } from '@aragon/osx-commons-subgraph';
-import {dataSource, store} from '@graphprotocol/graph-ts';
+import {dataSource} from '@graphprotocol/graph-ts';
 
 export function handleProposalCreated(event: ProposalCreated): void {
   let context = dataSource.context();
@@ -103,7 +102,6 @@ export function _handleProposalCreated(
 export function handleApproved(event: Approved): void {
   let memberAddress = event.params.approver;
   let pluginAddress = event.address;
-  let pluginEntityId = generatePluginEntityId(pluginAddress);
   let approverEntityId = generateMemberEntityId(pluginAddress, memberAddress);
   let pluginProposalId = event.params.proposalId;
   let proposalEntityId = generateProposalEntityId(
@@ -191,7 +189,6 @@ export function handleMembersRemoved(event: MembersRemoved): void {
   const members = event.params.members;
   for (let index = 0; index < members.length; index++) {
     const memberAddress = members[index];
-    const pluginEntityId = generatePluginEntityId(event.address);
     const approverEntityId = generateMemberEntityId(
       event.address,
       memberAddress

--- a/packages/subgraph/src/packages/multisig/multisig.ts
+++ b/packages/subgraph/src/packages/multisig/multisig.ts
@@ -119,6 +119,7 @@ export function handleApproved(event: Approved): void {
     MultisigProposalApprover.load(approverProposalId);
   if (!approverProposalEntity) {
     approverProposalEntity = new MultisigProposalApprover(approverProposalId);
+    approverProposalEntity.approver = memberEntityId;
     approverProposalEntity.proposal = proposalEntityId;
     approverProposalEntity.plugin = pluginEntityId;
     approverProposalEntity.address = generateEntityIdFromAddress(memberAddress);

--- a/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
+++ b/packages/subgraph/tests/addresslist-voting/addresslist-voting.test.ts
@@ -595,7 +595,6 @@ test('Run AddresslistVoting (handleMembersAdded) mappings with mock event', () =
     'id',
     memberEntityId
   );
-  const voter = AddresslistVotingVoter.load(memberEntityId);
   assert.fieldEquals(
     'AddresslistVotingVoter',
     memberEntityId,

--- a/packages/subgraph/tests/multisig/multisig.test.ts
+++ b/packages/subgraph/tests/multisig/multisig.test.ts
@@ -1,4 +1,4 @@
-import {MultisigApprover, MultisigProposal} from '../../generated/schema';
+import {MultisigApprover} from '../../generated/schema';
 import {
   handleMembersAdded,
   handleApproved,
@@ -44,7 +44,7 @@ import {
   generateProposalEntityId,
   createDummyAction,
 } from '@aragon/osx-commons-subgraph';
-import {Address, BigInt, log} from '@graphprotocol/graph-ts';
+import {Address, BigInt} from '@graphprotocol/graph-ts';
 import {assert, clearStore, test} from 'matchstick-as/assembly/index';
 
 let actions = [createDummyAction(DAO_TOKEN_ADDRESS, '0', '0x00000000')];

--- a/packages/subgraph/tests/multisig/multisig.test.ts
+++ b/packages/subgraph/tests/multisig/multisig.test.ts
@@ -229,8 +229,8 @@ test('Run Multisig (handleApproved) mappings with mock event', () => {
   assert.fieldEquals(
     'MultisigProposalApprover',
     voterEntityId,
-    'approver',
-    memberEntityId
+    'address',
+    ADDRESS_ONE
   );
   assert.fieldEquals(
     'MultisigProposalApprover',
@@ -243,6 +243,13 @@ test('Run Multisig (handleApproved) mappings with mock event', () => {
     voterEntityId,
     'createdAt',
     event.block.timestamp.toString()
+  );
+
+  assert.fieldEquals(
+    'MultisigProposalApprover',
+    voterEntityId,
+    'plugin',
+    Address.fromString(CONTRACT_ADDRESS).toHexString()
   );
 
   // check proposal

--- a/packages/subgraph/tests/token/governance-erc20.test.ts
+++ b/packages/subgraph/tests/token/governance-erc20.test.ts
@@ -17,7 +17,6 @@ import {getBalanceOf} from '../dao/utils';
 import {ExtendedTokenVotingMember} from '../helpers/extended-schema';
 import {
   createNewDelegateChangedEvent,
-  createNewERC20TransferEvent,
   createNewERC20TransferEventWithAddress,
   createTokenVotingMember,
   getDelegatee,
@@ -27,7 +26,7 @@ import {
   generateEntityIdFromAddress,
   generatePluginEntityId,
 } from '@aragon/osx-commons-subgraph';
-import {Address, BigInt, DataSourceContext, log} from '@graphprotocol/graph-ts';
+import {Address, BigInt, DataSourceContext} from '@graphprotocol/graph-ts';
 import {
   assert,
   afterEach,
@@ -610,8 +609,6 @@ describe('Governance ERC20', () => {
     test("It should initialize with the user's existing voting power and delegation, if she has any", () => {
       // constants
       const STARTING_BALANCE = '10';
-      const TRANSFER = '3';
-      const REMAINING = '7';
 
       // mocked calls
       getBalanceOf(
@@ -637,16 +634,6 @@ describe('Governance ERC20', () => {
       const memberEntityIdFromSecondPlugin = generateMemberEntityId(
         pluginAddressSecond,
         Address.fromString(fromAddressHexString)
-      );
-
-      const memberEntityIdTo = generateMemberEntityId(
-        pluginAddressSecond,
-        Address.fromString(toAddressHexString)
-      );
-
-      const memberEntityIdToSecondPlugin = generateMemberEntityId(
-        pluginAddressSecond,
-        Address.fromString(toAddressHexString)
       );
 
       // delegate to self


### PR DESCRIPTION
## Description

Some approvers did not appear as approvers on past proposals after they've been removed from the multisig because the entity for the multisift members and approvers was related. 

This fixes this issue using the solution discussed here: https://www.notion.so/aragonorg/Subgraph-Bug-Approvers-Query-Breaks-Multisig-Subgraph-d783e196ba464595974ba2a9d2dac80a#5ca1bd831bbd4dc191dd8fb0d4360e8f 

Task ID: [OS-1224](https://aragonassociation.atlassian.net/browse/OS-1224)

Playground: https://subgraph.satsuma-prod.com/aragon/osx-test-members-bug-mainnet/version/5/playground

## Type of change

See the framework lifecycle in `packages/contracts/docs/framework-lifecycle` to decide what kind of change this pull request is.

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [x] I have updated the Subgraph and added a QA URL to the description of this PR.


[OS-1224]: https://aragonassociation.atlassian.net/browse/OS-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ