### PR TITLE
fix: wrong env name

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -38,7 +38,7 @@ jobs:
           ETH_KEY: ''
           HARDHAT_DAO_ENS_DOMAIN: 'dao.eth'
           HARDHAT_PLUGIN_ENS_DOMAIN: 'plugin.dao.eth'
-          MANAGINGDAO_SUBDOMAIN: 'aragon-management'
+          MANAGEMENT_DAO_SUBDOMAIN: 'aragon-management'
         run: yarn run test
       - name: Run solidity-docgen
         run: yarn run docgen

--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -24,7 +24,7 @@ This checklist is seen as a guide to deploy the stack to a new chain.
 - [ ] Set the right API key for the chains blockchain explorer in `.env` (e.g. for mainnet it is `ETHERSCAN_KEY`)
 - [ ] Set the chosen DAO ENS domain (in step 1) to `NETWORK_DAO_ENS_DOMAIN` in `.env` and replace `NETWORK` with the correct network name (e.g. for mainnet it is `MAINNET_DAO_ENS_DOMAIN`)
 - [ ] Set the chosen Plugin ENS domain (in step 2) to `NETWORK_PLUGIN_ENS_DOMAIN` in `.env` and replace `NETWORK` with the correct network name (e.g. for mainnet it is `MAINNET_PLUGIN_ENS_DOMAIN`)
-- [ ] Set the subdomain to be used of the managing DAO to `MANAGINGDAO_SUBDOMAIN` in `.env`. If you want to use `management.dao.eth` put only `management`
+- [ ] Set the subdomain to be used of the managing DAO to `MANAGEMENT_DAO_SUBDOMAIN` in `.env`. If you want to use `management.dao.eth` put only `management`
 - [ ] Set the multisig members of the managing DAO as a comma (`,`) separated list to `MANAGINGDAO_MULTISIG_APPROVERS` in `.env`
 - [ ] Set the amount of minimum approvals the managing DAO needs to `MANAGINGDAO_MULTISIG_MINAPPROVALS` in `.env`
 - [ ] If new plugin builds are released

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -22,7 +22,7 @@ Copy `.env.example` into a file called `.env` or create a new one with these 3 k
 # keys used for running tests
 HARDHAT_DAO_ENS_DOMAIN=dao.eth
 HARDHAT_PLUGIN_ENS_DOMAIN=plugin.eth
-MANAGINGDAO_SUBDOMAIN=management
+MANAGEMENT_DAO_SUBDOMAIN=management
 ```
 
 Run these commands on the project's root folder in your terminal:
@@ -117,8 +117,8 @@ After successful contract compilation, TypeChain typings will be automatically g
 Here is a generic example of usage in a test:
 
 ```ts
-import {MyContract} from '@aragon/osx-ethers-v1.2.0/{path_to_MyContract}';
 import {MyContract____factory} from '@aragon/osx-ethers-v1.2.0/{path_to_MyContract__factory}';
+import {MyContract} from '@aragon/osx-ethers-v1.2.0/{path_to_MyContract}';
 
 describe('MyContract Test', function () {
   let myContract: MyContract;
@@ -141,13 +141,13 @@ Please replace 'MyContract' with the actual name of your contract, and follow th
 Example of usage in a test:
 
 ```ts
-import {expect} from 'chai';
-import {ethers} from 'hardhat';
-import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {
   DAO as DAO_V1_3_0,
   DAO__factory as DAO_V1_3_0_factory,
 } from '@aragon/osx-ethers-v1.3.0/contracts/core/dao/DAO.sol';
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
+import {expect} from 'chai';
+import {ethers} from 'hardhat';
 
 describe('Legacy Test Example', function () {
   let signers: SignerWithAddress[];

--- a/packages/contracts/deploy/new/40_finalize-managing-dao/20_register-managing-dao-on-dao-registry.ts
+++ b/packages/contracts/deploy/new/40_finalize-managing-dao/20_register-managing-dao-on-dao-registry.ts
@@ -1,6 +1,4 @@
-import {HardhatRuntimeEnvironment} from 'hardhat/types';
-import {DeployFunction} from 'hardhat-deploy/types';
-
+import {DAO__factory, DAORegistry__factory} from '../../../typechain';
 import {
   getContractAddress,
   getENSAddress,
@@ -8,14 +6,15 @@ import {
   MANAGING_DAO_METADATA,
   uploadToIPFS,
 } from '../../helpers';
-import {DAO__factory, DAORegistry__factory} from '../../../typechain';
+import {DeployFunction} from 'hardhat-deploy/types';
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {ethers, network} = hre;
   const [deployer] = await ethers.getSigners();
 
   // Get info from .env
-  const daoSubdomain = process.env.MANAGINGDAO_SUBDOMAIN || '';
+  const daoSubdomain = process.env.MANAGEMENT_DAO_SUBDOMAIN || '';
   const daoDomain =
     process.env[`${network.name.toUpperCase()}_DAO_ENS_DOMAIN`] || '';
 

--- a/packages/contracts/deploy/new/40_finalize-managing-dao/40_revoke-permissions.ts
+++ b/packages/contracts/deploy/new/40_finalize-managing-dao/40_revoke-permissions.ts
@@ -1,8 +1,7 @@
-import {DeployFunction} from 'hardhat-deploy/types';
-
-import {getContractAddress, managePermissions, Permission} from '../../helpers';
-import {Operation} from '../../../utils/types';
 import {DAO__factory, PluginRepo__factory} from '../../../typechain';
+import {Operation} from '../../../utils/types';
+import {getContractAddress, managePermissions, Permission} from '../../helpers';
+import {DeployFunction} from 'hardhat-deploy/types';
 import {HardhatRuntimeEnvironment} from 'hardhat/types';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -10,7 +9,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const [deployer] = await ethers.getSigners();
 
   // Get info from .env
-  const daoSubdomain = process.env.MANAGINGDAO_SUBDOMAIN || '';
+  const daoSubdomain = process.env.MANAGEMENT_DAO_SUBDOMAIN || '';
 
   if (!daoSubdomain)
     throw new Error('ManagingDAO subdomain has not been set in .env');

--- a/packages/contracts/src/README.md
+++ b/packages/contracts/src/README.md
@@ -22,7 +22,7 @@ Copy `.env.example` into a file called `.env` or create a new one with these 3 k
 # keys used for running tests
 HARDHAT_DAO_ENS_DOMAIN=dao.eth
 HARDHAT_PLUGIN_ENS_DOMAIN=plugin.eth
-MANAGINGDAO_SUBDOMAIN=management
+MANAGEMENT_DAO_SUBDOMAIN=management
 ```
 
 Run these commands on the project's root folder in your terminal:

--- a/packages/contracts/test/deploy/managing-dao.ts
+++ b/packages/contracts/test/deploy/managing-dao.ts
@@ -1,8 +1,8 @@
-import {expect} from 'chai';
-import {readImplementationValuesFromSlot} from '../../utils/storage';
-
-import hre, {ethers, deployments, getNamedAccounts} from 'hardhat';
-import {Deployment} from 'hardhat-deploy/dist/types';
+import daoRegistryArtifactData from '../../artifacts/@aragon/osx-v1.0.1/framework/dao/DAORegistry.sol/DAORegistry.json';
+import pluginRepoArtifactData from '../../artifacts/@aragon/osx-v1.0.1/framework/plugin/repo/PluginRepo.sol/PluginRepo.json';
+import pluginRepoRegistryArtifactData from '../../artifacts/@aragon/osx-v1.0.1/framework/plugin/repo/PluginRepoRegistry.sol/PluginRepoRegistry.json';
+import ensSubdomainRegistrarArtifactData from '../../artifacts/@aragon/osx-v1.0.1/framework/utils/ens/ENSSubdomainRegistrar.sol/ENSSubdomainRegistrar.json';
+import daoArtifactData from '../../artifacts/src/core/dao/DAO.sol/DAO.json';
 import {
   DAO,
   DAORegistry,
@@ -15,15 +15,12 @@ import {
   PluginRepoRegistry,
   PluginRepoRegistry__factory,
 } from '../../typechain';
-
-import daoArtifactData from '../../artifacts/src/core/dao/DAO.sol/DAO.json';
-import daoRegistryArtifactData from '../../artifacts/@aragon/osx-v1.0.1/framework/dao/DAORegistry.sol/DAORegistry.json';
-import pluginRepoRegistryArtifactData from '../../artifacts/@aragon/osx-v1.0.1/framework/plugin/repo/PluginRepoRegistry.sol/PluginRepoRegistry.json';
-import pluginRepoArtifactData from '../../artifacts/@aragon/osx-v1.0.1/framework/plugin/repo/PluginRepo.sol/PluginRepo.json';
-import ensSubdomainRegistrarArtifactData from '../../artifacts/@aragon/osx-v1.0.1/framework/utils/ens/ENSSubdomainRegistrar.sol/ENSSubdomainRegistrar.json';
-
-import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
+import {readImplementationValuesFromSlot} from '../../utils/storage';
 import {initializeDeploymentFixture} from '../test-utils/fixture';
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
+import {expect} from 'chai';
+import hre, {ethers, deployments, getNamedAccounts} from 'hardhat';
+import {Deployment} from 'hardhat-deploy/dist/types';
 
 async function deployAll() {
   await initializeDeploymentFixture('New');


### PR DESCRIPTION
## Description

The  management DAO ENS subdomain env var name was not updated after we changed it from 
`MANAGINGDAO_SUBDOMAIN ` to `MANAGEMENT_DAO_SUBDOMAIN`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [x] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [x] I have updated the Subgraph and added a QA URL to the description of this PR.
