### PR TITLE
Chore: correct the ERC on the DAO docs page

### DIFF
--- a/packages/contracts/docs/modules/ROOT/pages/core/dao.adoc
+++ b/packages/contracts/docs/modules/ROOT/pages/core/dao.adoc
@@ -45,7 +45,7 @@ Currently, Externally Owned Accounts (EOAs) can sign messages with their associa
 An exemplary use case is a decentralized exchange with an off-chain order book, where buy/sell orders are signed messages.
 To accept such a request, both, the external service provider and caller need to follow a standard with which the signed message of the caller can be validated.
 
-By supporting the link:https://eips.ethereum.org/EIPS/eip-721[ERC-721 (NFT Standard)], your DAO can validate signatures via its `isValidSignature` function that forwards the call to a signature validator contract.
+By supporting the link:https://eips.ethereum.org/EIPS/eip-1271[ERC-1271 (Standard Signature Validation Method for Contracts)], your DAO can validate signatures via its `isValidSignature` function that forwards the call to a signature validator contract.
 
 === 6. Permission Management
 


### PR DESCRIPTION
## Description

Docs incorrectly mention ERC-721 when talking about `isValidSignature` -- the correct ERC is 1271.

## Type of change

simple docs change 🙏 

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [x] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [x] I have created a follow-up task to update the Developer Portal with the changes made in this PR.
