### PR TITLE
refactor: added reinitializer and storage gap to `PluginRepo` and moved events to `IPluginRepo`

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `VersionComparisonLib` to compare semantic versioning numbers.
 - Inherit `ProtocolVersion` in `Plugin`, `PluginCloneable`, `PluginUUPSUpgradeable`, `PluginSetup`, `PermissionCondition`, `PermissionConditionUpgradeable` `PluginSetupProcessor`, `PluginRepoRegistry`, `DAORegistry`, and `ENSSubdomainRegistrar`.
 - Added the `FunctionDeprecated` error to `DAO`.
+- Added a storage gap to `PluginRepo`.
+- Added `initializeFrom` placeholder function to `PluginRepo`.
 
 ### Changed
 
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use the DAOs permission manager functionality to validate signatures.
 - Renamed `managingDAO` during deployment to `managmentDAO`.
 - Aligned contract names during deployment with the names given in `@aragon/osx-commons-configs`.
+- Move events `ReleaseMetadataUpdated`and `VersionCreated` from `PluginRepo` to `IPluginRepo`.
 
 ### Removed
 

--- a/packages/contracts/src/framework/plugin/repo/IPluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/IPluginRepo.sol
@@ -24,7 +24,7 @@ interface IPluginRepo {
         bytes calldata _releaseMetadata
     ) external;
 
-    /// @notice Thrown if the same plugin setup exists in previous releases.
+    /// @notice Emitted if the same plugin setup exists in previous releases.
     /// @param release The release number.
     /// @param build The build number.
     /// @param pluginSetup The address of the plugin setup contract.

--- a/packages/contracts/src/framework/plugin/repo/IPluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/IPluginRepo.sol
@@ -23,4 +23,21 @@ interface IPluginRepo {
         bytes calldata _buildMetadata,
         bytes calldata _releaseMetadata
     ) external;
+
+    /// @notice Thrown if the same plugin setup exists in previous releases.
+    /// @param release The release number.
+    /// @param build The build number.
+    /// @param pluginSetup The address of the plugin setup contract.
+    /// @param buildMetadata The build metadata URI.
+    event VersionCreated(
+        uint8 release,
+        uint16 build,
+        address indexed pluginSetup,
+        bytes buildMetadata
+    );
+
+    /// @notice Thrown when a release's metadata was updated.
+    /// @param release The release number.
+    /// @param releaseMetadata The release metadata URI.
+    event ReleaseMetadataUpdated(uint8 release, bytes releaseMetadata);
 }

--- a/packages/contracts/src/framework/plugin/repo/IPluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/IPluginRepo.sol
@@ -36,7 +36,7 @@ interface IPluginRepo {
         bytes buildMetadata
     );
 
-    /// @notice Thrown when a release's metadata was updated.
+    /// @notice Emitted when a release's metadata was updated.
     /// @param release The release number.
     /// @param releaseMetadata The release metadata URI.
     event ReleaseMetadataUpdated(uint8 release, bytes releaseMetadata);

--- a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
@@ -107,7 +107,7 @@ contract PluginRepo is
     /// - initializing the permission manager
     /// - granting the `MAINTAINER_PERMISSION_ID` permission to the initial owner.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
-    function initialize(address initialOwner) external reinitializer(2) {
+    function initialize(address initialOwner) external initializer {
         __PermissionManager_init(initialOwner);
 
         _grant(address(this), initialOwner, MAINTAINER_PERMISSION_ID);
@@ -117,16 +117,17 @@ contract PluginRepo is
     /// @notice Initializes the pluginRepo after an upgrade from a previous protocol version.
     /// @param _previousProtocolVersion The semantic protocol version number of the previous DAO implementation contract this upgrade is transitioning from.
     /// @param _initData The initialization data to be passed to via `upgradeToAndCall` (see [ERC-1967](https://docs.openzeppelin.com/contracts/4.x/api/proxy#ERC1967Upgrade)).
+    /// @dev This function is a placeholder until we require reinitialization.
     function initializeFrom(
         uint8[3] calldata _previousProtocolVersion,
         bytes calldata _initData
     ) external reinitializer(2) {
-        _initData; // Silences the unused function parameter warning.
-
-        // Check that the contract is not upgrading from a different major release.
-        if (_previousProtocolVersion[0] != 1) {
-            revert ProtocolVersionUpgradeNotSupported(_previousProtocolVersion);
-        }
+        // Silences the unused function parameter warning.
+        _previousProtocolVersion;
+        _initData;
+        
+        // Revert because this is a placeholder until this contract requires reinitialization.
+        revert();
     }
 
     /// @inheritdoc IPluginRepo

--- a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
@@ -125,7 +125,7 @@ contract PluginRepo is
         // Silences the unused function parameter warning.
         _previousProtocolVersion;
         _initData;
-        
+
         // Revert because this is a placeholder until this contract requires reinitialization.
         revert();
     }

--- a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
@@ -255,4 +255,7 @@ contract PluginRepo is
             _interfaceId == type(IProtocolVersion).interfaceId ||
             super.supportsInterface(_interfaceId);
     }
+
+    /// @notice This empty reserved space is put in place to allow future versions to add new variables without shifting down storage in the inheritance chain (see [OpenZeppelin's guide about storage gaps](https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps)).
+    uint256[46] private __gap;
 }

--- a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
@@ -96,23 +96,6 @@ contract PluginRepo is
     /// @notice Thrown if release does not exist.
     error ReleaseDoesNotExist();
 
-    /// @notice Thrown if the same plugin setup exists in previous releases.
-    /// @param release The release number.
-    /// @param build The build number.
-    /// @param pluginSetup The address of the plugin setup contract.
-    /// @param buildMetadata The build metadata URI.
-    event VersionCreated(
-        uint8 release,
-        uint16 build,
-        address indexed pluginSetup,
-        bytes buildMetadata
-    );
-
-    /// @notice Thrown when a release's metadata was updated.
-    /// @param release The release number.
-    /// @param releaseMetadata The release metadata URI.
-    event ReleaseMetadataUpdated(uint8 release, bytes releaseMetadata);
-
     /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
     constructor() {
         _disableInitializers();

--- a/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
+++ b/packages/contracts/src/framework/plugin/repo/PluginRepo.sol
@@ -95,8 +95,6 @@ contract PluginRepo is
 
     /// @notice Thrown if release does not exist.
     error ReleaseDoesNotExist();
-    /// @notice Thrown if an upgrade is not supported from a specific protocol version .
-    error ProtocolVersionUpgradeNotSupported(uint8[3] protocolVersion);
 
     /// @dev Used to disallow initializing the implementation contract by an attacker for extra safety.
     constructor() {

--- a/packages/contracts/test/framework/plugin/plugin-repo.ts
+++ b/packages/contracts/test/framework/plugin/plugin-repo.ts
@@ -515,7 +515,7 @@ describe('PluginRepo', function () {
         ).to.be.revertedWithCustomError(pluginRepo, 'EmptyReleaseMetadata');
       });
 
-      it('successfully updates metadata for the release that already exists and emits the "ReleaseMetadataUpdated" event', async () => {
+      it('updates metadata for the release that already exists and emits the "ReleaseMetadataUpdated" event', async () => {
         await pluginRepo.createVersion(
           1,
           pluginSetupMock.address,

--- a/packages/contracts/test/framework/plugin/plugin-repo.ts
+++ b/packages/contracts/test/framework/plugin/plugin-repo.ts
@@ -515,7 +515,7 @@ describe('PluginRepo', function () {
         ).to.be.revertedWithCustomError(pluginRepo, 'EmptyReleaseMetadata');
       });
 
-      it('successfuly updates metadata for the release that already exists', async () => {
+      it('successfuly updates metadata for the release that already exists and emits the "ReleaseMetadataUpdated" event', async () => {
         await pluginRepo.createVersion(
           1,
           pluginSetupMock.address,

--- a/packages/contracts/test/framework/plugin/plugin-repo.ts
+++ b/packages/contracts/test/framework/plugin/plugin-repo.ts
@@ -515,7 +515,7 @@ describe('PluginRepo', function () {
         ).to.be.revertedWithCustomError(pluginRepo, 'EmptyReleaseMetadata');
       });
 
-      it('successfuly updates metadata for the release that already exists and emits the "ReleaseMetadataUpdated" event', async () => {
+      it('successfully updates metadata for the release that already exists and emits the "ReleaseMetadataUpdated" event', async () => {
         await pluginRepo.createVersion(
           1,
           pluginSetupMock.address,

--- a/packages/contracts/test/framework/plugin/plugin-repo.ts
+++ b/packages/contracts/test/framework/plugin/plugin-repo.ts
@@ -154,7 +154,7 @@ describe('PluginRepo', function () {
       });
     });
     describe('InitializeFrom', () => {
-      it('Should revert because the function is a placeholder', async () => {
+      it('reverts because the function is a placeholder', async () => {
         // Call `initializeFrom` with version 1.3.0. and revert
         await expect(pluginRepo.initializeFrom([1, 3, 0], emptyBytes)).to.be
           .reverted;

--- a/packages/contracts/test/framework/plugin/plugin-repo.ts
+++ b/packages/contracts/test/framework/plugin/plugin-repo.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../typechain';
 import {PluginRepo__factory as PluginRepo_V1_0_0__factory} from '../../../typechain/@aragon/osx-v1.0.1/framework/plugin/repo/PluginRepo.sol';
 import {PluginRepo__factory as PluginRepo_V1_3_0__factory} from '../../../typechain/@aragon/osx-v1.3.0/framework/plugin/repo/PluginRepo.sol';
+import {OZ_INITIALIZED_SLOT_POSITION} from '../../../utils/storage';
 import {ZERO_BYTES32} from '../../test-utils/dao';
 import {osxContractsVersion} from '../../test-utils/protocol-version';
 import {tagHash} from '../../test-utils/psp/hash-helpers';
@@ -150,6 +151,23 @@ describe('PluginRepo', function () {
         expect(fromProtocolVersion).to.not.deep.equal(toProtocolVersion);
         expect(fromProtocolVersion).to.deep.equal([1, 3, 0]);
         expect(toProtocolVersion).to.deep.equal(osxContractsVersion());
+      });
+    });
+    describe('InitializeFrom', () => {
+      it('increments `_initialized` to `1`', async () => {
+        // Expect the contract to be initialized  with `_initialized = 1`.
+        expect(
+          ethers.BigNumber.from(
+            await ethers.provider.getStorageAt(
+              pluginRepo.address,
+              OZ_INITIALIZED_SLOT_POSITION
+            )
+          ).toNumber()
+        ).to.equal(1);
+
+        // Call `initializeFrom` with version 1.3.0. and revert
+        await expect(pluginRepo.initializeFrom([1, 3, 0], emptyBytes)).to.be
+          .reverted;
       });
     });
 

--- a/packages/contracts/test/framework/plugin/plugin-repo.ts
+++ b/packages/contracts/test/framework/plugin/plugin-repo.ts
@@ -154,17 +154,7 @@ describe('PluginRepo', function () {
       });
     });
     describe('InitializeFrom', () => {
-      it('increments `_initialized` to `1`', async () => {
-        // Expect the contract to be initialized  with `_initialized = 1`.
-        expect(
-          ethers.BigNumber.from(
-            await ethers.provider.getStorageAt(
-              pluginRepo.address,
-              OZ_INITIALIZED_SLOT_POSITION
-            )
-          ).toNumber()
-        ).to.equal(1);
-
+      it('Should revert because the function is a placeholder', async () => {
         // Call `initializeFrom` with version 1.3.0. and revert
         await expect(pluginRepo.initializeFrom([1, 3, 0], emptyBytes)).to.be
           .reverted;


### PR DESCRIPTION
## Description

- [x] is upgradeable, but it doesn’t have a storage gap
- [x]  Why are the events VersionCreated and ReleaseMetadataUpdated in PluginRepo and not in the IPluginRepo Interface?
  - we can move the events to the right place without changing the ERC-165 interface ID and updating the PluginRepoFactory
- [x] We miss a test checking that function updateReleaseMetadata emits the ReleaseMetadataUpdated event
- [x] Add an initializeFrom function to the contract. (see )
  - check on DAO.sol how this function is supposed to work
  - if we don’t need to re-initialize, then this function will be empty for now.

Task ID: [OS-676](https://aragonassociation.atlassian.net/browse/OS-676)

## Type of change

See the framework lifecycle in `packages/contracts/docs/framework-lifecycle` to decide what kind of change this pull request is.

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [ ] I have updated the Subgraph and added a QA URL to the description of this PR.


[OS-676]: https://aragonassociation.atlassian.net/browse/OS-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ