### PR TITLE
feat: add tx hash to dao entity in subgraph

### DIFF
--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UPCOMING]
 
-## 1.4.1
+### Added
 
-## 1.5.0
+- Add `txHash` field to the Dao entity.
+
+## 1.4.1
 
 ### Changed
 

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -461,6 +461,7 @@ type Dao @entity {
   daoURI: String
   metadata: String
   createdAt: BigInt!
+  txHash: Bytes!
   token: ERC20Contract
   actions: [Action!]! @derivedFrom(field: "dao")
   transfers: [TokenTransfer!]! @derivedFrom(field: "dao")

--- a/packages/subgraph/src/registries/daoRegistry.ts
+++ b/packages/subgraph/src/registries/daoRegistry.ts
@@ -21,6 +21,7 @@ export function handleDAORegistered(event: DAORegistered): void {
 
   entity.creator = event.params.creator;
   entity.createdAt = event.block.timestamp;
+  entity.txHash = event.transaction.hash;
 
   // subscribe to templates
   DaoTemplateV1_0_0.create(daoAddress);

--- a/packages/subgraph/tests/dao/utils.ts
+++ b/packages/subgraph/tests/dao/utils.ts
@@ -420,6 +420,8 @@ export function createDaoEntityState(
   daoEntity.creator = Address.fromString(creator);
   daoEntity.createdAt = BigInt.zero();
   daoEntity.token = Address.fromString(token).toHexString();
+  // random tx hash for testing purposes only
+  daoEntity.txHash = Bytes.fromHexString('0x01');
   daoEntity.save();
 
   return daoEntity;

--- a/packages/subgraph/tests/helpers/method-classes.ts
+++ b/packages/subgraph/tests/helpers/method-classes.ts
@@ -480,6 +480,8 @@ class DaoMethods extends Dao {
     this.token = Address.fromString(DAO_TOKEN_ADDRESS).toHexString();
     this.trustedForwarder = Address.fromHexString(ADDRESS_TWO);
     this.signatureValidator = Address.fromHexString(ADDRESS_THREE);
+    // random tx hash for testing purposes only
+    this.txHash = Bytes.fromHexString('0x01');
     return this;
   }
 

--- a/packages/subgraph/tests/registry/daoRegistry.test.ts
+++ b/packages/subgraph/tests/registry/daoRegistry.test.ts
@@ -43,6 +43,12 @@ describe('DAORegistry', () => {
       'createdAt',
       newDaoEvent.block.timestamp.toString()
     );
+    assert.fieldEquals(
+      'Dao',
+      daoEntityId,
+      'txHash',
+      newDaoEvent.transaction.hash.toHexString()
+    );
   });
 
   test("Don't store subdomain for blocklisted DAO", () => {
@@ -71,6 +77,12 @@ describe('DAORegistry', () => {
       denylistedEntityId,
       'createdAt',
       newDaoEvent.block.timestamp.toString()
+    );
+    assert.fieldEquals(
+      'Dao',
+      denylistedEntityId,
+      'txHash',
+      newDaoEvent.transaction.hash.toHexString()
     );
 
     const daoEntity = Dao.load(denylistedEntityId);


### PR DESCRIPTION
## Description

Pr for adding the tx hash field in the subgraph Dao entity. 

[QA subgraph deployed](https://subgraphs.alchemy.com/subgraphs/5350/versions/17509)

Task ID: [OS-1181](https://aragonassociation.atlassian.net/browse/OS-1181)

## Type of change

See the framework lifecycle in `packages/contracts/docs/framework-lifecycle` to decide what kind of change this pull request is.

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [ ] I have updated the Subgraph and added a QA URL to the description of this PR.


[OS-1181]: https://aragonassociation.atlassian.net/browse/OS-1181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ