### PR TITLE
Updating osx-commons import paths

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -2,4 +2,3 @@
 @openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 @ensdomains/ens-contracts/=lib/ens-contracts/
 forge-std/=lib/forge-std/src/
-@aragon/osx-commons-contracts/=src/common/

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,4 +2,4 @@
 @openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 @ensdomains/ens-contracts/=lib/ens-contracts/
 forge-std/=lib/forge-std/src/
-@aragon/osx-commons-contracts/src/=src/common/
+@aragon/osx-commons-contracts/=src/common/

--- a/scripts/DeployMemberRegistry.s.sol
+++ b/scripts/DeployMemberRegistry.s.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.17;
 import {Script, console} from "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {IDAO} from "../src/common/dao/IDAO.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {MemberRegistry} from "../src/framework/member/MemberRegistry.sol";

--- a/scripts/DeployMemberRegistry.s.sol
+++ b/scripts/DeployMemberRegistry.s.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.17;
 import {Script, console} from "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {MemberRegistry} from "../src/framework/member/MemberRegistry.sol";

--- a/src/core/dao/DAO.sol
+++ b/src/core/dao/DAO.sol
@@ -13,13 +13,13 @@ import {IERC1155ReceiverUpgradeable} from "@openzeppelin/contracts-upgradeable/t
 import {AddressUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
-import {IProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/IProtocolVersion.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
-import {VersionComparisonLib} from "@aragon/osx-commons-contracts/utils/versioning/VersionComparisonLib.sol";
-import {hasBit, flipBit} from "@aragon/osx-commons-contracts/utils/math/BitMap.sol";
-import {Action} from "@aragon/osx-commons-contracts/executors/Executor.sol";
-import {IExecutor} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {IProtocolVersion} from "../../common/utils/versioning/IProtocolVersion.sol";
+import {ProtocolVersion} from "../../common/utils/versioning/ProtocolVersion.sol";
+import {VersionComparisonLib} from "../../common/utils/versioning/VersionComparisonLib.sol";
+import {hasBit, flipBit} from "../../common/utils/math/BitMap.sol";
+import {Action} from "../../common/executors/Executor.sol";
+import {IExecutor} from "../../common/executors/IExecutor.sol";
+import {IDAO} from "../../common/dao/IDAO.sol";
 
 import {PermissionManager} from "../permission/PermissionManager.sol";
 import {CallbackHandler} from "../utils/CallbackHandler.sol";

--- a/src/core/dao/DAO.sol
+++ b/src/core/dao/DAO.sol
@@ -13,13 +13,13 @@ import {IERC1155ReceiverUpgradeable} from "@openzeppelin/contracts-upgradeable/t
 import {AddressUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
-import {IProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/IProtocolVersion.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
-import {VersionComparisonLib} from "@aragon/osx-commons-contracts/src/utils/versioning/VersionComparisonLib.sol";
-import {hasBit, flipBit} from "@aragon/osx-commons-contracts/src/utils/math/BitMap.sol";
-import {Action} from "@aragon/osx-commons-contracts/src/executors/Executor.sol";
-import {IExecutor} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {IProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/IProtocolVersion.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {VersionComparisonLib} from "@aragon/osx-commons-contracts/utils/versioning/VersionComparisonLib.sol";
+import {hasBit, flipBit} from "@aragon/osx-commons-contracts/utils/math/BitMap.sol";
+import {Action} from "@aragon/osx-commons-contracts/executors/Executor.sol";
+import {IExecutor} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 import {PermissionManager} from "../permission/PermissionManager.sol";
 import {CallbackHandler} from "../utils/CallbackHandler.sol";

--- a/src/core/permission/PermissionManager.sol
+++ b/src/core/permission/PermissionManager.sol
@@ -5,9 +5,9 @@ pragma solidity ^0.8.8;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 
-import {IPermissionCondition} from "@aragon/osx-commons-contracts/src/permission/condition/IPermissionCondition.sol";
-import {PermissionCondition} from "@aragon/osx-commons-contracts/src/permission/condition/PermissionCondition.sol";
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
+import {IPermissionCondition} from "@aragon/osx-commons-contracts/permission/condition/IPermissionCondition.sol";
+import {PermissionCondition} from "@aragon/osx-commons-contracts/permission/condition/PermissionCondition.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
 
 /// @title PermissionManager
 /// @author Aragon X - 2021-2023

--- a/src/core/permission/PermissionManager.sol
+++ b/src/core/permission/PermissionManager.sol
@@ -5,9 +5,9 @@ pragma solidity ^0.8.8;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 
-import {IPermissionCondition} from "@aragon/osx-commons-contracts/permission/condition/IPermissionCondition.sol";
-import {PermissionCondition} from "@aragon/osx-commons-contracts/permission/condition/PermissionCondition.sol";
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {IPermissionCondition} from "../../common/permission/condition/IPermissionCondition.sol";
+import {PermissionCondition} from "../../common/permission/condition/PermissionCondition.sol";
+import {PermissionLib} from "../../common/permission/PermissionLib.sol";
 
 /// @title PermissionManager
 /// @author Aragon X - 2021-2023

--- a/src/framework/dao/DAOFactory.sol
+++ b/src/framework/dao/DAOFactory.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.8;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {IProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/IProtocolVersion.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {IProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/IProtocolVersion.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
 
 import {DAO} from "../../core/dao/DAO.sol";
 import {PluginRepo} from "../plugin/repo/PluginRepo.sol";

--- a/src/framework/dao/DAOFactory.sol
+++ b/src/framework/dao/DAOFactory.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.8;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
-import {IProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/IProtocolVersion.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
+import {IDAO} from "../../common/dao/IDAO.sol";
+import {IProtocolVersion} from "../../common/utils/versioning/IProtocolVersion.sol";
+import {ProtocolVersion} from "../../common/utils/versioning/ProtocolVersion.sol";
+import {IPluginSetup} from "../../common/plugin/setup/IPluginSetup.sol";
+import {PermissionLib} from "../../common/permission/PermissionLib.sol";
+import {ProxyLib} from "../../common/utils/deployment/ProxyLib.sol";
 
 import {DAO} from "../../core/dao/DAO.sol";
 import {PluginRepo} from "../plugin/repo/PluginRepo.sol";

--- a/src/framework/dao/DAORegistry.sol
+++ b/src/framework/dao/DAORegistry.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 import {ENSSubdomainRegistrar} from "../utils/ens/ENSSubdomainRegistrar.sol";
 import {InterfaceBasedRegistry} from "../utils/InterfaceBasedRegistry.sol";

--- a/src/framework/dao/DAORegistry.sol
+++ b/src/framework/dao/DAORegistry.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {ProtocolVersion} from "../../common/utils/versioning/ProtocolVersion.sol";
+import {IDAO} from "../../common/dao/IDAO.sol";
 
 import {ENSSubdomainRegistrar} from "../utils/ens/ENSSubdomainRegistrar.sol";
 import {InterfaceBasedRegistry} from "../utils/InterfaceBasedRegistry.sol";

--- a/src/framework/member/MemberRegistry.sol
+++ b/src/framework/member/MemberRegistry.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.17;
 
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
 import {
     DaoAuthorizableUpgradeable
-} from "@aragon/osx-commons-contracts/src/permission/auth/DaoAuthorizableUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 import {isSubdomainValid} from "../utils/RegistryUtils.sol";
 
 import {IMemberRegistry} from "./IMemberRegistry.sol";

--- a/src/framework/member/MemberRegistry.sol
+++ b/src/framework/member/MemberRegistry.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.17;
 
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {ProtocolVersion} from "../../common/utils/versioning/ProtocolVersion.sol";
 import {
     DaoAuthorizableUpgradeable
-} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+} from "../../common/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {IDAO} from "../../common/dao/IDAO.sol";
 import {isSubdomainValid} from "../utils/RegistryUtils.sol";
 
 import {IMemberRegistry} from "./IMemberRegistry.sol";

--- a/src/framework/plugin/repo/PluginRepo.sol
+++ b/src/framework/plugin/repo/PluginRepo.sol
@@ -8,10 +8,10 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 import {AddressUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 import {ERC165CheckerUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165CheckerUpgradeable.sol";
 
-import {IProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/IProtocolVersion.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginSetup.sol";
+import {IProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/IProtocolVersion.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
 
 import {PermissionManager} from "../../../core/permission/PermissionManager.sol";
 import {IPluginRepo} from "./IPluginRepo.sol";

--- a/src/framework/plugin/repo/PluginRepo.sol
+++ b/src/framework/plugin/repo/PluginRepo.sol
@@ -8,10 +8,10 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 import {AddressUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 import {ERC165CheckerUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165CheckerUpgradeable.sol";
 
-import {IProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/IProtocolVersion.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
+import {IProtocolVersion} from "../../../common/utils/versioning/IProtocolVersion.sol";
+import {ProtocolVersion} from "../../../common/utils/versioning/ProtocolVersion.sol";
+import {IPluginSetup} from "../../../common/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "../../../common/plugin/setup/PluginSetup.sol";
 
 import {PermissionManager} from "../../../core/permission/PermissionManager.sol";
 import {IPluginRepo} from "./IPluginRepo.sol";

--- a/src/framework/plugin/repo/PluginRepoFactory.sol
+++ b/src/framework/plugin/repo/PluginRepoFactory.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.8;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {IProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/IProtocolVersion.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
+import {PermissionLib} from "../../../common/permission/PermissionLib.sol";
+import {IProtocolVersion} from "../../../common/utils/versioning/IProtocolVersion.sol";
+import {ProtocolVersion} from "../../../common/utils/versioning/ProtocolVersion.sol";
+import {ProxyLib} from "../../../common/utils/deployment/ProxyLib.sol";
 import {PluginRepoRegistry} from "./PluginRepoRegistry.sol";
 import {PluginRepo} from "./PluginRepo.sol";
 

--- a/src/framework/plugin/repo/PluginRepoFactory.sol
+++ b/src/framework/plugin/repo/PluginRepoFactory.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.8;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {IProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/IProtocolVersion.sol";
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {IProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/IProtocolVersion.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
 import {PluginRepoRegistry} from "./PluginRepoRegistry.sol";
 import {PluginRepo} from "./PluginRepo.sol";
 

--- a/src/framework/plugin/repo/PluginRepoRegistry.sol
+++ b/src/framework/plugin/repo/PluginRepoRegistry.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {ProtocolVersion} from "../../../common/utils/versioning/ProtocolVersion.sol";
+import {IDAO} from "../../../common/dao/IDAO.sol";
 import {ENSSubdomainRegistrar} from "../../utils/ens/ENSSubdomainRegistrar.sol";
 import {InterfaceBasedRegistry} from "../../utils/InterfaceBasedRegistry.sol";
 import {isSubdomainValid} from "../../utils/RegistryUtils.sol";

--- a/src/framework/plugin/repo/PluginRepoRegistry.sol
+++ b/src/framework/plugin/repo/PluginRepoRegistry.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 import {ENSSubdomainRegistrar} from "../../utils/ens/ENSSubdomainRegistrar.sol";
 import {InterfaceBasedRegistry} from "../../utils/InterfaceBasedRegistry.sol";
 import {isSubdomainValid} from "../../utils/RegistryUtils.sol";

--- a/src/framework/plugin/repo/placeholder/PlaceholderSetup.sol
+++ b/src/framework/plugin/repo/placeholder/PlaceholderSetup.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
 
 /// @title PlaceholderSetup
 /// @author Aragon X - 2023

--- a/src/framework/plugin/repo/placeholder/PlaceholderSetup.sol
+++ b/src/framework/plugin/repo/placeholder/PlaceholderSetup.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "../../../../common/permission/PermissionLib.sol";
+import {IPluginSetup} from "../../../../common/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "../../../../common/plugin/setup/PluginSetup.sol";
 
 /// @title PlaceholderSetup
 /// @author Aragon X - 2023

--- a/src/framework/plugin/setup/PluginSetupProcessor.sol
+++ b/src/framework/plugin/setup/PluginSetupProcessor.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.8;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginSetup.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
 import {DAO} from "../../../core/dao/DAO.sol";
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
-import {IPlugin} from "@aragon/osx-commons-contracts/src/plugin/IPlugin.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/plugin/PluginUUPSUpgradeable.sol";
+import {IPlugin} from "@aragon/osx-commons-contracts/plugin/IPlugin.sol";
 
 import {PluginRepoRegistry} from "../repo/PluginRepoRegistry.sol";
 import {PluginRepo} from "../repo/PluginRepo.sol";

--- a/src/framework/plugin/setup/PluginSetupProcessor.sol
+++ b/src/framework/plugin/setup/PluginSetupProcessor.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.8;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
+import {ProtocolVersion} from "../../../common/utils/versioning/ProtocolVersion.sol";
+import {IPluginSetup} from "../../../common/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "../../../common/plugin/setup/PluginSetup.sol";
 import {DAO} from "../../../core/dao/DAO.sol";
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/plugin/PluginUUPSUpgradeable.sol";
-import {IPlugin} from "@aragon/osx-commons-contracts/plugin/IPlugin.sol";
+import {PermissionLib} from "../../../common/permission/PermissionLib.sol";
+import {PluginUUPSUpgradeable} from "../../../common/plugin/PluginUUPSUpgradeable.sol";
+import {IPlugin} from "../../../common/plugin/IPlugin.sol";
 
 import {PluginRepoRegistry} from "../repo/PluginRepoRegistry.sol";
 import {PluginRepo} from "../repo/PluginRepo.sol";

--- a/src/framework/plugin/setup/PluginSetupProcessorHelpers.sol
+++ b/src/framework/plugin/setup/PluginSetupProcessorHelpers.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "../../../common/permission/PermissionLib.sol";
+import {PluginSetup} from "../../../common/plugin/setup/PluginSetup.sol";
 import {PluginRepo} from "../repo/PluginRepo.sol";
 
 /// @notice The struct containing a reference to a plugin setup by specifying the containing plugin repository and the associated version tag.

--- a/src/framework/plugin/setup/PluginSetupProcessorHelpers.sol
+++ b/src/framework/plugin/setup/PluginSetupProcessorHelpers.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
 import {PluginRepo} from "../repo/PluginRepo.sol";
 
 /// @notice The struct containing a reference to a plugin setup by specifying the containing plugin repository and the associated version tag.

--- a/src/framework/utils/InterfaceBasedRegistry.sol
+++ b/src/framework/utils/InterfaceBasedRegistry.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.8;
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC165CheckerUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165CheckerUpgradeable.sol";
 
-import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/src/permission/auth/DaoAuthorizableUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 /// @title InterfaceBasedRegistry
 /// @author Aragon X - 2022-2023

--- a/src/framework/utils/InterfaceBasedRegistry.sol
+++ b/src/framework/utils/InterfaceBasedRegistry.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.8;
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC165CheckerUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165CheckerUpgradeable.sol";
 
-import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {DaoAuthorizableUpgradeable} from "../../common/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {IDAO} from "../../common/dao/IDAO.sol";
 
 /// @title InterfaceBasedRegistry
 /// @author Aragon X - 2022-2023

--- a/src/framework/utils/ens/ENSSubdomainRegistrar.sol
+++ b/src/framework/utils/ens/ENSSubdomainRegistrar.sol
@@ -7,9 +7,9 @@ import "@ensdomains/ens-contracts/contracts/resolvers/Resolver.sol";
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
-import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {ProtocolVersion} from "../../../common/utils/versioning/ProtocolVersion.sol";
+import {DaoAuthorizableUpgradeable} from "../../../common/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {IDAO} from "../../../common/dao/IDAO.sol";
 
 /// @title ENSSubdomainRegistrar
 /// @author Aragon X - 2022-2023

--- a/src/framework/utils/ens/ENSSubdomainRegistrar.sol
+++ b/src/framework/utils/ens/ENSSubdomainRegistrar.sol
@@ -7,9 +7,9 @@ import "@ensdomains/ens-contracts/contracts/resolvers/Resolver.sol";
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
-import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/src/permission/auth/DaoAuthorizableUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 /// @title ENSSubdomainRegistrar
 /// @author Aragon X - 2022-2023

--- a/test/framework/member/MemberRegistry.t.sol
+++ b/test/framework/member/MemberRegistry.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {DaoUnauthorized} from "@aragon/osx-commons-contracts/src/permission/auth/auth.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {DaoUnauthorized} from "@aragon/osx-commons-contracts/permission/auth/auth.sol";
 import {DAOMock} from "../../mocks/commons/dao/DAOMock.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/test/framework/member/MemberRegistry.t.sol
+++ b/test/framework/member/MemberRegistry.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
-import {DaoUnauthorized} from "@aragon/osx-commons-contracts/permission/auth/auth.sol";
+import {IDAO} from "../../../src/common/dao/IDAO.sol";
+import {DaoUnauthorized} from "../../../src/common/permission/auth/auth.sol";
 import {DAOMock} from "../../mocks/commons/dao/DAOMock.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/test/framework/member/fork/MemberRegistryFork.t.sol
+++ b/test/framework/member/fork/MemberRegistryFork.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 import {DAOMock} from "../../../mocks/commons/dao/DAOMock.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/test/framework/member/fork/MemberRegistryFork.t.sol
+++ b/test/framework/member/fork/MemberRegistryFork.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
 import {DAOMock} from "../../../mocks/commons/dao/DAOMock.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/test/framework/member/fork/RegisterSimulation.t.sol
+++ b/test/framework/member/fork/RegisterSimulation.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 
 import {Test, console} from "forge-std/Test.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {MemberRegistry} from "../../../../src/framework/member/MemberRegistry.sol";

--- a/test/framework/member/fork/RegisterSimulation.t.sol
+++ b/test/framework/member/fork/RegisterSimulation.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 
 import {Test, console} from "forge-std/Test.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {MemberRegistry} from "../../../../src/framework/member/MemberRegistry.sol";

--- a/test/framework/member/fork/SetupSimulation.t.sol
+++ b/test/framework/member/fork/SetupSimulation.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 
 import {Test, console} from "forge-std/Test.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {MemberRegistry} from "../../../../src/framework/member/MemberRegistry.sol";

--- a/test/framework/member/fork/SetupSimulation.t.sol
+++ b/test/framework/member/fork/SetupSimulation.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 
 import {Test, console} from "forge-std/Test.sol";
 import {ENS} from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {MemberRegistry} from "../../../../src/framework/member/MemberRegistry.sol";

--- a/test/mocks/ProtocolVersionMock.sol
+++ b/test/mocks/ProtocolVersionMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
 
 /// @title ProtocolVersionMock
 // solhint-disable-next-line no-empty-blocks

--- a/test/mocks/ProtocolVersionMock.sol
+++ b/test/mocks/ProtocolVersionMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {ProtocolVersion} from "../../src/common/utils/versioning/ProtocolVersion.sol";
 
 /// @title ProtocolVersionMock
 // solhint-disable-next-line no-empty-blocks

--- a/test/mocks/commons/dao/DAOMock.sol
+++ b/test/mocks/commons/dao/DAOMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
-import {IExecutor, Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
+import {IExecutor, Action} from "../../../../src/common/executors/IExecutor.sol";
 
 /// @notice A mock DAO that anyone can set permissions in.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/dao/DAOMock.sol
+++ b/test/mocks/commons/dao/DAOMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {IExecutor, Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {IExecutor, Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
 
 /// @notice A mock DAO that anyone can set permissions in.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/executors/ActionExecute.sol
+++ b/test/mocks/commons/executors/ActionExecute.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {IExecutor, Action} from "@aragon/osx-commons-contracts/executors/Executor.sol";
+import {IExecutor, Action} from "../../../../src/common/executors/Executor.sol";
 
 /// @notice A dummy contract to test if Executor can successfully execute an action.
 contract ActionExecute {

--- a/test/mocks/commons/executors/ActionExecute.sol
+++ b/test/mocks/commons/executors/ActionExecute.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {IExecutor, Action} from "@aragon/osx-commons-contracts/src/executors/Executor.sol";
+import {IExecutor, Action} from "@aragon/osx-commons-contracts/executors/Executor.sol";
 
 /// @notice A dummy contract to test if Executor can successfully execute an action.
 contract ActionExecute {

--- a/test/mocks/commons/permission/auth/DaoAuthorizableMock.sol
+++ b/test/mocks/commons/permission/auth/DaoAuthorizableMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {DaoAuthorizable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {DaoAuthorizable} from "../../../../../src/common/permission/auth/DaoAuthorizable.sol";
+import {IDAO} from "../../../../../src/common/dao/IDAO.sol";
 
 /// @notice A mock contract containing a function protected by the `auth` modifier.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/permission/auth/DaoAuthorizableMock.sol
+++ b/test/mocks/commons/permission/auth/DaoAuthorizableMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {DaoAuthorizable} from "@aragon/osx-commons-contracts/src/permission/auth/DaoAuthorizable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {DaoAuthorizable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizable.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 /// @notice A mock contract containing a function protected by the `auth` modifier.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/permission/auth/DaoAuthorizableUpgradeableMock.sol
+++ b/test/mocks/commons/permission/auth/DaoAuthorizableUpgradeableMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {DaoAuthorizableUpgradeable} from "../../../../../src/common/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {IDAO} from "../../../../../src/common/dao/IDAO.sol";
 
 /// @notice A mock contract containing a function protected by the `auth` modifier.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/permission/auth/DaoAuthorizableUpgradeableMock.sol
+++ b/test/mocks/commons/permission/auth/DaoAuthorizableUpgradeableMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/src/permission/auth/DaoAuthorizableUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 /// @notice A mock contract containing a function protected by the `auth` modifier.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/permission/condition/PermissionConditionMock.sol
+++ b/test/mocks/commons/permission/condition/PermissionConditionMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionCondition} from "@aragon/osx-commons-contracts/permission/condition/PermissionCondition.sol";
+import {PermissionCondition} from "../../../../../src/common/permission/condition/PermissionCondition.sol";
 
 /// @notice A mock permission condition that can be set to permit or deny every call.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/permission/condition/PermissionConditionMock.sol
+++ b/test/mocks/commons/permission/condition/PermissionConditionMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionCondition} from "@aragon/osx-commons-contracts/src/permission/condition/PermissionCondition.sol";
+import {PermissionCondition} from "@aragon/osx-commons-contracts/permission/condition/PermissionCondition.sol";
 
 /// @notice A mock permission condition that can be set to permit or deny every call.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/permission/condition/PermissionConditionUpgradeableMock.sol
+++ b/test/mocks/commons/permission/condition/PermissionConditionUpgradeableMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionConditionUpgradeable} from "@aragon/osx-commons-contracts/src/permission/condition/PermissionConditionUpgradeable.sol";
+import {PermissionConditionUpgradeable} from "@aragon/osx-commons-contracts/permission/condition/PermissionConditionUpgradeable.sol";
 
 /// @notice A mock permission condition that can be set to permit or deny every call and be upgraded by everyone.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/permission/condition/PermissionConditionUpgradeableMock.sol
+++ b/test/mocks/commons/permission/condition/PermissionConditionUpgradeableMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionConditionUpgradeable} from "@aragon/osx-commons-contracts/permission/condition/PermissionConditionUpgradeable.sol";
+import {PermissionConditionUpgradeable} from "../../../../../src/common/permission/condition/PermissionConditionUpgradeable.sol";
 
 /// @notice A mock permission condition that can be set to permit or deny every call and be upgraded by everyone.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/permission/condition/extensions/RuledConditionMock.sol
+++ b/test/mocks/commons/permission/condition/extensions/RuledConditionMock.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.8;
-import {RuledCondition} from "@aragon/osx-commons-contracts/src/permission/condition/extensions/RuledCondition.sol";
-import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/src/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {RuledCondition} from "@aragon/osx-commons-contracts/permission/condition/extensions/RuledCondition.sol";
+import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
 
 /// @notice A mock powerful condition to expose internal functions
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/permission/condition/extensions/RuledConditionMock.sol
+++ b/test/mocks/commons/permission/condition/extensions/RuledConditionMock.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.8;
-import {RuledCondition} from "@aragon/osx-commons-contracts/permission/condition/extensions/RuledCondition.sol";
-import {DaoAuthorizableUpgradeable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizableUpgradeable.sol";
+import {RuledCondition} from "../../../../../../src/common/permission/condition/extensions/RuledCondition.sol";
+import {DaoAuthorizableUpgradeable} from "../../../../../../src/common/permission/auth/DaoAuthorizableUpgradeable.sol";
 
 /// @notice A mock powerful condition to expose internal functions
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/plugin/CustomExecutorMock.sol
+++ b/test/mocks/commons/plugin/CustomExecutorMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {IExecutor, Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
+import {IExecutor, Action} from "../../../../src/common/executors/IExecutor.sol";
 
 /// @notice A mock DAO that anyone can set permissions in.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/plugin/CustomExecutorMock.sol
+++ b/test/mocks/commons/plugin/CustomExecutorMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {IExecutor, Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {IExecutor, Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
 
 /// @notice A mock DAO that anyone can set permissions in.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/plugin/PluginCloneableMock.sol
+++ b/test/mocks/commons/plugin/PluginCloneableMock.sol
@@ -3,9 +3,9 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PluginCloneable} from "@aragon/osx-commons-contracts/plugin/PluginCloneable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
-import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
+import {PluginCloneable} from "../../../../src/common/plugin/PluginCloneable.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
+import {Action} from "../../../../src/common/executors/IExecutor.sol";
 
 /// @notice A mock cloneable plugin to be deployed via the minimal proxy pattern.
 /// v1.1 (Release 1, Build 1)

--- a/test/mocks/commons/plugin/PluginCloneableMock.sol
+++ b/test/mocks/commons/plugin/PluginCloneableMock.sol
@@ -3,9 +3,9 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PluginCloneable} from "@aragon/osx-commons-contracts/src/plugin/PluginCloneable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {PluginCloneable} from "@aragon/osx-commons-contracts/plugin/PluginCloneable.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
 
 /// @notice A mock cloneable plugin to be deployed via the minimal proxy pattern.
 /// v1.1 (Release 1, Build 1)

--- a/test/mocks/commons/plugin/PluginCloneableSetupMock.sol
+++ b/test/mocks/commons/plugin/PluginCloneableSetupMock.sol
@@ -3,11 +3,11 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {PermissionLib} from "../../../../src/common/permission/PermissionLib.sol";
+import {IPluginSetup} from "../../../../src/common/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "../../../../src/common/plugin/setup/PluginSetup.sol";
+import {ProxyLib} from "../../../../src/common/utils/deployment/ProxyLib.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
 import {mockPermissions, mockHelpers} from "./PluginSetupMockData.sol";
 import {PluginCloneableMockBuild1, PluginCloneableMockBuild2} from "./PluginCloneableMock.sol";
 

--- a/test/mocks/commons/plugin/PluginCloneableSetupMock.sol
+++ b/test/mocks/commons/plugin/PluginCloneableSetupMock.sol
@@ -3,11 +3,11 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginSetup.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
+import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 import {mockPermissions, mockHelpers} from "./PluginSetupMockData.sol";
 import {PluginCloneableMockBuild1, PluginCloneableMockBuild2} from "./PluginCloneableMock.sol";
 

--- a/test/mocks/commons/plugin/PluginMock.sol
+++ b/test/mocks/commons/plugin/PluginMock.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.8;
 
-import {Plugin} from "@aragon/osx-commons-contracts/plugin/Plugin.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
-import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
+import {Plugin} from "../../../../src/common/plugin/Plugin.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
+import {Action} from "../../../../src/common/executors/IExecutor.sol";
 
 /// @notice A mock plugin to be deployed via the `new` keyword.
 /// v1.1 (Release 1, Build 1)

--- a/test/mocks/commons/plugin/PluginMock.sol
+++ b/test/mocks/commons/plugin/PluginMock.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.8;
 
-import {Plugin} from "@aragon/osx-commons-contracts/src/plugin/Plugin.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {Plugin} from "@aragon/osx-commons-contracts/plugin/Plugin.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
 
 /// @notice A mock plugin to be deployed via the `new` keyword.
 /// v1.1 (Release 1, Build 1)

--- a/test/mocks/commons/plugin/PluginSetupMock.sol
+++ b/test/mocks/commons/plugin/PluginSetupMock.sol
@@ -3,10 +3,10 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {PermissionLib} from "../../../../src/common/permission/PermissionLib.sol";
+import {IPluginSetup} from "../../../../src/common/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "../../../../src/common/plugin/setup/PluginSetup.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
 import {mockPermissions, mockHelpers} from "./PluginSetupMockData.sol";
 import {PluginMockBuild1} from "./PluginMock.sol";
 

--- a/test/mocks/commons/plugin/PluginSetupMock.sol
+++ b/test/mocks/commons/plugin/PluginSetupMock.sol
@@ -3,10 +3,10 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginSetup.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 import {mockPermissions, mockHelpers} from "./PluginSetupMockData.sol";
 import {PluginMockBuild1} from "./PluginMock.sol";
 

--- a/test/mocks/commons/plugin/PluginSetupMockData.sol
+++ b/test/mocks/commons/plugin/PluginSetupMockData.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
 
 address constant NO_CONDITION = address(0);
 

--- a/test/mocks/commons/plugin/PluginSetupMockData.sol
+++ b/test/mocks/commons/plugin/PluginSetupMockData.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {PermissionLib} from "../../../../src/common/permission/PermissionLib.sol";
 
 address constant NO_CONDITION = address(0);
 

--- a/test/mocks/commons/plugin/PluginUUPSUpgradeableMock.sol
+++ b/test/mocks/commons/plugin/PluginUUPSUpgradeableMock.sol
@@ -3,9 +3,9 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/plugin/PluginUUPSUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
-import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
+import {PluginUUPSUpgradeable} from "../../../../src/common/plugin/PluginUUPSUpgradeable.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
+import {Action} from "../../../../src/common/executors/IExecutor.sol";
 
 /// @notice A mock upgradeable plugin to be deployed via the UUPS proxy pattern.
 /// v1.1 (Release 1, Build 1)

--- a/test/mocks/commons/plugin/PluginUUPSUpgradeableMock.sol
+++ b/test/mocks/commons/plugin/PluginUUPSUpgradeableMock.sol
@@ -3,9 +3,9 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/plugin/PluginUUPSUpgradeable.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
 
 /// @notice A mock upgradeable plugin to be deployed via the UUPS proxy pattern.
 /// v1.1 (Release 1, Build 1)

--- a/test/mocks/commons/plugin/PluginUUPSUpgradeableSetupMock.sol
+++ b/test/mocks/commons/plugin/PluginUUPSUpgradeableSetupMock.sol
@@ -3,11 +3,11 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
-import {PluginUpgradeableSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginUpgradeableSetup.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
+import {PluginUpgradeableSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginUpgradeableSetup.sol";
+import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 import {mockPermissions, mockHelpers} from "./PluginSetupMockData.sol";
 import {PluginUUPSUpgradeableMockBuild1, PluginUUPSUpgradeableMockBuild2, PluginUUPSUpgradeableMockBuild3} from "./PluginUUPSUpgradeableMock.sol";
 

--- a/test/mocks/commons/plugin/PluginUUPSUpgradeableSetupMock.sol
+++ b/test/mocks/commons/plugin/PluginUUPSUpgradeableSetupMock.sol
@@ -3,11 +3,11 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
-import {PluginUpgradeableSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginUpgradeableSetup.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {PermissionLib} from "../../../../src/common/permission/PermissionLib.sol";
+import {IPluginSetup} from "../../../../src/common/plugin/setup/IPluginSetup.sol";
+import {PluginUpgradeableSetup} from "../../../../src/common/plugin/setup/PluginUpgradeableSetup.sol";
+import {ProxyLib} from "../../../../src/common/utils/deployment/ProxyLib.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
 import {mockPermissions, mockHelpers} from "./PluginSetupMockData.sol";
 import {PluginUUPSUpgradeableMockBuild1, PluginUUPSUpgradeableMockBuild2, PluginUUPSUpgradeableMockBuild3} from "./PluginUUPSUpgradeableMock.sol";
 

--- a/test/mocks/commons/plugin/extensions/governance/AddresslistMock.sol
+++ b/test/mocks/commons/plugin/extensions/governance/AddresslistMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {Addresslist} from "@aragon/osx-commons-contracts/plugin/extensions/governance/Addresslist.sol";
+import {Addresslist} from "../../../../../../src/common/plugin/extensions/governance/Addresslist.sol";
 
 /// @notice A mock addresslist that everyone can add and remove addresses to and from, respectively.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/plugin/extensions/governance/AddresslistMock.sol
+++ b/test/mocks/commons/plugin/extensions/governance/AddresslistMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {Addresslist} from "@aragon/osx-commons-contracts/src/plugin/extensions/governance/Addresslist.sol";
+import {Addresslist} from "@aragon/osx-commons-contracts/plugin/extensions/governance/Addresslist.sol";
 
 /// @notice A mock addresslist that everyone can add and remove addresses to and from, respectively.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/plugin/extensions/proposal/ProposalMock.sol
+++ b/test/mocks/commons/plugin/extensions/proposal/ProposalMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {Proposal} from "@aragon/osx-commons-contracts/plugin/extensions/proposal/Proposal.sol";
-import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
+import {Proposal} from "../../../../../../src/common/plugin/extensions/proposal/Proposal.sol";
+import {Action} from "../../../../../../src/common/executors/IExecutor.sol";
 
 /// @notice A mock contract.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/plugin/extensions/proposal/ProposalMock.sol
+++ b/test/mocks/commons/plugin/extensions/proposal/ProposalMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {Proposal} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/Proposal.sol";
-import {Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {Proposal} from "@aragon/osx-commons-contracts/plugin/extensions/proposal/Proposal.sol";
+import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
 
 /// @notice A mock contract.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/plugin/extensions/proposal/ProposalUpgradeableMock.sol
+++ b/test/mocks/commons/plugin/extensions/proposal/ProposalUpgradeableMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {ProposalUpgradeable} from "@aragon/osx-commons-contracts/plugin/extensions/proposal/ProposalUpgradeable.sol";
-import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
+import {ProposalUpgradeable} from "../../../../../../src/common/plugin/extensions/proposal/ProposalUpgradeable.sol";
+import {Action} from "../../../../../../src/common/executors/IExecutor.sol";
 
 /// @notice A mock contract.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/plugin/extensions/proposal/ProposalUpgradeableMock.sol
+++ b/test/mocks/commons/plugin/extensions/proposal/ProposalUpgradeableMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {ProposalUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/ProposalUpgradeable.sol";
-import {Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {ProposalUpgradeable} from "@aragon/osx-commons-contracts/plugin/extensions/proposal/ProposalUpgradeable.sol";
+import {Action} from "@aragon/osx-commons-contracts/executors/IExecutor.sol";
 
 /// @notice A mock contract.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/math/BitmapMock.sol
+++ b/test/mocks/commons/utils/math/BitmapMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {hasBit as _hasBit, flipBit as _flipBit} from "@aragon/osx-commons-contracts/src/utils/math/BitMap.sol";
+import {hasBit as _hasBit, flipBit as _flipBit} from "@aragon/osx-commons-contracts/utils/math/BitMap.sol";
 
 /// @notice A mock contract containing functions manipulating bitmaps.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/math/BitmapMock.sol
+++ b/test/mocks/commons/utils/math/BitmapMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {hasBit as _hasBit, flipBit as _flipBit} from "@aragon/osx-commons-contracts/utils/math/BitMap.sol";
+import {hasBit as _hasBit, flipBit as _flipBit} from "../../../../../src/common/utils/math/BitMap.sol";
 
 /// @notice A mock contract containing functions manipulating bitmaps.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/math/RatioMock.sol
+++ b/test/mocks/commons/utils/math/RatioMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {RATIO_BASE, _applyRatioCeiled} from "@aragon/osx-commons-contracts/utils/math/Ratio.sol";
+import {RATIO_BASE, _applyRatioCeiled} from "../../../../../src/common/utils/math/Ratio.sol";
 
 /// @notice A mock contract containing functions manipulating bitmaps.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/math/RatioMock.sol
+++ b/test/mocks/commons/utils/math/RatioMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {RATIO_BASE, _applyRatioCeiled} from "@aragon/osx-commons-contracts/src/utils/math/Ratio.sol";
+import {RATIO_BASE, _applyRatioCeiled} from "@aragon/osx-commons-contracts/utils/math/Ratio.sol";
 
 /// @notice A mock contract containing functions manipulating bitmaps.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/metadata/MetadataExtensionMock.sol
+++ b/test/mocks/commons/utils/metadata/MetadataExtensionMock.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.8;
 
-import {MetadataExtension} from "@aragon/osx-commons-contracts/utils/metadata/MetadataExtension.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
-import {DaoAuthorizable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizable.sol";
+import {MetadataExtension} from "../../../../../src/common/utils/metadata/MetadataExtension.sol";
+import {IDAO} from "../../../../../src/common/dao/IDAO.sol";
+import {DaoAuthorizable} from "../../../../../src/common/permission/auth/DaoAuthorizable.sol";
 
 /// @notice A mock contract.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/metadata/MetadataExtensionMock.sol
+++ b/test/mocks/commons/utils/metadata/MetadataExtensionMock.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.8;
 
-import {MetadataExtension} from "@aragon/osx-commons-contracts/src/utils/metadata/MetadataExtension.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {DaoAuthorizable} from "@aragon/osx-commons-contracts/src/permission/auth/DaoAuthorizable.sol";
+import {MetadataExtension} from "@aragon/osx-commons-contracts/utils/metadata/MetadataExtension.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {DaoAuthorizable} from "@aragon/osx-commons-contracts/permission/auth/DaoAuthorizable.sol";
 
 /// @notice A mock contract.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/metadata/MetadataExtensionUpgradeableMock.sol
+++ b/test/mocks/commons/utils/metadata/MetadataExtensionUpgradeableMock.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.8;
 
-import {MetadataExtensionUpgradeable} from "@aragon/osx-commons-contracts/src/utils/metadata/MetadataExtensionUpgradeable.sol";
+import {MetadataExtensionUpgradeable} from "@aragon/osx-commons-contracts/utils/metadata/MetadataExtensionUpgradeable.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 /// @notice A mock contract.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/metadata/MetadataExtensionUpgradeableMock.sol
+++ b/test/mocks/commons/utils/metadata/MetadataExtensionUpgradeableMock.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.8;
 
-import {MetadataExtensionUpgradeable} from "@aragon/osx-commons-contracts/utils/metadata/MetadataExtensionUpgradeable.sol";
+import {MetadataExtensionUpgradeable} from "../../../../../src/common/utils/metadata/MetadataExtensionUpgradeable.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {IDAO} from "../../../../../src/common/dao/IDAO.sol";
 
 /// @notice A mock contract.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/versioning/ProtocolVersionMock.sol
+++ b/test/mocks/commons/utils/versioning/ProtocolVersionMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/src/utils/versioning/ProtocolVersion.sol";
+import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
 
 /// @notice A mock contract returning the OSx protocol version number.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/versioning/ProtocolVersionMock.sol
+++ b/test/mocks/commons/utils/versioning/ProtocolVersionMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {ProtocolVersion} from "@aragon/osx-commons-contracts/utils/versioning/ProtocolVersion.sol";
+import {ProtocolVersion} from "../../../../../src/common/utils/versioning/ProtocolVersion.sol";
 
 /// @notice A mock contract returning the OSx protocol version number.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/versioning/VersionComparisonLibMock.sol
+++ b/test/mocks/commons/utils/versioning/VersionComparisonLibMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {VersionComparisonLib} from "@aragon/osx-commons-contracts/src/utils/versioning/VersionComparisonLib.sol";
+import {VersionComparisonLib} from "@aragon/osx-commons-contracts/utils/versioning/VersionComparisonLib.sol";
 
 /// @notice A mock contract containing functions to compare semantic version numbers.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/commons/utils/versioning/VersionComparisonLibMock.sol
+++ b/test/mocks/commons/utils/versioning/VersionComparisonLibMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {VersionComparisonLib} from "@aragon/osx-commons-contracts/utils/versioning/VersionComparisonLib.sol";
+import {VersionComparisonLib} from "../../../../../src/common/utils/versioning/VersionComparisonLib.sol";
 
 /// @notice A mock contract containing functions to compare semantic version numbers.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/permission/PermissionConditionMock.sol
+++ b/test/mocks/permission/PermissionConditionMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionCondition} from "@aragon/osx-commons-contracts/permission/condition/PermissionCondition.sol";
+import {PermissionCondition} from "../../../src/common/permission/condition/PermissionCondition.sol";
 
 /// @notice A mock permission condition that can be set to permit or deny every call.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/permission/PermissionConditionMock.sol
+++ b/test/mocks/permission/PermissionConditionMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionCondition} from "@aragon/osx-commons-contracts/src/permission/condition/PermissionCondition.sol";
+import {PermissionCondition} from "@aragon/osx-commons-contracts/permission/condition/PermissionCondition.sol";
 
 /// @notice A mock permission condition that can be set to permit or deny every call.
 /// @dev DO NOT USE IN PRODUCTION!

--- a/test/mocks/plugin/Cloneable/PluginCloneableMock.sol
+++ b/test/mocks/plugin/Cloneable/PluginCloneableMock.sol
@@ -3,8 +3,8 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PluginCloneable} from "@aragon/osx-commons-contracts/plugin/PluginCloneable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {PluginCloneable} from "../../../../src/common/plugin/PluginCloneable.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
 
 contract PluginCloneableV1Mock is PluginCloneable {
     uint256 public state1;

--- a/test/mocks/plugin/Cloneable/PluginCloneableMock.sol
+++ b/test/mocks/plugin/Cloneable/PluginCloneableMock.sol
@@ -3,8 +3,8 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PluginCloneable} from "@aragon/osx-commons-contracts/src/plugin/PluginCloneable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {PluginCloneable} from "@aragon/osx-commons-contracts/plugin/PluginCloneable.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 contract PluginCloneableV1Mock is PluginCloneable {
     uint256 public state1;

--- a/test/mocks/plugin/Cloneable/PluginCloneableSetupMock.sol
+++ b/test/mocks/plugin/Cloneable/PluginCloneableSetupMock.sol
@@ -3,9 +3,9 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
 
 import {mockPermissions, mockHelpers, mockPluginProxy} from "../PluginMockData.sol";
 import {PluginCloneableV1Mock, PluginCloneableV1MockBad, PluginCloneableV2Mock} from "./PluginCloneableMock.sol";

--- a/test/mocks/plugin/Cloneable/PluginCloneableSetupMock.sol
+++ b/test/mocks/plugin/Cloneable/PluginCloneableSetupMock.sol
@@ -3,9 +3,9 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "../../../../src/common/permission/PermissionLib.sol";
+import {IPluginSetup} from "../../../../src/common/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "../../../../src/common/plugin/setup/PluginSetup.sol";
 
 import {mockPermissions, mockHelpers, mockPluginProxy} from "../PluginMockData.sol";
 import {PluginCloneableV1Mock, PluginCloneableV1MockBad, PluginCloneableV2Mock} from "./PluginCloneableMock.sol";

--- a/test/mocks/plugin/Constructable/PluginMock.sol
+++ b/test/mocks/plugin/Constructable/PluginMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {Plugin} from "@aragon/osx-commons-contracts/plugin/Plugin.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {Plugin} from "../../../../src/common/plugin/Plugin.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
 
 contract PluginV1Mock is Plugin {
     uint256 public state1;

--- a/test/mocks/plugin/Constructable/PluginMock.sol
+++ b/test/mocks/plugin/Constructable/PluginMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {Plugin} from "@aragon/osx-commons-contracts/src/plugin/Plugin.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {Plugin} from "@aragon/osx-commons-contracts/plugin/Plugin.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 contract PluginV1Mock is Plugin {
     uint256 public state1;

--- a/test/mocks/plugin/PluginMockData.sol
+++ b/test/mocks/plugin/PluginMockData.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
 
 address constant NO_CONDITION = address(0);
 

--- a/test/mocks/plugin/PluginMockData.sol
+++ b/test/mocks/plugin/PluginMockData.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts/utils/deployment/ProxyLib.sol";
+import {PermissionLib} from "../../../src/common/permission/PermissionLib.sol";
+import {ProxyLib} from "../../../src/common/utils/deployment/ProxyLib.sol";
 
 address constant NO_CONDITION = address(0);
 

--- a/test/mocks/plugin/UUPSUpgradeable/PluginUUPSUpgradeableMock.sol
+++ b/test/mocks/plugin/UUPSUpgradeable/PluginUUPSUpgradeableMock.sol
@@ -3,8 +3,8 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/plugin/PluginUUPSUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
+import {PluginUUPSUpgradeable} from "../../../../src/common/plugin/PluginUUPSUpgradeable.sol";
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
 
 contract PluginUUPSUpgradeableV1Mock is PluginUUPSUpgradeable {
     uint256 public state1;

--- a/test/mocks/plugin/UUPSUpgradeable/PluginUUPSUpgradeableMock.sol
+++ b/test/mocks/plugin/UUPSUpgradeable/PluginUUPSUpgradeableMock.sol
@@ -3,8 +3,8 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {PluginUUPSUpgradeable} from "@aragon/osx-commons-contracts/plugin/PluginUUPSUpgradeable.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/dao/IDAO.sol";
 
 contract PluginUUPSUpgradeableV1Mock is PluginUUPSUpgradeable {
     uint256 public state1;

--- a/test/mocks/plugin/UUPSUpgradeable/PluginUUPSUpgradeableSetupMock.sol
+++ b/test/mocks/plugin/UUPSUpgradeable/PluginUUPSUpgradeableSetupMock.sol
@@ -3,11 +3,11 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "../../../../src/common/permission/PermissionLib.sol";
+import {IPluginSetup} from "../../../../src/common/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "../../../../src/common/plugin/setup/PluginSetup.sol";
 
-import {PluginUpgradeableSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginUpgradeableSetup.sol";
+import {PluginUpgradeableSetup} from "../../../../src/common/plugin/setup/PluginUpgradeableSetup.sol";
 
 import {mockPermissions, mockHelpers, mockPluginProxy} from "../PluginMockData.sol";
 import {PluginUUPSUpgradeableV1Mock, PluginUUPSUpgradeableV2Mock, PluginUUPSUpgradeableV3Mock} from "./PluginUUPSUpgradeableMock.sol";

--- a/test/mocks/plugin/UUPSUpgradeable/PluginUUPSUpgradeableSetupMock.sol
+++ b/test/mocks/plugin/UUPSUpgradeable/PluginUUPSUpgradeableSetupMock.sol
@@ -3,11 +3,11 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.8;
 
-import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
-import {PluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/permission/PermissionLib.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/IPluginSetup.sol";
+import {PluginSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginSetup.sol";
 
-import {PluginUpgradeableSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginUpgradeableSetup.sol";
+import {PluginUpgradeableSetup} from "@aragon/osx-commons-contracts/plugin/setup/PluginUpgradeableSetup.sol";
 
 import {mockPermissions, mockHelpers, mockPluginProxy} from "../PluginMockData.sol";
 import {PluginUUPSUpgradeableV1Mock, PluginUUPSUpgradeableV2Mock, PluginUUPSUpgradeableV3Mock} from "./PluginUUPSUpgradeableMock.sol";


### PR DESCRIPTION
The layouf of the whole osx-commons package forced other repo's to include `/src` in the import path in the past. 

With "commons" being a part of OSx, now these paths are broken on other repositories. Yet, they cannot just use `@aragon/osx/commons` because OSx itself does use `@aragon/osx-commons-contracts/src`.

This PR normalizes import paths so that they work on any dependency.