### PR TITLE
Feature/fix apply methods

### DIFF
--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -534,7 +534,7 @@ abstract contract PermissionManager is Initializable {
         address _where,
         PermissionLib.SingleTargetPermission[] calldata _items
     ) external virtual {
-        (bool hasRoot, bool hasApplyTargetPermission) = canApplyTarget();
+        (bool hasRoot, bool hasApplyTargetPermission) = _canApplyTarget();
 
         for (uint256 i; i < _items.length; ) {
             PermissionLib.SingleTargetPermission memory item = _items[i];
@@ -574,7 +574,7 @@ abstract contract PermissionManager is Initializable {
     function applyMultiTargetPermissions(
         PermissionLib.MultiTargetPermission[] calldata _items
     ) external virtual {
-        (bool hasRoot, bool hasApplyTargetPermission) = canApplyTarget();
+        (bool hasRoot, bool hasApplyTargetPermission) = _canApplyTarget();
 
         for (uint256 i; i < _items.length; ) {
             PermissionLib.MultiTargetPermission memory item = _items[i];

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -943,7 +943,7 @@ abstract contract PermissionManager is Initializable {
         }
     }
 
-    /// @notice An internal function to check if the caller is allowed to call applyTarget functions.
+    /// @notice An internal function to check if the caller has either root or apply target permission.
     /// @dev Reverts in case the caller has none of these permissions.
     /// @return hasRoot whether the caller has ROOT and `APPLY_TARGET_PERMISSION_ID` permissions.
     function _canApplyTarget() internal view returns (bool hasRoot, bool hasApplyTargetPermission) {

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -1031,18 +1031,18 @@ abstract contract PermissionManager is Initializable {
         }
 
         // Check either caller is delegated or an owner.
-        uint256 flags = _permission.delegations[_who];
-        if (flags == 0) {
-            flags = _permission.owners[_who];
-        } else {
-            delete _permission.delegations[_who];
-        }
+        uint256 delegationFlags = _permission.delegations[_who];
+        uint256 ownerFlags = _permission.owners[_who];
+        uint256 flags = delegationFlags | ownerFlags;
 
         if (
             _operation == PermissionLib.Operation.Grant ||
             _operation == PermissionLib.Operation.GrantWithCondition
         ) {
             if (_checkFlags(flags, GRANT_OWNER_FLAG)) {
+                if (_checkFlags(delegationFlags, GRANT_OWNER_FLAG)) {
+                    _permission.delegations[_who] = delegationFlags ^ GRANT_OWNER_FLAG;
+                }
                 return true;
             }
 
@@ -1051,6 +1051,9 @@ abstract contract PermissionManager is Initializable {
 
         if (_operation == PermissionLib.Operation.Revoke) {
             if (_checkFlags(flags, REVOKE_OWNER_FLAG)) {
+                if (_checkFlags(delegationFlags, REVOKE_OWNER_FLAG)) {
+                    _permission.delegations[_who] = delegationFlags ^ REVOKE_OWNER_FLAG;
+                }
                 return true;
             }
 

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -946,7 +946,7 @@ abstract contract PermissionManager is Initializable {
     /// @notice An internal function to check if the caller is allowed to call applyTarget functions.
     /// @dev Reverts in case the caller has none of these permissions.
     /// @return hasRoot whether the caller has ROOT and `APPLY_TARGET_PERMISSION_ID` permissions.
-    function canApplyTarget() internal view returns (bool hasRoot, bool hasApplyTargetPermission) {
+    function _canApplyTarget() internal view returns (bool hasRoot, bool hasApplyTargetPermission) {
         hasRoot = _isRoot(msg.sender);
 
         if (!hasRoot) {

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -164,7 +164,7 @@ abstract contract PermissionManager is Initializable {
     /// @param where The address of the target contract for which the delegatee loses permissions.
     /// @param permissionIdOrSelector The permission identifier.
     /// @param delegatee The address of the delegatee.
-    /// @param flags The current flags undelegated to the delegatee.
+    /// @param flags The current/updated flags left on the delegatee.
     event PermissionUndelegated(
         address indexed where,
         bytes32 indexed permissionIdOrSelector,
@@ -188,12 +188,14 @@ abstract contract PermissionManager is Initializable {
     /// @param where The address of the target contract for which the owner loses permissions.
     /// @param permissionIdOrSelector The permission identifier.
     /// @param owner The address of the owner.
-    /// @param flags The flags to remove from the owner.
+    /// @param updatedOwnerFlags The updated/current flags left on the owner.
+    /// @param updatedDelegateeFlags The updated/current flags left on the owner.
     event OwnerRemoved(
         address indexed where,
         bytes32 indexed permissionIdOrSelector,
         address indexed owner,
-        uint256 flags
+        uint256 updatedOwnerFlags,
+        uint256 updatedDelegateeFlags
     );
 
     /// @notice Emitted when a permission does get created.
@@ -281,7 +283,7 @@ abstract contract PermissionManager is Initializable {
         uint256 currentFlags = permission.delegations[_delegatee];
 
         // If the same flags that a `delegatee` already holds is added, return early.
-        if (currentFlags == _flags) {
+        if (_checkFlags(currentFlags, _flags)) {
             return;
         }
 
@@ -358,7 +360,7 @@ abstract contract PermissionManager is Initializable {
         uint256 currentFlags = permission.owners[_owner];
 
         // If the same flags that an `owner` already holds is added, return early.
-        if (currentFlags == _flags) {
+        if (_checkFlags(currentFlags, _flags)) {
             return;
         }
 
@@ -396,11 +398,11 @@ abstract contract PermissionManager is Initializable {
             permissionHash(_where, _permissionIdOrSelector)
         ];
 
-        uint256 currentFlags = permission.owners[msg.sender];
+        uint256 ownerFlags = permission.owners[msg.sender];
 
         // Check if the removal flags have more bit set as the owner currently has.
-        if (!_checkFlags(currentFlags, _flags)) {
-            revert InvalidFlagsForRemovalPassed(currentFlags, _flags);
+        if (!_checkFlags(ownerFlags, _flags)) {
+            revert InvalidFlagsForRemovalPassed(ownerFlags, _flags);
         }
 
         if (_checkFlags(_flags, GRANT_OWNER_FLAG)) {
@@ -411,10 +413,25 @@ abstract contract PermissionManager is Initializable {
             permission.revokeCounter--;
         }
 
-        uint256 newFlags = currentFlags ^ _flags; // remove permissions
-        permission.owners[msg.sender] = newFlags;
+        uint256 newOwnerFlags = ownerFlags ^ _flags; // remove permissions
+        permission.owners[msg.sender] = newOwnerFlags;
 
-        emit OwnerRemoved(_where, _permissionIdOrSelector, msg.sender, newFlags);
+        // Renouncing the ownership should also mean to renounce delegation.
+        uint256 delegateeFlags = permission.delegations[msg.sender];
+        uint256 newDelegateeFlags = 0;
+
+        if (_checkFlags(delegateeFlags, _flags)) {
+            newDelegateeFlags = delegateeFlags ^ _flags;
+            permission.delegations[msg.sender] = newDelegateeFlags;
+        }
+
+        emit OwnerRemoved(
+            _where,
+            _permissionIdOrSelector,
+            msg.sender,
+            newOwnerFlags,
+            newDelegateeFlags
+        );
     }
 
     /// @notice Function to check if this specific permission is frozen.
@@ -432,10 +449,12 @@ abstract contract PermissionManager is Initializable {
         return _isPermissionFrozen(permission);
     }
 
-    /// @notice Function to retrieve the owner and delegate flags of an `_owner` on a permission.
+    /// @notice Function to retrieve if permission is created and how many owners it has.
     /// @param _where The address of the target contract for which `_who` receives permission.
     /// @param _permissionIdOrSelector The permission hash or function selector used for this permission.
-    /// @return The counts of how many owners are on a permission and whether permission has been created or not yet.
+    /// @return Whether the permission has been created or not.
+    /// @return How many grant owners this permission has currently.
+    /// @return How many revoke owners this permission has currently.
     function getPermissionData(
         address _where,
         bytes32 _permissionIdOrSelector
@@ -447,21 +466,22 @@ abstract contract PermissionManager is Initializable {
         return (permission.created, permission.grantCounter, permission.revokeCounter);
     }
 
-    /// @notice Function to retrieve the owner and delegate flags of an `_owner` on a permission.
+    /// @notice Function to retrieve the owner and delegate flags of an `_account` on a permission.
     /// @param _where The address of the target contract for which `_who` receives permission.
     /// @param _permissionIdOrSelector The permission hash or function selector used for this permission.
-    /// @param _owner The address for which to return the current flags.
-    /// @return The owner and delegate flags.
+    /// @param _account The address for which to return the current flags.
+    /// @return uint256 Returns owner flags. 0 if an `account` is not an owner.
+    /// @return uint256 Returns delegatee flags. 0 if an `account` is not a delegatee.
     function getFlags(
         address _where,
         bytes32 _permissionIdOrSelector,
-        address _owner
+        address _account
     ) public view returns (uint256, uint256) {
         Permission storage permission = permissions[
             permissionHash(_where, _permissionIdOrSelector)
         ];
 
-        return (permission.owners[_owner], permission.delegations[_owner]);
+        return (permission.owners[_account], permission.delegations[_account]);
     }
 
     /// @notice Grants permission to an address to call methods in a contract guarded by an auth modifier with the specified permission identifier.
@@ -945,7 +965,8 @@ abstract contract PermissionManager is Initializable {
 
     /// @notice An internal function to check if the caller has either root or apply target permission.
     /// @dev Reverts in case the caller has none of these permissions.
-    /// @return hasRoot whether the caller has ROOT and `APPLY_TARGET_PERMISSION_ID` permissions.
+    /// @return hasRoot True if the caller has ROOT on `address(this)`, otherwise false.
+    /// @return hasApplyTargetPermission True if the caller has `APPLY_TARGET_PERMISSION_ID` on `address(this)`, otherwise false.
     function _canApplyTarget() internal view returns (bool hasRoot, bool hasApplyTargetPermission) {
         hasRoot = _isRoot(msg.sender);
 
@@ -1030,31 +1051,37 @@ abstract contract PermissionManager is Initializable {
             return isRoot;
         }
 
-        uint256 delegationFlags = _permission.delegations[_who];
-
         if (
             _operation == PermissionLib.Operation.Grant ||
             _operation == PermissionLib.Operation.GrantWithCondition
         ) {
-            if (_checkFlags(delegationFlags, GRANT_OWNER_FLAG)) {
-                _permission.delegations[_who] = delegationFlags ^ GRANT_OWNER_FLAG;
+            if (_checkFlags(_permission.owners[_who], GRANT_OWNER_FLAG)) {
                 return true;
-            } else if (_checkFlags(_permission.owners[_who], GRANT_OWNER_FLAG)) {
-                return true;
-            }
+            } else {
+                uint256 delegationFlags = _permission.delegations[_who];
 
-            return isRoot && _permission.grantCounter == 0;
+                if (_checkFlags(delegationFlags, GRANT_OWNER_FLAG)) {
+                    _permission.delegations[_who] = delegationFlags ^ GRANT_OWNER_FLAG;
+                    return true;
+                }
+
+                return isRoot && _permission.grantCounter == 0;
+            }
         }
 
         if (_operation == PermissionLib.Operation.Revoke) {
-            if (_checkFlags(delegationFlags, REVOKE_OWNER_FLAG)) {
-                _permission.delegations[_who] = delegationFlags ^ REVOKE_OWNER_FLAG;
+            if (_checkFlags(_permission.owners[_who], REVOKE_OWNER_FLAG)) {
                 return true;
-            } else if (_checkFlags(_permission.owners[_who], REVOKE_OWNER_FLAG)) {
-                return true;
-            }
+            } else {
+                uint256 delegationFlags = _permission.delegations[_who];
 
-            return isRoot && _permission.revokeCounter == 0;
+                if (_checkFlags(delegationFlags, REVOKE_OWNER_FLAG)) {
+                    _permission.delegations[_who] = delegationFlags ^ REVOKE_OWNER_FLAG;
+                    return true;
+                }
+
+                return isRoot && _permission.revokeCounter == 0;
+            }
         }
 
         return false;

--- a/packages/contracts/src/core/permission/PermissionManager.sol
+++ b/packages/contracts/src/core/permission/PermissionManager.sol
@@ -1030,19 +1030,16 @@ abstract contract PermissionManager is Initializable {
             return isRoot;
         }
 
-        // Check either caller is delegated or an owner.
         uint256 delegationFlags = _permission.delegations[_who];
-        uint256 ownerFlags = _permission.owners[_who];
-        uint256 flags = delegationFlags | ownerFlags;
 
         if (
             _operation == PermissionLib.Operation.Grant ||
             _operation == PermissionLib.Operation.GrantWithCondition
         ) {
-            if (_checkFlags(flags, GRANT_OWNER_FLAG)) {
-                if (_checkFlags(delegationFlags, GRANT_OWNER_FLAG)) {
-                    _permission.delegations[_who] = delegationFlags ^ GRANT_OWNER_FLAG;
-                }
+            if (_checkFlags(delegationFlags, GRANT_OWNER_FLAG)) {
+                _permission.delegations[_who] = delegationFlags ^ GRANT_OWNER_FLAG;
+                return true;
+            } else if (_checkFlags(_permission.owners[_who], GRANT_OWNER_FLAG)) {
                 return true;
             }
 
@@ -1050,10 +1047,10 @@ abstract contract PermissionManager is Initializable {
         }
 
         if (_operation == PermissionLib.Operation.Revoke) {
-            if (_checkFlags(flags, REVOKE_OWNER_FLAG)) {
-                if (_checkFlags(delegationFlags, REVOKE_OWNER_FLAG)) {
-                    _permission.delegations[_who] = delegationFlags ^ REVOKE_OWNER_FLAG;
-                }
+            if (_checkFlags(delegationFlags, REVOKE_OWNER_FLAG)) {
+                _permission.delegations[_who] = delegationFlags ^ REVOKE_OWNER_FLAG;
+                return true;
+            } else if (_checkFlags(_permission.owners[_who], REVOKE_OWNER_FLAG)) {
                 return true;
             }
 

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -1796,6 +1796,41 @@ describe.only('Core: PermissionManager', function () {
 
         expect(permission).to.be.equal(ALLOW_FLAG);
       });
+
+      it('should succeed if caller is delegated', async () => {
+        let caller = signers[3];
+        let owner = signers[2];
+
+        await pm.createPermission(
+          someWhere,
+          ADMIN_PERMISSION_ID,
+          owner.address,
+          []
+        );
+
+        await pm.grant(
+          pm.address,
+          caller.address,
+          DAO_PERMISSIONS.ROOT_PERMISSION_ID
+        );
+
+        await expect(
+          pm.connect(caller).applyMultiTargetPermissions([bulkItem])
+        ).to.be.revertedWithCustomError(pm, 'Unauthorized');
+
+        await pm
+          .connect(owner)
+          .delegatePermission(
+            someWhere,
+            ADMIN_PERMISSION_ID,
+            caller.address,
+            GRANT_OWNER_FLAG
+          );
+
+        await expect(
+          pm.connect(caller).applyMultiTargetPermissions([bulkItem])
+        ).to.emit(pm, 'Granted');
+      });
     });
 
     it('should bulk revoke', async () => {
@@ -2083,6 +2118,41 @@ describe.only('Core: PermissionManager', function () {
         );
 
         expect(permission).to.be.equal(ALLOW_FLAG);
+      });
+
+      it('should succeed if caller is delegated', async () => {
+        let caller = signers[3];
+        let owner = signers[2];
+
+        await pm.createPermission(
+          someWhere,
+          ADMIN_PERMISSION_ID,
+          owner.address,
+          []
+        );
+
+        await pm.grant(
+          pm.address,
+          caller.address,
+          DAO_PERMISSIONS.ROOT_PERMISSION_ID
+        );
+
+        await expect(
+          pm.connect(caller).applySingleTargetPermissions(someWhere, [bulkItem])
+        ).to.be.revertedWithCustomError(pm, 'Unauthorized');
+
+        await pm
+          .connect(owner)
+          .delegatePermission(
+            someWhere,
+            ADMIN_PERMISSION_ID,
+            caller.address,
+            GRANT_OWNER_FLAG
+          );
+
+        await expect(
+          pm.connect(caller).applySingleTargetPermissions(someWhere, [bulkItem])
+        ).to.emit(pm, 'Granted');
       });
     });
 

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -990,6 +990,28 @@ describe.only('Core: PermissionManager', function () {
         .addOwner(someWhere, somePermissionId, alice.address, GRANT_OWNER_FLAG);
 
       await pm.connect(alice).grant(someWhere, someWhere, somePermissionId);
+      await pm.connect(alice).revoke(someWhere, someWhere, somePermissionId);
+    });
+
+    it('should still keep the flag for delegation if a caller is an owner and delegate and calls grant', async () => {
+      let owner = signers[4];
+
+      await pm.createPermission(someWhere, somePermissionId, owner.address, []);
+
+      await pm
+        .connect(owner)
+        .delegatePermission(
+          someWhere,
+          somePermissionId,
+          owner.address,
+          GRANT_OWNER_FLAG
+        );
+
+      await pm.connect(owner).grant(someWhere, someWhere, somePermissionId);
+
+      expect(
+        await pm.getFlags(someWhere, somePermissionId, owner.address)
+      ).to.deep.equal([FULL_OWNER_FLAG, GRANT_OWNER_FLAG]);
     });
 
     it('should still keep `REVOKE_OWNER_FLAG` for delegatee if only `GRANT_OWNER_FLAG` is used/depleted', async () => {
@@ -1621,6 +1643,27 @@ describe.only('Core: PermissionManager', function () {
       )
         .to.be.revertedWithCustomError(pm, 'Unauthorized')
         .withArgs(someWhere, otherSigner.address, somePermissionId);
+    });
+
+    it('should still keep the flag for delegation if a caller is an owner and delegate and calls revoke', async () => {
+      let owner = signers[4];
+
+      await pm.createPermission(someWhere, somePermissionId, owner.address, []);
+
+      await pm
+        .connect(owner)
+        .delegatePermission(
+          someWhere,
+          somePermissionId,
+          owner.address,
+          REVOKE_OWNER_FLAG
+        );
+
+      await pm.connect(owner).revoke(someWhere, someWhere, somePermissionId);
+
+      expect(
+        await pm.getFlags(someWhere, somePermissionId, owner.address)
+      ).to.deep.equal([FULL_OWNER_FLAG, REVOKE_OWNER_FLAG]);
     });
 
     it('should still keep `GRANT_OWNER_FLAG` for delegatee if only `REVOKE_OWNER_FLAG` is used/depleted', async () => {

--- a/packages/contracts/test/core/permission/permission-manager.ts
+++ b/packages/contracts/test/core/permission/permission-manager.ts
@@ -1620,7 +1620,7 @@ describe.only('Core: PermissionManager', function () {
       };
     });
 
-    it('throws `Unauthorized` error when caller does not have `APPLY_TARGET_PERMISSION` and isnt root', async () => {
+    it("throws `Unauthorized` error when caller does not have `APPLY_TARGET_PERMISSION` and isn't root", async () => {
       let caller = signers[3];
 
       await expect(pm.connect(caller).applyMultiTargetPermissions([bulkItem]))


### PR DESCRIPTION
## Description

If caller was not root, but had permission of APPLY_TARGET_PERMISSION_ID and one of the bulk permission(that was being applied) had no owner, the code would fail, because isRoot passed to checkOwner was false, so returning checkOwner as false, which definitely seems wrong. See the code to see how it's fixed.

The PR also organizes the bulk methods' tests much cleaner/elegenantly.

(../CONTRIBUTIONS.md)

Task ID: [OS-?](https://aragonassociation.atlassian.net/browse/OS-?)

## Type of change

See the framework lifecycle in `packages/contracts/docs/framework-lifecycle` to decide what kind of change this pull request is.

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [ ] I have updated the Subgraph and added a QA URL to the description of this PR.
- [ ] I have created a follow-up task to update the Developer Portal with the changes made in this PR.
