### PR TITLE
fix: multisig removeAddresses revert param order

### DIFF
--- a/packages/contracts/src/plugins/governance/multisig/Multisig.sol
+++ b/packages/contracts/src/plugins/governance/multisig/Multisig.sol
@@ -188,8 +188,8 @@ contract Multisig is
         // Check if the new address list length would become less than the current minimum number of approvals required.
         if (newAddresslistLength < multisigSettings.minApprovals) {
             revert MinApprovalsOutOfBounds({
-                limit: newAddresslistLength,
-                actual: multisigSettings.minApprovals
+                limit: multisigSettings.minApprovals,
+                actual: newAddresslistLength
             });
         }
 
@@ -323,7 +323,7 @@ contract Multisig is
     /// @return approvals The number of approvals casted.
     /// @return parameters The parameters of the proposal vote.
     /// @return actions The actions to be executed in the associated DAO after the proposal has passed.
-    /// @param allowFailureMap A bitmap allowing the proposal to succeed, even if individual actions might revert. If the bit at index `i` is 1, the proposal succeeds even if the `i`th action reverts. A failure map value of 0 requires every action to not revert.
+    /// @return allowFailureMap A bitmap allowing the proposal to succeed, even if individual actions might revert. If the bit at index `i` is 1, the proposal succeeds even if the `i`th action reverts. A failure map value of 0 requires every action to not revert.
     function getProposal(
         uint256 _proposalId
     )

--- a/packages/contracts/test/plugins/governance/multisig/multisig.ts
+++ b/packages/contracts/test/plugins/governance/multisig/multisig.ts
@@ -446,8 +446,8 @@ describe('Multisig', function () {
       await expect(multisig.removeAddresses([signers[0].address]))
         .to.be.revertedWithCustomError(multisig, 'MinApprovalsOutOfBounds')
         .withArgs(
-          (await multisig.addresslistLength()).sub(1),
-          multisigSettings.minApprovals
+          multisigSettings.minApprovals,
+          (await multisig.addresslistLength()).sub(1)
         );
     });
 
@@ -465,8 +465,8 @@ describe('Multisig', function () {
       await expect(multisig.removeAddresses([signers[2].address]))
         .to.be.revertedWithCustomError(multisig, 'MinApprovalsOutOfBounds')
         .withArgs(
-          (await multisig.addresslistLength()).sub(1),
-          multisigSettings.minApprovals
+          multisigSettings.minApprovals,
+          (await multisig.addresslistLength()).sub(1)
         );
     });
   });


### PR DESCRIPTION
## Description

Fix revert params order in `removeAddresses`function

Task ID: [OS-1299](https://aragonassociation.atlassian.net/browse/OS-1299)

## Type of change

See the framework lifecycle in `packages/contracts/docs/framework-lifecycle` to decide what kind of change this pull request is.

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [ ] I have updated the Subgraph and added a QA URL to the description of this PR.


[OS-1299]: https://aragonassociation.atlassian.net/browse/OS-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ