### PR TITLE
fix minor typos in docs and Hardhat config

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The following graphic shows an exemplary DAO setup:
 
 ![A potential DAO setup](./images/dao-plugin.svg)
 
-An examplary DAO setup showing interactions between the three core contract pieces triggered by different user groups: The `DAO` and `PermissionManager` contract in blue and red, respectively, as well as two `Plugin` contracts in green. Bear in mind, the `DAO` and `Permission Manager` components both coexist within the same `DAO` contract. Function calls are visualized as black arrows and require permission checks (red, dashed arrow). In this example, the permission manager determines whether the token voting plugin can execute actions on the DAO, a member can change its settings, or if an DeFi-related plugin is allowed to invest in a certain, external contract.
+An exemplary DAO setup showing interactions between the three core contract pieces triggered by different user groups: The `DAO` and `PermissionManager` contract in blue and red, respectively, as well as two `Plugin` contracts in green. Bear in mind, the `DAO` and `Permission Manager` components both coexist within the same `DAO` contract. Function calls are visualized as black arrows and require permission checks (red, dashed arrow). In this example, the permission manager determines whether the token voting plugin can execute actions on the DAO, a member can change its settings, or if an DeFi-related plugin is allowed to invest in a certain, external contract.
 
 ### Framework Contracts
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -38,7 +38,7 @@ When testing locally:
 
 Default values for all required environment variables are provided when running against hardhat, check the [`.env.example`](./.env.example) for details of what these are and what they mean.
 
-The private key provided by default is a hardhat publically known key for `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`. Don't use it outside of a local development context.
+The private key provided by default is a hardhat publicly known key for `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`. Don't use it outside of a local development context.
 
 > Tests can be sped up if needed. See [the test performance optimization](#performance-optimizations) section for more info.
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -19,7 +19,7 @@ Before starting make sure that you have created an `.env` file from the `.env.ex
 Now you can get started running your repository locally:
 
 1. Install packages from the root folder with `yarn`
-2. Change directory into this package (`/pacakages/contracts`)
+2. Change directory into this package (`/packages/contracts`)
 3. Run `yarn build` to compile the contracts
 4. Run `yarn test` to execute the test suite (this can take a while, so see [performance optimizations](#performance-optimizations) for ways to speed up the tests).
 

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -50,7 +50,7 @@ for (const network of Object.keys(hardhatNetworks) as SupportedNetworks[]) {
   }
 
   if (networkExtensions[network] == undefined) {
-    console.log(`WARNING: newtork ${network} is not found in networks.ts file`);
+    console.log(`WARNING: network ${network} is not found in networks.ts file`);
     continue;
   }
 


### PR DESCRIPTION


- **Root `README.md`**: `examplary` → `exemplary`.
- **`packages/contracts/README.md`**:
  - `/pacakages/contracts` → `/packages/contracts`
  - `publically` → `publicly`
- **`packages/contracts/hardhat.config.ts`**:
  - Console message: `nertwork` → `network`.

