### PR TITLE
F/member registry audit

### DIFF
--- a/src/framework/member/IMemberRegistry.sol
+++ b/src/framework/member/IMemberRegistry.sol
@@ -66,6 +66,9 @@ interface IMemberRegistry {
     /// @notice Thrown if the management DAO address is the zero address.
     error InvalidManagementDao(address dao);
 
+    /// @notice Thrown if the resolver address has no contract code (zero address or EOA).
+    error InvalidResolver(address resolver);
+
     /// @notice Register as a member by claiming a subdomain. Permissionless.
     ///         One subdomain per address. Reverts if already registered (release first).
     /// @param subdomain The subdomain label to claim (e.g., "alice").

--- a/src/framework/member/MemberRegistry.sol
+++ b/src/framework/member/MemberRegistry.sol
@@ -78,6 +78,9 @@ contract MemberRegistry is IMemberRegistry, UUPSUpgradeable, DaoAuthorizableUpgr
         // Verify the parent domain is not empty.
         else if (bytes(_domain).length == 0) revert InvalidDomain(_domain);
 
+        // Reject zero address / EOA resolvers. High-level calls to a no-code address
+        if (_resolver.code.length == 0) revert InvalidResolver(_resolver);
+
         // Verify the resolver supports per-node approval (reverts if missing).
         IResolver(_resolver).isApprovedFor(address(this), bytes32(0), address(0));
 
@@ -114,8 +117,6 @@ contract MemberRegistry is IMemberRegistry, UUPSUpgradeable, DaoAuthorizableUpgr
         bytes32 label = keccak256(bytes(subdomain));
         address member = labelOwner[label];
         if (member == address(0)) revert SubdomainNotRegistered(subdomain);
-        // Reject `address(this)` — registering the registry as a member would lock the
-        // subdomain (release() keys on msg.sender, and the registry never self-calls).
         if (newController == member || newController == address(this)) revert InvalidNewController(newController);
 
         _release(member);

--- a/src/framework/member/MemberRegistry.sol
+++ b/src/framework/member/MemberRegistry.sol
@@ -114,7 +114,9 @@ contract MemberRegistry is IMemberRegistry, UUPSUpgradeable, DaoAuthorizableUpgr
         bytes32 label = keccak256(bytes(subdomain));
         address member = labelOwner[label];
         if (member == address(0)) revert SubdomainNotRegistered(subdomain);
-        if (newController == member) revert InvalidNewController(newController);
+        // Reject `address(this)` — registering the registry as a member would lock the
+        // subdomain (release() keys on msg.sender, and the registry never self-calls).
+        if (newController == member || newController == address(this)) revert InvalidNewController(newController);
 
         _release(member);
         emit SubdomainEvicted(member, msg.sender, subdomain);

--- a/src/framework/utils/ens/ENSDomain.sol
+++ b/src/framework/utils/ens/ENSDomain.sol
@@ -7,9 +7,16 @@ pragma solidity ^0.8.17;
 /// and splitting at the first dot. Single source of truth used by the contract,
 /// deploy scripts and tests.
 library ENSDomain {
+    /// @notice Thrown when `domain` is structurally malformed (empty label from a leading,
+    /// trailing, or consecutive dot). Silently hashing such inputs would produce a value
+    /// that diverges from EIP-137, so the library reverts instead.
+    error InvalidDomain(string domain);
+
     /// @notice Returns the namehash of `domain` (e.g., `"members.dao.eth"`).
-    /// @dev Returns `bytes32(0)` for an empty input. Does not validate label characters —
-    /// callers must enforce any character/length rules separately.
+    /// @dev Returns `bytes32(0)` for an empty input. Reverts with `InvalidDomain` on
+    /// structurally malformed inputs (leading, trailing, or consecutive dot — i.e. any
+    /// empty label). Does not validate label *characters* — callers must enforce any
+    /// character/length rules separately.
     function namehash(string memory domain) internal pure returns (bytes32 result) {
         bytes memory b = bytes(domain);
         if (b.length == 0) return bytes32(0);
@@ -17,10 +24,14 @@ library ENSDomain {
         uint256 end = b.length;
         for (uint256 i = b.length; i > 0; i--) {
             if (b[i - 1] == ".") {
+                // Trailing dot (first iter) or consecutive dot (subsequent iters): empty label.
+                if (i == end) revert InvalidDomain(domain);
                 result = keccak256(abi.encodePacked(result, _labelHash(b, i, end)));
                 end = i - 1;
             }
         }
+        // Leading dot: the first label is empty.
+        if (end == 0) revert InvalidDomain(domain);
         result = keccak256(abi.encodePacked(result, _labelHash(b, 0, end)));
     }
 

--- a/src/framework/utils/ens/ENSDomain.sol
+++ b/src/framework/utils/ens/ENSDomain.sol
@@ -7,16 +7,13 @@ pragma solidity ^0.8.17;
 /// and splitting at the first dot. Single source of truth used by the contract,
 /// deploy scripts and tests.
 library ENSDomain {
-    /// @notice Thrown when `domain` is structurally malformed (empty label from a leading,
-    /// trailing, or consecutive dot). Silently hashing such inputs would produce a value
-    /// that diverges from EIP-137, so the library reverts instead.
+    /// @notice Thrown when `domain` is structurally malformed
     error InvalidDomain(string domain);
 
     /// @notice Returns the namehash of `domain` (e.g., `"members.dao.eth"`).
     /// @dev Returns `bytes32(0)` for an empty input. Reverts with `InvalidDomain` on
-    /// structurally malformed inputs (leading, trailing, or consecutive dot — i.e. any
-    /// empty label). Does not validate label *characters* — callers must enforce any
-    /// character/length rules separately.
+    /// structurally malformed inputs. Does not validate label characters:
+    /// callers must enforce any extra rules separately.
     function namehash(string memory domain) internal pure returns (bytes32 result) {
         bytes memory b = bytes(domain);
         if (b.length == 0) return bytes32(0);

--- a/test/framework/member/MemberRegistry.t.sol
+++ b/test/framework/member/MemberRegistry.t.sol
@@ -713,6 +713,28 @@ contract MemberRegistryTest is Test {
         );
     }
 
+    function test_initialize_revertsIfZeroResolver() public {
+        // Guards against address(0) succeeding silently
+        MemberRegistry impl = new MemberRegistry();
+
+        vm.expectRevert(abi.encodeWithSelector(IMemberRegistry.InvalidResolver.selector, address(0)));
+        new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(MemberRegistry.initialize, (IDAO(address(dao)), ENS(address(ens)), DOMAIN, address(0)))
+        );
+    }
+
+    function test_initialize_revertsIfEOAResolver() public {
+        // Same root cause as the zero-address case: an EOA has no code
+        MemberRegistry impl = new MemberRegistry();
+
+        vm.expectRevert(abi.encodeWithSelector(IMemberRegistry.InvalidResolver.selector, bob));
+        new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(MemberRegistry.initialize, (IDAO(address(dao)), ENS(address(ens)), DOMAIN, bob))
+        );
+    }
+
     function test_initialize_revertsIfDoubleInit() public {
         vm.expectRevert("Initializable: contract is already initialized");
         registry.initialize(IDAO(address(dao)), ENS(address(ens)), DOMAIN, address(resolver));

--- a/test/framework/member/MemberRegistry.t.sol
+++ b/test/framework/member/MemberRegistry.t.sol
@@ -377,6 +377,24 @@ contract MemberRegistryTest is Test {
         registry.evict("alice", alice);
     }
 
+    function test_evict_transferRevertsIfNewControllerIsRegistry() public {
+        // Guards against HAL-02: assigning the registry itself as a member would lock the
+        // subdomain (release() keys on msg.sender; the contract never self-calls).
+        vm.prank(alice);
+        registry.register("alice");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IMemberRegistry.InvalidNewController.selector, address(registry))
+        );
+        vm.prank(evictor);
+        registry.evict("alice", address(registry));
+
+        // alice is untouched (revert happens before _release).
+        assertTrue(registry.isRegistered(alice));
+        assertEq(registry.labelOwner(keccak256("alice")), alice);
+        assertEq(ens.owner(_subnode("alice")), address(registry));
+    }
+
     function test_evict_transferRevertsIfNewControllerAlreadyRegistered() public {
         vm.prank(alice);
         registry.register("alice");

--- a/test/framework/utils/ens/ENSDomain.t.sol
+++ b/test/framework/utils/ens/ENSDomain.t.sol
@@ -86,15 +86,6 @@ contract ENSDomainTest is Test {
         assertTrue(a != b);
     }
 
-    // -------------------------------------------------------------------------
-    // namehash — malformed input rejection (HAL-03)
-    //
-    // Empty labels (leading, trailing, or consecutive dots) would produce a hash that
-    // diverges from EIP-137. The library must revert rather than silently return a
-    // wrong value, since the wrong value would propagate to `parentNode` and every
-    // subnode computation downstream.
-    // -------------------------------------------------------------------------
-
     /// @dev External wrapper so `vm.expectRevert` sees a real call boundary
     /// (the library function is `internal` and would otherwise be inlined).
     function callNamehash(string calldata domain) external pure returns (bytes32) {

--- a/test/framework/utils/ens/ENSDomain.t.sol
+++ b/test/framework/utils/ens/ENSDomain.t.sol
@@ -87,6 +87,51 @@ contract ENSDomainTest is Test {
     }
 
     // -------------------------------------------------------------------------
+    // namehash — malformed input rejection (HAL-03)
+    //
+    // Empty labels (leading, trailing, or consecutive dots) would produce a hash that
+    // diverges from EIP-137. The library must revert rather than silently return a
+    // wrong value, since the wrong value would propagate to `parentNode` and every
+    // subnode computation downstream.
+    // -------------------------------------------------------------------------
+
+    /// @dev External wrapper so `vm.expectRevert` sees a real call boundary
+    /// (the library function is `internal` and would otherwise be inlined).
+    function callNamehash(string calldata domain) external pure returns (bytes32) {
+        return ENSDomain.namehash(domain);
+    }
+
+    function test_namehash_revertsOnTrailingDot() public {
+        vm.expectRevert(abi.encodeWithSelector(ENSDomain.InvalidDomain.selector, "eth."));
+        this.callNamehash("eth.");
+
+        vm.expectRevert(abi.encodeWithSelector(ENSDomain.InvalidDomain.selector, "members.dao.eth."));
+        this.callNamehash("members.dao.eth.");
+    }
+
+    function test_namehash_revertsOnLeadingDot() public {
+        vm.expectRevert(abi.encodeWithSelector(ENSDomain.InvalidDomain.selector, ".eth"));
+        this.callNamehash(".eth");
+
+        vm.expectRevert(abi.encodeWithSelector(ENSDomain.InvalidDomain.selector, ".members.dao.eth"));
+        this.callNamehash(".members.dao.eth");
+    }
+
+    function test_namehash_revertsOnConsecutiveDots() public {
+        vm.expectRevert(abi.encodeWithSelector(ENSDomain.InvalidDomain.selector, "a..b"));
+        this.callNamehash("a..b");
+
+        vm.expectRevert(abi.encodeWithSelector(ENSDomain.InvalidDomain.selector, "members..dao.eth"));
+        this.callNamehash("members..dao.eth");
+    }
+
+    function test_namehash_revertsOnDotOnly() public {
+        // A single dot is simultaneously a leading and trailing dot.
+        vm.expectRevert(abi.encodeWithSelector(ENSDomain.InvalidDomain.selector, "."));
+        this.callNamehash(".");
+    }
+
+    // -------------------------------------------------------------------------
     // splitDomain
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
Addressing the feedback from Halborn's audit, including:
- MemberRegistry.sol
- ENSDomain.sol