### PR TITLE
fix(crosschain): security hardening of the cross-chain module

### DIFF
--- a/src/common/crosschain/CrossChainController.sol
+++ b/src/common/crosschain/CrossChainController.sol
@@ -2,6 +2,11 @@
 
 pragma solidity ^0.8.8;
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {
+    SafeERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import {IBaseAdapter} from "./adapters/IBaseAdapter.sol";
 import {DaoAuthorizable} from "../permission/auth/DaoAuthorizable.sol";
 import {Action, IExecutor} from "../executors/IExecutor.sol";
@@ -9,28 +14,150 @@ import {Action, IExecutor} from "../executors/IExecutor.sol";
 import {IDAO} from "../dao/IDAO.sol";
 import {Errors} from "./lib/Errors.sol";
 
+/// @title CrossChainController
+/// @notice Per-DAO hub for sending and receiving cross-chain messages. It holds
+///         `EXECUTE_PERMISSION` on its DAO, so every inbound path into
+///         `receiveMessage` is security critical.
+/// @dev Threat model / invariants:
+///      - `receiveMessage` is callable ONLY by a local adapter registered
+///        through `updateConfig`. The per-origin-chain authentication of the
+///        remote sender is the adapter's responsibility (trusted remotes).
+///      - Adapters are invoked with a plain `call`, never `delegatecall`.
+///        Adapter storage therefore belongs to the adapter, and the address the
+///        bridge sees as the sender is the ADAPTER (see `IBaseAdapter`).
+///      - This contract custodies the bridge fee funds (native and/or ERC20)
+///        and forwards exactly the quoted fee to the adapter per send. Only the
+///        sending side needs funding; receive-only deployments do not.
+/// @custom:security-contact sirt@aragon.org
 contract CrossChainController is DaoAuthorizable {
+    using SafeERC20 for IERC20;
+
+    /// @notice Permission to forward a message to a remote chain. Held by the
+    ///         DAO / the plugin whose proposals produce cross-chain actions.
     bytes32 public constant FORWARD_MESSAGE_PERMISSION_ID =
         keccak256("FORWARD_MESSAGE_PERMISSION");
 
+    /// @notice Permission to (re)configure the chainId -> adapters mapping.
+    /// @dev SECURITY: this permission is highly privileged. A holder can point
+    ///      a chain at an adapter it controls and, because that adapter becomes
+    ///      a registered local adapter, deliver arbitrary `Action[]` payloads
+    ///      into `receiveMessage` and thus execute anything on the DAO. It
+    ///      MUST be granted only to the DAO itself (i.e. only reachable through
+    ///      a passed proposal) and never to an EOA or a permissionless
+    ///      condition. Since adapters are called (not `delegatecall`ed), a
+    ///      malicious adapter cannot corrupt this contract's storage or spend
+    ///      more than the fee it is handed, but it CAN forge inbound messages.
     bytes32 public constant UPDATE_CONFIG_PERMISSION_ID =
         keccak256("UPDATE_CONFIG_PERMISSION");
 
+    /// @notice Permission to retry a message whose execution reverted on
+    ///         arrival. Intended for the DAO and/or an ops multisig, since the
+    ///         payload itself was already authenticated by the bridge.
+    bytes32 public constant RETRY_MESSAGE_PERMISSION_ID =
+        keccak256("RETRY_MESSAGE_PERMISSION");
+
+    /// @notice Permission to move pre-funded fee assets out of this contract.
+    bytes32 public constant SWEEP_PERMISSION_ID = keccak256("SWEEP_PERMISSION");
+
     /// @param localAdapter The address of adapter where cross chain controller will send a message on the same chain.
     /// @param remoteAdapter The address of adapter on remote chain that will receive the message.
+    /// @dev `remoteAdapter` is BOTH the bridge-level receiver of outbound
+    ///      messages AND the address the remote adapter must have configured as
+    ///      its trusted remote for this chain (because the sender seen on the
+    ///      far side is this chain's adapter). Use
+    ///      `BaseAdapter.assertTrustedRemotesMatchController` after deployment
+    ///      to check the two sides agree.
     struct AdapterByChain {
         address localAdapter;
         address remoteAdapter;
     }
 
-    // TODO: add
-    event MessageForwarded();
+    /// @notice A message whose execution reverted on arrival, kept for retry.
+    /// @param pending Whether a retry is still outstanding.
+    /// @param originChainId The standard chain id the message came from.
+    /// @param messageId The bridge-level message identifier.
+    /// @param payload The encoded `Action[]`.
+    struct FailedMessage {
+        bool pending;
+        uint256 originChainId;
+        bytes32 messageId;
+        bytes payload;
+    }
 
+    /// @notice Emitted when a lane is configured or cleared.
+    event ConfigUpdated(
+        uint256 indexed chainId,
+        address localAdapter,
+        address remoteAdapter
+    );
+
+    /// @notice Emitted when a message was handed to the local adapter.
+    event MessageForwarded(
+        uint256 indexed destinationChainId,
+        bytes32 indexed messageId,
+        address indexed localAdapter,
+        address remoteAdapter,
+        uint256 gasLimit,
+        address feeToken,
+        uint256 fee
+    );
+
+    /// @notice Emitted when an inbound message executed successfully.
+    event MessageReceived(
+        uint256 indexed originChainId,
+        bytes32 indexed messageId,
+        bytes32 indexed callId
+    );
+
+    /// @notice Emitted when an inbound message reverted and was stored.
+    event MessageExecutionFailed(
+        uint256 indexed originChainId,
+        bytes32 indexed messageId,
+        bytes32 indexed callId,
+        bytes reason
+    );
+
+    /// @notice Emitted when a stored failed message was successfully retried.
+    event MessageRetried(bytes32 indexed callId);
+
+    /// @notice Emitted when fee assets are moved out of the contract.
+    event Swept(address indexed token, address indexed to, uint256 amount);
+
+    /// @notice standard chain id -> adapter pair.
     mapping(uint256 => AdapterByChain) public chainToAdapter;
+
+    /// @notice local adapter -> number of chain ids it is registered for.
+    /// @dev A single adapter (e.g. one CCIP adapter) usually serves many lanes,
+    ///      so a refcount is required for correct removal/rotation: the
+    ///      adapter only stops being trusted once its last lane is cleared.
+    mapping(address => uint256) private _localAdapterLaneCount;
+
+    /// @notice callId -> stored failed message.
+    mapping(bytes32 => FailedMessage) private _failedMessages;
+
+    /// @notice Restricts a function to local adapters registered via `updateConfig`.
+    modifier onlyLocalAdapter() {
+        if (_localAdapterLaneCount[msg.sender] == 0) {
+            revert Errors.CALLER_NOT_LOCAL_ADAPTER(msg.sender);
+        }
+        _;
+    }
 
     constructor(address _dao) DaoAuthorizable(IDAO(_dao)) {}
 
+    /// @notice Accepts native pre-funding used to pay bridge fees.
+    receive() external payable {}
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
     /// @notice Allows to update adapters per each chain.
+    /// @dev Pass the zero pair (`address(0)`, `address(0)`) to clear a lane;
+    ///      this also decrements the local adapter's refcount so a rotated-out
+    ///      adapter loses the right to call `receiveMessage`.
+    /// @param _chainIds The standard chain ids to configure.
+    /// @param _adapters The adapter pair per chain id.
     function updateConfig(
         uint256[] memory _chainIds,
         AdapterByChain[] memory _adapters
@@ -39,51 +166,299 @@ contract CrossChainController is DaoAuthorizable {
             revert Errors.INVALID_LENGTH_MISMATCH();
 
         for (uint256 i = 0; i < _chainIds.length; i++) {
-            chainToAdapter[_chainIds[i]] = _adapters[i];
+            uint256 chainId = _chainIds[i];
+            if (chainId == 0) revert Errors.INVALID_CHAIN_ID();
+
+            AdapterByChain memory newConfig = _adapters[i];
+
+            // A lane is either fully set or fully cleared; a half-configured
+            // lane is the "silent no-op" footgun.
+            if (
+                (newConfig.localAdapter == address(0)) !=
+                (newConfig.remoteAdapter == address(0))
+            ) {
+                revert Errors.INCOMPLETE_ADAPTER_CONFIG(chainId);
+            }
+
+            address oldLocalAdapter = chainToAdapter[chainId].localAdapter;
+
+            if (oldLocalAdapter != newConfig.localAdapter) {
+                if (oldLocalAdapter != address(0)) {
+                    _localAdapterLaneCount[oldLocalAdapter] -= 1;
+                }
+                if (newConfig.localAdapter != address(0)) {
+                    _localAdapterLaneCount[newConfig.localAdapter] += 1;
+                }
+            }
+
+            chainToAdapter[chainId] = newConfig;
+
+            emit ConfigUpdated(
+                chainId,
+                newConfig.localAdapter,
+                newConfig.remoteAdapter
+            );
         }
     }
 
-    /// @notice The final destination for a message that arrives on remote chain.
-    /// @param _payload The encoded Action[] message.
-    /// @param _originChainId The origin chain id from which cross-chain message originated.
-    function receiveMessage(
-        bytes memory _payload,
-        uint256 _originChainId
-    ) public {
-        Action[] memory actions = abi.decode(_payload, (Action[]));
+    /// @notice Whether an address is currently registered as a local adapter.
+    /// @param _adapter The address to check.
+    /// @return True if the address may call `receiveMessage`.
+    function isRegisteredLocalAdapter(
+        address _adapter
+    ) public view returns (bool) {
+        return _adapter != address(0) && _localAdapterLaneCount[_adapter] != 0;
+    }
 
-        IExecutor(address(dao())).execute(bytes32(0), actions, 0);
+    /// @notice The number of lanes an adapter is registered for.
+    /// @param _adapter The adapter address.
+    /// @return The lane count.
+    function localAdapterLaneCount(
+        address _adapter
+    ) public view returns (uint256) {
+        return _localAdapterLaneCount[_adapter];
+    }
+
+    // -------------------------------------------------------------------------
+    // Sending
+    // -------------------------------------------------------------------------
+
+    /// @notice Quotes the bridge fee for a prospective send.
+    /// @dev Off-chain monitoring should poll this and top the contract up ahead
+    ///      of a deadline: a quote taken when a proposal is created can be
+    ///      badly stale by the time the voting window closes.
+    /// @param _destinationChainId The standard chain id of remote chain.
+    /// @param _gasLimit The gas limit that will be used for crosschain message execution.
+    /// @param _message The encoded Action[] message.
+    /// @return feeToken The fee token (`address(0)` for native).
+    /// @return fee The required fee amount.
+    /// @return available The balance this contract currently holds of `feeToken`.
+    function quoteFee(
+        uint256 _destinationChainId,
+        uint256 _gasLimit,
+        bytes memory _message
+    ) public view returns (address feeToken, uint256 fee, uint256 available) {
+        AdapterByChain memory adapters = _validatedAdapters(
+            _destinationChainId
+        );
+
+        (feeToken, fee) = IBaseAdapter(adapters.localAdapter).quoteFee(
+            adapters.remoteAdapter,
+            _gasLimit,
+            _destinationChainId,
+            _message
+        );
+
+        available = feeToken == address(0)
+            ? address(this).balance
+            : IERC20(feeToken).balanceOf(address(this));
     }
 
     /// @notice Entry point to receive a message and send it to cross-chain.
     /// @param _destinationChainId The standard chain id of remote chain.
     /// @param _gasLimit The gas limit that will be used for crosschain message execution.
     /// @param _message The encoded Action[] message.
+    /// @return messageId The bridge-level identifier of the sent message.
     function forwardMessage(
         uint256 _destinationChainId,
         uint256 _gasLimit,
         bytes memory _message
-    ) public auth(FORWARD_MESSAGE_PERMISSION_ID) {
-        AdapterByChain storage adapters = chainToAdapter[_destinationChainId];
+    ) public auth(FORWARD_MESSAGE_PERMISSION_ID) returns (bytes32 messageId) {
+        AdapterByChain memory adapters = _validatedAdapters(
+            _destinationChainId
+        );
 
-        (bool success, bytes memory returnData) = adapters
-            .localAdapter
-            .delegatecall(
-                abi.encodeCall(
-                    IBaseAdapter.sendMessage,
-                    (
-                        adapters.remoteAdapter,
-                        _gasLimit,
-                        _destinationChainId,
-                        _message
-                    )
-                )
+        (address feeToken, uint256 fee) = IBaseAdapter(adapters.localAdapter)
+            .quoteFee(
+                adapters.remoteAdapter,
+                _gasLimit,
+                _destinationChainId,
+                _message
             );
 
-        if (!success) {
-            revert Errors.SEND_MESSAGE_TO_ADAPTER_FAILED(returnData);
+        uint256 nativeValue;
+
+        if (feeToken == address(0)) {
+            if (address(this).balance < fee) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(
+                    feeToken,
+                    fee,
+                    address(this).balance
+                );
+            }
+            nativeValue = fee;
+        } else {
+            uint256 balance = IERC20(feeToken).balanceOf(address(this));
+            if (balance < fee) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(feeToken, fee, balance);
+            }
+            // Hand the adapter exactly the quoted fee for this send; the
+            // adapter returns any remainder in the same transaction.
+            if (fee != 0) {
+                IERC20(feeToken).safeTransfer(adapters.localAdapter, fee);
+            }
         }
 
-        emit MessageForwarded();
+        messageId = IBaseAdapter(adapters.localAdapter).sendMessage{
+            value: nativeValue
+        }(adapters.remoteAdapter, _gasLimit, _destinationChainId, _message);
+
+        emit MessageForwarded(
+            _destinationChainId,
+            messageId,
+            adapters.localAdapter,
+            adapters.remoteAdapter,
+            _gasLimit,
+            feeToken,
+            fee
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Receiving
+    // -------------------------------------------------------------------------
+
+    /// @notice The final destination for a message that arrives on remote chain.
+    /// @dev Only a registered local adapter may call this. The adapter is
+    ///      responsible for having authenticated the remote sender. Execution
+    ///      is wrapped defensively: a reverting payload is stored and can be
+    ///      retried later instead of being stranded until the bridge's manual
+    ///      execution window (~8h for CCIP) closes.
+    /// @param _messageId The bridge-level message identifier.
+    /// @param _payload The encoded Action[] message.
+    /// @param _originChainId The origin chain id from which cross-chain message originated.
+    /// @return callId The deterministic call id used for the DAO execution.
+    function receiveMessage(
+        bytes32 _messageId,
+        bytes memory _payload,
+        uint256 _originChainId
+    ) public onlyLocalAdapter returns (bytes32 callId) {
+        callId = deriveCallId(_originChainId, _messageId);
+
+        if (_failedMessages[callId].pending) {
+            revert Errors.MESSAGE_ALREADY_PENDING(callId);
+        }
+
+        // The self-call also contains payload decoding, so a malformed payload
+        // is captured for retry rather than reverting the bridge delivery.
+        try this.executeActions(callId, _payload) {
+            emit MessageReceived(_originChainId, _messageId, callId);
+        } catch (bytes memory reason) {
+            _failedMessages[callId] = FailedMessage({
+                pending: true,
+                originChainId: _originChainId,
+                messageId: _messageId,
+                payload: _payload
+            });
+
+            emit MessageExecutionFailed(
+                _originChainId,
+                _messageId,
+                callId,
+                reason
+            );
+        }
+    }
+
+    /// @notice Decodes and executes an authenticated payload on the DAO.
+    /// @dev External only so it can be wrapped in `try/catch`; callable
+    ///      exclusively by this contract.
+    /// @param _callId The call id passed to the executor.
+    /// @param _payload The encoded Action[] message.
+    function executeActions(bytes32 _callId, bytes memory _payload) external {
+        if (msg.sender != address(this)) {
+            revert Errors.CALLER_NOT_SELF(msg.sender);
+        }
+
+        Action[] memory actions = abi.decode(_payload, (Action[]));
+
+        IExecutor(address(dao())).execute(_callId, actions, 0);
+    }
+
+    /// @notice Retries a previously failed inbound message.
+    /// @dev Reverts (bubbling the failure) if the retry fails again, so the
+    ///      stored message stays pending.
+    /// @param _callId The call id emitted by `MessageExecutionFailed`.
+    function retryFailedMessage(
+        bytes32 _callId
+    ) public auth(RETRY_MESSAGE_PERMISSION_ID) {
+        FailedMessage memory failed = _failedMessages[_callId];
+        if (!failed.pending) revert Errors.NO_FAILED_MESSAGE(_callId);
+
+        delete _failedMessages[_callId];
+
+        this.executeActions(_callId, failed.payload);
+
+        emit MessageRetried(_callId);
+    }
+
+    /// @notice Returns a stored failed message.
+    /// @param _callId The call id.
+    /// @return The stored message; `pending` is false if there is none.
+    function getFailedMessage(
+        bytes32 _callId
+    ) public view returns (FailedMessage memory) {
+        return _failedMessages[_callId];
+    }
+
+    /// @notice Derives the DAO call id / failed-message key of a message.
+    /// @param _originChainId The standard origin chain id.
+    /// @param _messageId The bridge-level message identifier.
+    /// @return The call id.
+    function deriveCallId(
+        uint256 _originChainId,
+        bytes32 _messageId
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(_originChainId, _messageId));
+    }
+
+    // -------------------------------------------------------------------------
+    // Fee custody
+    // -------------------------------------------------------------------------
+
+    /// @notice Moves pre-funded fee assets out of this contract.
+    /// @param _token The asset to move; `address(0)` for native currency.
+    /// @param _to The recipient (typically the DAO).
+    /// @param _amount The amount to move.
+    function sweep(
+        address _token,
+        address _to,
+        uint256 _amount
+    ) public auth(SWEEP_PERMISSION_ID) {
+        if (_to == address(0)) revert Errors.ZERO_ADDRESS();
+
+        if (_token == address(0)) {
+            (bool ok, ) = _to.call{value: _amount}("");
+            if (!ok) revert Errors.NATIVE_TRANSFER_FAILED(_to, _amount);
+        } else {
+            IERC20(_token).safeTransfer(_to, _amount);
+        }
+
+        emit Swept(_token, _to, _amount);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    /// @notice Loads and validates the adapter pair for a destination chain.
+    /// @dev Reverts instead of silently no-op'ing: a `call`/`delegatecall` to a
+    ///      codeless address reports success, which would let a proposal
+    ///      "execute" while nothing was ever bridged.
+    function _validatedAdapters(
+        uint256 _destinationChainId
+    ) internal view returns (AdapterByChain memory adapters) {
+        adapters = chainToAdapter[_destinationChainId];
+
+        if (
+            adapters.localAdapter == address(0) ||
+            adapters.remoteAdapter == address(0)
+        ) {
+            revert Errors.ADAPTER_NOT_CONFIGURED(_destinationChainId);
+        }
+
+        if (adapters.localAdapter.code.length == 0) {
+            revert Errors.ADAPTER_HAS_NO_CODE(adapters.localAdapter);
+        }
     }
 }

--- a/src/common/crosschain/adapters/BaseAdapter.sol
+++ b/src/common/crosschain/adapters/BaseAdapter.sol
@@ -4,45 +4,139 @@ pragma solidity ^0.8.8;
 
 import {Errors} from "../lib/Errors.sol";
 import {CrossChainController} from "../CrossChainController.sol";
+import {DaoAuthorizable} from "../../permission/auth/DaoAuthorizable.sol";
 import {IBaseAdapter} from "./IBaseAdapter.sol";
 
-abstract contract BaseAdapter is IBaseAdapter {
-    /// @notice The address of crosschain controller.
-    address public immutable CROSS_CHAIN_CONTROLLER;
+/// @title BaseAdapter
+/// @notice Shared logic for bridge adapters owned by a `CrossChainController`.
+/// @dev The controller invokes adapters with a plain `call`, so:
+///      - adapter storage is the adapter's own (no `delegatecall` collisions);
+///      - the sender address the bridge reports on the destination chain is
+///        THIS ADAPTER. Consequently `_trustedRemotes[chainId]` must hold the
+///        REMOTE ADAPTER address, which is exactly what the controller stores
+///        as `chainToAdapter[chainId].remoteAdapter`. Use
+///        `assertTrustedRemotesMatchController` to verify both sides agree.
+///      Adapter administration is authorized through the same DAO that owns the
+///      controller, so no separate ownership system is introduced.
+/// @custom:security-contact sirt@aragon.org
+abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
+    /// @notice Permission to change adapter configuration (trusted remotes,
+    ///         fee token, chain-id mappings).
+    bytes32 public constant UPDATE_ADAPTER_CONFIG_PERMISSION_ID =
+        keccak256("UPDATE_ADAPTER_CONFIG_PERMISSION");
 
-    /// @notice standard chain id -> origin forwarder address.
+    /// @notice The address of crosschain controller.
+    address public immutable override CROSS_CHAIN_CONTROLLER;
+
+    /// @notice standard chain id -> remote adapter address allowed to originate
+    ///         messages for that chain.
     mapping(uint256 => address) internal _trustedRemotes;
 
+    /// @notice Emitted when a trusted remote is set or cleared.
+    event TrustedRemoteSet(uint256 indexed chainId, address trustedRemote);
+
+    /// @notice Restricts a function to the owning `CrossChainController`.
+    modifier onlyCrossChainController() {
+        if (msg.sender != CROSS_CHAIN_CONTROLLER) {
+            revert Errors.CALLER_NOT_CROSS_CHAIN_CONTROLLER(msg.sender);
+        }
+        _;
+    }
+
+    /// @param _crossChainController The controller that owns this adapter. Its
+    ///        DAO is adopted as the adapter's permission manager.
+    /// @param _remoteChainIds The standard chain ids of the remote lanes.
+    /// @param _remoteTrustedSenders The remote ADAPTER address per lane.
     constructor(
         address _crossChainController,
         uint256[] memory _remoteChainIds,
         address[] memory _remoteTrustedSenders
-    ) {
+    ) DaoAuthorizable(CrossChainController(payable(_crossChainController)).dao()) {
         CROSS_CHAIN_CONTROLLER = _crossChainController;
 
-        if (_remoteChainIds.length != _remoteTrustedSenders.length) {
-            revert Errors.INVALID_LENGTH_MISMATCH();
-        }
+        _setTrustedRemotes(_remoteChainIds, _remoteTrustedSenders);
+    }
 
-        for (uint256 i = 0; i < _remoteChainIds.length; i++) {
-            address remoteTrustedSender = _remoteTrustedSenders[i];
-            if (remoteTrustedSender == address(0)) {
-                revert Errors.TRUSTED_REMOTE_NOT_SET();
+    /// @notice The remote adapter trusted to originate messages for a chain.
+    /// @param _chainId The standard chain id.
+    /// @return The trusted remote adapter address, or zero if unset.
+    function trustedRemote(uint256 _chainId) public view returns (address) {
+        return _trustedRemotes[_chainId];
+    }
+
+    /// @notice Sets or clears trusted remotes.
+    /// @dev Pass `address(0)` for a sender to clear a lane.
+    /// @param _remoteChainIds The standard chain ids.
+    /// @param _remoteTrustedSenders The remote adapter addresses.
+    function setTrustedRemotes(
+        uint256[] memory _remoteChainIds,
+        address[] memory _remoteTrustedSenders
+    ) public auth(UPDATE_ADAPTER_CONFIG_PERMISSION_ID) {
+        _setTrustedRemotes(_remoteChainIds, _remoteTrustedSenders);
+    }
+
+    /// @notice Reverts unless, for every given chain, this adapter's trusted
+    ///         remote equals the controller's configured `remoteAdapter`.
+    /// @dev Deployment-time sanity check for the easily-misconfigured pair
+    ///      described in the contract-level docs.
+    /// @param _chainIds The standard chain ids to check.
+    function assertTrustedRemotesMatchController(
+        uint256[] memory _chainIds
+    ) public view {
+        for (uint256 i = 0; i < _chainIds.length; i++) {
+            uint256 chainId = _chainIds[i];
+
+            (, address remoteAdapter) = CrossChainController(
+                payable(CROSS_CHAIN_CONTROLLER)
+            ).chainToAdapter(chainId);
+
+            address trusted = _trustedRemotes[chainId];
+
+            if (trusted == address(0) || trusted != remoteAdapter) {
+                revert Errors.TRUSTED_REMOTE_MISMATCH(
+                    chainId,
+                    trusted,
+                    remoteAdapter
+                );
             }
-
-            _trustedRemotes[_remoteChainIds[i]] = _remoteTrustedSenders[i];
         }
     }
 
     /// @notice Once adapter receives a message, this must be called
     ///         to redirect/forward it to CrossChainController.
+    /// @dev MUST stay `internal`: it is the unauthenticated side of the receive
+    ///      path, reachable only after the bridge-specific caller and
+    ///      trusted-remote checks have passed.
+    /// @param _messageId The bridge-level message identifier.
+    /// @param _payload The encoded Action[] message.
+    /// @param _originChainId The standard chain id the message came from.
     function _forwardMessage(
+        bytes32 _messageId,
         bytes memory _payload,
-        uint256 originChainId
-    ) public {
-        CrossChainController(CROSS_CHAIN_CONTROLLER).receiveMessage(
+        uint256 _originChainId
+    ) internal {
+        CrossChainController(payable(CROSS_CHAIN_CONTROLLER)).receiveMessage(
+            _messageId,
             _payload,
-            originChainId
+            _originChainId
         );
+    }
+
+    function _setTrustedRemotes(
+        uint256[] memory _remoteChainIds,
+        address[] memory _remoteTrustedSenders
+    ) internal {
+        if (_remoteChainIds.length != _remoteTrustedSenders.length) {
+            revert Errors.INVALID_LENGTH_MISMATCH();
+        }
+
+        for (uint256 i = 0; i < _remoteChainIds.length; i++) {
+            uint256 chainId = _remoteChainIds[i];
+            if (chainId == 0) revert Errors.INVALID_CHAIN_ID();
+
+            _trustedRemotes[chainId] = _remoteTrustedSenders[i];
+
+            emit TrustedRemoteSet(chainId, _remoteTrustedSenders[i]);
+        }
     }
 }

--- a/src/common/crosschain/adapters/CCIP/CCIPAdapter.sol
+++ b/src/common/crosschain/adapters/CCIP/CCIPAdapter.sol
@@ -6,10 +6,10 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {
     SafeERC20
-} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {
     SafeCast
-} from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import {
     IRouterClient
@@ -24,6 +24,19 @@ import {Errors} from "../../lib/Errors.sol";
 import {BaseAdapter} from "../BaseAdapter.sol";
 import {IBaseAdapter} from "../IBaseAdapter.sol";
 
+/// @title CCIPAdapter
+/// @notice Chainlink CCIP implementation of `IBaseAdapter`.
+/// @dev Called (never `delegatecall`ed) by the `CrossChainController`, so this
+///      contract's storage is its own and CCIP sees THIS ADAPTER as the sender.
+///      The remote side must therefore trust this adapter's address, and
+///      `_trustedRemotes[chainId]` here must hold the remote ADAPTER address.
+///
+///      Fee handling: the controller custodies the funds and hands this adapter
+///      exactly the quoted fee per send (native as `msg.value`, ERC20 by
+///      transfer immediately before the call). Any remainder is returned to the
+///      controller in the same transaction. CCIP does NOT refund overpayment,
+///      so the fee is quoted with `getFee` and paid exactly.
+/// @custom:security-contact sirt@aragon.org
 contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     using SafeERC20 for IERC20;
 
@@ -31,7 +44,20 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     IRouterClient public immutable CCIP_ROUTER;
 
     /// @notice The fee token that will be used to pay for bridge fees.
+    ///         `address(0)` means the chain's native currency.
     address public feeToken;
+
+    /// @notice standard chain id -> CCIP chain selector.
+    mapping(uint256 => uint64) internal _chainIdToSelector;
+
+    /// @notice CCIP chain selector -> standard chain id.
+    mapping(uint64 => uint256) internal _selectorToChainId;
+
+    /// @notice Emitted when the fee token is changed.
+    event FeeTokenSet(address feeToken);
+
+    /// @notice Emitted when a chain-id <-> selector pair is set or cleared.
+    event ChainSelectorSet(uint256 indexed chainId, uint64 chainSelector);
 
     /// @notice The receive function must only allow CCIP router.
     modifier onlyRouter() {
@@ -42,59 +68,159 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
         _;
     }
 
+    /// @param _crosschainController The owning controller.
+    /// @param _ccipRouter The CCIP router on this chain.
+    /// @param _feeToken The fee token, or `address(0)` for native.
+    /// @param _chainIds The standard chain ids of the configured lanes.
+    /// @param _trustedRemoteSenders The remote ADAPTER address per lane.
+    /// @param _selectorChainIds The standard chain ids of the selector mapping.
+    /// @param _chainSelectors The CCIP selector per entry of `_selectorChainIds`.
     constructor(
         address _crosschainController,
         address _ccipRouter,
         address _feeToken,
         uint256[] memory _chainIds,
-        address[] memory _trustedRemoteSenders
+        address[] memory _trustedRemoteSenders,
+        uint256[] memory _selectorChainIds,
+        uint64[] memory _chainSelectors
     ) BaseAdapter(_crosschainController, _chainIds, _trustedRemoteSenders) {
+        if (_ccipRouter == address(0)) revert Errors.ZERO_ADDRESS();
+
         CCIP_ROUTER = IRouterClient(_ccipRouter);
         feeToken = _feeToken;
+
+        _setChainSelectors(_selectorChainIds, _chainSelectors);
     }
 
+    /// @notice Accepts the native fee handed over by the controller.
+    receive() external payable {}
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    /// @notice Sets the fee token used for subsequent sends.
+    /// @param _feeToken The new fee token, or `address(0)` for native.
+    function setFeeToken(
+        address _feeToken
+    ) public auth(UPDATE_ADAPTER_CONFIG_PERMISSION_ID) {
+        feeToken = _feeToken;
+
+        emit FeeTokenSet(_feeToken);
+    }
+
+    /// @notice Sets or clears standard chain id <-> CCIP selector pairs.
+    /// @dev New CCIP lanes appear over time, so this must be updatable without
+    ///      redeploying the adapter. Pass selector `0` to clear a mapping.
+    /// @param _chainIds The standard chain ids.
+    /// @param _chainSelectors The CCIP chain selectors.
+    function setChainSelectors(
+        uint256[] memory _chainIds,
+        uint64[] memory _chainSelectors
+    ) public auth(UPDATE_ADAPTER_CONFIG_PERMISSION_ID) {
+        _setChainSelectors(_chainIds, _chainSelectors);
+    }
+
+    // -------------------------------------------------------------------------
+    // Sending
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IBaseAdapter
+    function quoteFee(
+        address _receiver,
+        uint256 _gasLimit,
+        uint256 _destinationChainId,
+        bytes calldata _message
+    ) public view override returns (address, uint256) {
+        if (_receiver == address(0)) revert Errors.RECEIVER_ADDRESS_ZERO();
+
+        uint64 destChainSelector = SafeCast.toUint64(
+            toNativeChainId(_destinationChainId)
+        );
+
+        address currentFeeToken = feeToken;
+
+        return (
+            currentFeeToken,
+            CCIP_ROUTER.getFee(
+                destChainSelector,
+                _buildMessage(_receiver, _gasLimit, _message, currentFeeToken)
+            )
+        );
+    }
+
+    /// @inheritdoc IBaseAdapter
     function sendMessage(
         address _receiver,
         uint256 _gasLimit,
         uint256 _destinationChainId,
         bytes calldata _message
-    ) public returns (uint256) {
+    ) public payable override onlyCrossChainController returns (bytes32) {
         if (_receiver == address(0)) revert Errors.RECEIVER_ADDRESS_ZERO();
 
-        // TODO: shall we add to only be allowed to call from crosschain controller.
-
-        // Transform standard chain id into chainlink's custom chainId.
-        uint64 destChainId = SafeCast.toUint64(
+        // Transform standard chain id into chainlink's chain selector.
+        uint64 destChainSelector = SafeCast.toUint64(
             toNativeChainId(_destinationChainId)
         );
 
-        // Build CCIP message.
-        bytes memory extraArgs = Client._argsToBytes(
-            Client.GenericExtraArgsV2({
-                gasLimit: _gasLimit,
-                allowOutOfOrderExecution: true
-            })
+        address currentFeeToken = feeToken;
+
+        Client.EVM2AnyMessage memory ccipMessage = _buildMessage(
+            _receiver,
+            _gasLimit,
+            _message,
+            currentFeeToken
         );
 
-        Client.EVM2AnyMessage memory ccipMessage = Client.EVM2AnyMessage({
-            receiver: abi.encode(_receiver),
-            data: _message,
-            tokenAmounts: new Client.EVMTokenAmount[](0),
-            extraArgs: extraArgs,
-            feeToken: address(feeToken)
-        });
+        // CCIP does not refund overpayment, so quote and pay exactly.
+        uint256 fees = CCIP_ROUTER.getFee(destChainSelector, ccipMessage);
 
-        // get fees of how much it will cost to send a message.
-        uint256 fees = CCIP_ROUTER.getFee(destChainId, ccipMessage);
+        bytes32 messageId;
 
-        if (IERC20(feeToken).balanceOf(address(this)) < fees) {
-            revert Errors.NOT_ENOUGH_TO_PAY_BRIDGE();
+        if (currentFeeToken == address(0)) {
+            uint256 balance = address(this).balance;
+            if (balance < fees) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(
+                    address(0),
+                    fees,
+                    balance
+                );
+            }
+
+            messageId = CCIP_ROUTER.ccipSend{value: fees}(
+                destChainSelector,
+                ccipMessage
+            );
+        } else {
+            // Native value would be stranded here; the controller custodies it.
+            if (msg.value != 0) revert Errors.UNEXPECTED_NATIVE_VALUE();
+
+            uint256 balance = IERC20(currentFeeToken).balanceOf(address(this));
+            if (balance < fees) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(
+                    currentFeeToken,
+                    fees,
+                    balance
+                );
+            }
+
+            // The Router pulls the fee via `transferFrom`.
+            IERC20(currentFeeToken).forceApprove(address(CCIP_ROUTER), fees);
+
+            messageId = CCIP_ROUTER.ccipSend(destChainSelector, ccipMessage);
+
+            // Leave no standing allowance.
+            IERC20(currentFeeToken).forceApprove(address(CCIP_ROUTER), 0);
         }
 
-        bytes32 messageId = CCIP_ROUTER.ccipSend(destChainId, ccipMessage);
+        _returnRemainder(currentFeeToken);
 
-        return uint256(messageId);
+        return messageId;
     }
+
+    // -------------------------------------------------------------------------
+    // Receiving
+    // -------------------------------------------------------------------------
 
     /// @inheritdoc IAny2EVMMessageReceiver
     function ccipReceive(
@@ -102,7 +228,7 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     ) external onlyRouter {
         address srcAddress = abi.decode(message.sender, (address));
 
-        // Transform adapter's chainId into standard chain Id.
+        // Transform CCIP's chain selector into the standard chain Id.
         uint256 originChainId = fromNativeChainId(message.sourceChainSelector);
 
         if (
@@ -112,7 +238,7 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
             revert Errors.REMOTE_NOT_TRUSTED();
         }
 
-        _forwardMessage(message.data, originChainId);
+        _forwardMessage(message.messageId, message.data, originChainId);
     }
 
     /// @inheritdoc IERC165
@@ -122,17 +248,107 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
             interfaceId == type(IERC165).interfaceId;
     }
 
+    // -------------------------------------------------------------------------
+    // Chain id mapping
+    // -------------------------------------------------------------------------
+
     /// @inheritdoc IBaseAdapter
+    /// @dev CCIP addresses lanes by chain SELECTOR, not by EVM chain id, so
+    ///      this is a real lookup. Unknown ids revert rather than returning `0`
+    ///      (which would target a nonexistent lane).
     function toNativeChainId(
         uint256 _chainId
-    ) public pure virtual override returns (uint256) {
-        return _chainId;
+    ) public view virtual override returns (uint256) {
+        uint64 selector = _chainIdToSelector[_chainId];
+        if (selector == 0) revert Errors.UNKNOWN_CHAIN_ID(_chainId);
+        return selector;
     }
 
     /// @inheritdoc IBaseAdapter
     function fromNativeChainId(
         uint256 _chainId
-    ) public pure virtual override returns (uint256) {
-        return _chainId;
+    ) public view virtual override returns (uint256) {
+        uint256 chainId = _selectorToChainId[SafeCast.toUint64(_chainId)];
+        if (chainId == 0) revert Errors.UNKNOWN_NATIVE_CHAIN_ID(_chainId);
+        return chainId;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    function _buildMessage(
+        address _receiver,
+        uint256 _gasLimit,
+        bytes memory _message,
+        address _feeToken
+    ) internal pure returns (Client.EVM2AnyMessage memory) {
+        bytes memory extraArgs = Client._argsToBytes(
+            Client.GenericExtraArgsV2({
+                gasLimit: _gasLimit,
+                allowOutOfOrderExecution: true
+            })
+        );
+
+        return
+            Client.EVM2AnyMessage({
+                receiver: abi.encode(_receiver),
+                data: _message,
+                tokenAmounts: new Client.EVMTokenAmount[](0),
+                extraArgs: extraArgs,
+                feeToken: _feeToken
+            });
+    }
+
+    /// @dev Returns anything left over after paying the bridge to the
+    ///      controller, so the adapter never accumulates custody.
+    function _returnRemainder(address _feeToken) internal {
+        if (_feeToken == address(0)) {
+            uint256 remainder = address(this).balance;
+            if (remainder != 0) {
+                (bool ok, ) = CROSS_CHAIN_CONTROLLER.call{value: remainder}("");
+                if (!ok) {
+                    revert Errors.NATIVE_TRANSFER_FAILED(
+                        CROSS_CHAIN_CONTROLLER,
+                        remainder
+                    );
+                }
+            }
+        } else {
+            uint256 remainder = IERC20(_feeToken).balanceOf(address(this));
+            if (remainder != 0) {
+                IERC20(_feeToken).safeTransfer(
+                    CROSS_CHAIN_CONTROLLER,
+                    remainder
+                );
+            }
+        }
+    }
+
+    function _setChainSelectors(
+        uint256[] memory _chainIds,
+        uint64[] memory _chainSelectors
+    ) internal {
+        if (_chainIds.length != _chainSelectors.length) {
+            revert Errors.INVALID_LENGTH_MISMATCH();
+        }
+
+        for (uint256 i = 0; i < _chainIds.length; i++) {
+            uint256 chainId = _chainIds[i];
+            if (chainId == 0) revert Errors.INVALID_CHAIN_ID();
+
+            uint64 previousSelector = _chainIdToSelector[chainId];
+            if (previousSelector != 0) {
+                delete _selectorToChainId[previousSelector];
+            }
+
+            uint64 selector = _chainSelectors[i];
+            _chainIdToSelector[chainId] = selector;
+            if (selector != 0) {
+                _selectorToChainId[selector] = chainId;
+            }
+
+            emit ChainSelectorSet(chainId, selector);
+        }
     }
 }

--- a/src/common/crosschain/adapters/IBaseAdapter.sol
+++ b/src/common/crosschain/adapters/IBaseAdapter.sol
@@ -1,29 +1,60 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+/// @title IBaseAdapter
+/// @notice Bridge-agnostic interface implemented by every cross-chain adapter.
+/// @dev Adapters are invoked by the `CrossChainController` with a regular
+///      `call` (never `delegatecall`), therefore adapter storage is the
+///      adapter's own and the `msg.sender` seen by the bridge is the ADAPTER.
 interface IBaseAdapter {
     /// @notice The address of cross chain controller that adapter stores
     ///         to send/receive messages to/from.
-    function CROSS_CHAIN_CONTROLLER() external returns (address);
+    function CROSS_CHAIN_CONTROLLER() external view returns (address);
 
     /// @notice Transforms standard chain id into adapter's own custom chain Ids.
     /// @param _chainId The standard chain Id.
     /// @return The transformed chain id into adapter's custom id.
-    function toNativeChainId(uint256 _chainId) external returns (uint256);
+    /// @dev MUST revert for unmapped chain ids instead of returning `0`.
+    function toNativeChainId(uint256 _chainId) external view returns (uint256);
 
     /// @notice Transforms adapter's own custom chain Id into standard chain id.
     /// @param _chainId The custom chain id of adapter.
     /// @return The transformed chain id into standard chain id.
-    function fromNativeChainId(uint256 _chainId) external returns (uint256);
+    /// @dev MUST revert for unmapped chain ids instead of returning `0`.
+    function fromNativeChainId(
+        uint256 _chainId
+    ) external view returns (uint256);
 
-    /// @param _receiver The address of the adapter on a remote chain
+    /// @notice Quotes the bridge fee for a given message.
+    /// @param _receiver The address of the adapter on a remote chain.
     /// @param _gasLimit The gas limit for cross-chain execution.
     /// @param _destinationChainId The remote chain's standard id.
     /// @param _message Encoded message.
+    /// @return feeToken The token the fee is denominated in. `address(0)`
+    ///         means the chain's native currency.
+    /// @return fee The amount of `feeToken` required to send the message.
+    function quoteFee(
+        address _receiver,
+        uint256 _gasLimit,
+        uint256 _destinationChainId,
+        bytes calldata _message
+    ) external view returns (address feeToken, uint256 fee);
+
+    /// @notice Sends a message over the bridge. Callable only by the
+    ///         `CROSS_CHAIN_CONTROLLER`.
+    /// @dev The controller pays the fee per send: native fees arrive as
+    ///      `msg.value`, ERC20 fees are transferred to the adapter immediately
+    ///      before the call. The adapter MUST NOT rely on a standing balance
+    ///      and MUST return any remainder to the controller.
+    /// @param _receiver The address of the adapter on a remote chain.
+    /// @param _gasLimit The gas limit for cross-chain execution.
+    /// @param _destinationChainId The remote chain's standard id.
+    /// @param _message Encoded message.
+    /// @return The bridge's message identifier.
     function sendMessage(
         address _receiver,
         uint256 _gasLimit,
         uint256 _destinationChainId,
         bytes calldata _message
-    ) external returns (uint256);
+    ) external payable returns (bytes32);
 }

--- a/src/common/crosschain/lib/Errors.sol
+++ b/src/common/crosschain/lib/Errors.sol
@@ -3,11 +3,104 @@
 pragma solidity ^0.8.8;
 
 library Errors {
-    error NOT_ENOUGH_TO_PAY_BRIDGE();
-    error RECEIVER_ADDRESS_ZERO();
-    error CALLER_NOT_CCIP_ROUTER();
+    // ---------------------------------------------------------------------
+    // Generic / configuration
+    // ---------------------------------------------------------------------
+
     error INVALID_LENGTH_MISMATCH();
+
+    /// @notice Thrown when a chain id of `0` is used. `0` is reserved as the
+    ///         "unset" marker of the `chainToAdapter` and chain-selector maps.
+    error INVALID_CHAIN_ID();
+
+    /// @notice Thrown when only one of `localAdapter`/`remoteAdapter` is set.
+    ///         A lane is either fully configured or fully cleared.
+    error INCOMPLETE_ADAPTER_CONFIG(uint256 chainId);
+
+    /// @notice Thrown when forwarding to a chain that has no adapter pair set.
+    error ADAPTER_NOT_CONFIGURED(uint256 chainId);
+
+    /// @notice Thrown when the configured local adapter has no deployed code.
+    ///         Guards against the EVM reporting success for calls to codeless
+    ///         addresses.
+    error ADAPTER_HAS_NO_CODE(address adapter);
+
+    error ZERO_ADDRESS();
+
+    // ---------------------------------------------------------------------
+    // Authorization
+    // ---------------------------------------------------------------------
+
+    error CALLER_NOT_CCIP_ROUTER();
+
+    /// @notice Thrown when `receiveMessage` is called by anything other than a
+    ///         local adapter registered through `updateConfig`.
+    error CALLER_NOT_LOCAL_ADAPTER(address caller);
+
+    /// @notice Thrown when an adapter entry point is called by anything other
+    ///         than the `CrossChainController` that owns the adapter.
+    error CALLER_NOT_CROSS_CHAIN_CONTROLLER(address caller);
+
+    /// @notice Thrown when the internal self-call entry point is called
+    ///         externally.
+    error CALLER_NOT_SELF(address caller);
+
+    // ---------------------------------------------------------------------
+    // Trusted remotes
+    // ---------------------------------------------------------------------
+
     error TRUSTED_REMOTE_NOT_SET();
     error REMOTE_NOT_TRUSTED();
-    error SEND_MESSAGE_TO_ADAPTER_FAILED(bytes reason);
+    error RECEIVER_ADDRESS_ZERO();
+
+    /// @notice Thrown by the deployment-time consistency helper when the
+    ///         adapter's trusted remote does not match the controller's
+    ///         configured `remoteAdapter` for the same chain.
+    error TRUSTED_REMOTE_MISMATCH(
+        uint256 chainId,
+        address trustedRemote,
+        address configuredRemoteAdapter
+    );
+
+    // ---------------------------------------------------------------------
+    // Chain id mapping
+    // ---------------------------------------------------------------------
+
+    /// @notice Thrown when a standard chain id has no bridge-native counterpart.
+    error UNKNOWN_CHAIN_ID(uint256 chainId);
+
+    /// @notice Thrown when a bridge-native chain id has no standard counterpart.
+    error UNKNOWN_NATIVE_CHAIN_ID(uint256 nativeChainId);
+
+    // ---------------------------------------------------------------------
+    // Fees
+    // ---------------------------------------------------------------------
+
+    /// @notice Thrown when the pre-funded fee balance is below the quoted fee.
+    /// @dev Distinct on purpose: ops alerts on exactly this to know when the
+    ///      fee-paying contract must be topped up.
+    error INSUFFICIENT_FEE_BALANCE(
+        address feeToken,
+        uint256 required,
+        uint256 available
+    );
+
+    error NOT_ENOUGH_TO_PAY_BRIDGE();
+
+    /// @notice Thrown when native value is sent while an ERC20 fee token is
+    ///         configured (the value would be stranded).
+    error UNEXPECTED_NATIVE_VALUE();
+
+    error NATIVE_TRANSFER_FAILED(address to, uint256 amount);
+
+    // ---------------------------------------------------------------------
+    // Defensive receive / retry
+    // ---------------------------------------------------------------------
+
+    /// @notice Thrown when retrying a call id that has no stored failed message.
+    error NO_FAILED_MESSAGE(bytes32 callId);
+
+    /// @notice Thrown when an inbound message reuses a call id that is already
+    ///         stored as failed and pending retry.
+    error MESSAGE_ALREADY_PENDING(bytes32 callId);
 }

--- a/test/common/crosschain/CCIPAdapter.t.sol
+++ b/test/common/crosschain/CCIPAdapter.t.sol
@@ -1,0 +1,695 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {
+    IAny2EVMMessageReceiver
+} from "@chainlink/contracts-ccip/contracts/interfaces/IAny2EVMMessageReceiver.sol";
+import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
+
+import {CCIPAdapter} from "../../../src/common/crosschain/adapters/CCIP/CCIPAdapter.sol";
+import {CrossChainController} from "../../../src/common/crosschain/CrossChainController.sol";
+import {Errors} from "../../../src/common/crosschain/lib/Errors.sol";
+import {DaoUnauthorized} from "../../../src/common/permission/auth/auth.sol";
+import {Action} from "../../../src/common/executors/IExecutor.sol";
+
+import {DAOMock} from "../../mocks/commons/dao/DAOMock.sol";
+import {ERC20Mock} from "../../mocks/commons/token/ERC20Mock.sol";
+import {CCIPRouterMock} from "../../mocks/commons/crosschain/CCIPRouterMock.sol";
+
+/// @notice Regression suite for `CCIPAdapter` (`src/common/crosschain/adapters/CCIP/CCIPAdapter.sol`)
+///         written against the just-hardened cross-chain adapter code.
+///
+/// Setup mirrors production wiring: a `DAOMock` owns a real `CrossChainController`,
+/// and the `CCIPAdapter` adopts that controller's DAO in its constructor
+/// (`BaseAdapter` -> `DaoAuthorizable`). The controller invokes the adapter with a
+/// plain `call`, so CCIP sees the ADAPTER as the message sender on the remote
+/// chain — `_trustedRemotes[chainId]` therefore holds the REMOTE ADAPTER address,
+/// which is exactly what `CrossChainController.chainToAdapter[chainId].remoteAdapter`
+/// stores for the local->remote lane.
+///
+/// Coverage locks in the security-review regressions:
+///  a) `_forwardMessage` is not externally callable (was `public` pre-hardening).
+///  b) `ccipReceive` caller / trusted-remote checks and the success path.
+///  c) chain-id <-> CCIP-selector mapping now reverts instead of silently
+///     mapping to chain `0`.
+///  d) `sendMessage` caller / receiver guards.
+///  e) fee handling: ERC20 fee approval (the missing-`forceApprove` bug),
+///     leftover-return, and native/ERC20 edge cases.
+///  f) config setters are permissioned and emit events.
+///  g) `assertTrustedRemotesMatchController` deployment sanity check.
+///  h) ERC-165 `supportsInterface`.
+///  i) an end-to-end send through `CrossChainController.forwardMessage`.
+contract CCIPAdapterTest is Test {
+    // -------------------------------------------------------------------------
+    // Real CCIP chain selectors / standard chain ids used throughout.
+    // -------------------------------------------------------------------------
+    uint64 internal constant SEL_ETH_MAINNET = 5009297550715157269;
+    uint64 internal constant SEL_BASE = 15971525489660198786;
+    uint64 internal constant SEL_ARBITRUM_ONE = 4949039107694359620;
+    uint64 internal constant SEL_SEPOLIA = 16015286601757825753;
+    uint64 internal constant SEL_BASE_SEPOLIA = 10344971235874465080;
+
+    uint256 internal constant CHAIN_ETH_MAINNET = 1;
+    uint256 internal constant CHAIN_BASE = 8453;
+    uint256 internal constant CHAIN_ARBITRUM_ONE = 42161;
+    uint256 internal constant CHAIN_SEPOLIA = 11155111;
+
+    // -------------------------------------------------------------------------
+    // Events re-declared locally so `vm.expectEmit` can match by signature.
+    // -------------------------------------------------------------------------
+    event FeeTokenSet(address feeToken);
+    event ChainSelectorSet(uint256 indexed chainId, uint64 chainSelector);
+    event TrustedRemoteSet(uint256 indexed chainId, address trustedRemote);
+    event MessageReceived(uint256 indexed originChainId, bytes32 indexed messageId, bytes32 indexed callId);
+
+    DAOMock internal daoMock;
+    CrossChainController internal controller;
+    CCIPRouterMock internal router;
+    ERC20Mock internal feeTokenErc20;
+    CCIPAdapter internal adapter;
+
+    address internal alice;
+    /// @dev The remote-chain ADAPTER address trusted for `CHAIN_ETH_MAINNET`.
+    address internal remoteAdapter;
+
+    function setUp() public {
+        alice = makeAddr("alice");
+        remoteAdapter = makeAddr("remoteAdapter");
+
+        daoMock = new DAOMock();
+        controller = new CrossChainController(address(daoMock));
+        router = new CCIPRouterMock();
+        feeTokenErc20 = new ERC20Mock("Fee Token", "FEE");
+
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ETH_MAINNET;
+        address[] memory trustedRemotes = new address[](1);
+        trustedRemotes[0] = remoteAdapter;
+
+        uint256[] memory selChainIds = new uint256[](3);
+        selChainIds[0] = CHAIN_ETH_MAINNET;
+        selChainIds[1] = CHAIN_BASE;
+        selChainIds[2] = CHAIN_ARBITRUM_ONE;
+        uint64[] memory selectors = new uint64[](3);
+        selectors[0] = SEL_ETH_MAINNET;
+        selectors[1] = SEL_BASE;
+        selectors[2] = SEL_ARBITRUM_ONE;
+
+        adapter = new CCIPAdapter(
+            address(controller),
+            address(router),
+            address(0), // native fee token by default
+            chainIds,
+            trustedRemotes,
+            selChainIds,
+            selectors
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /// @dev `DAOMock.hasPermission` is a single flag that authorizes EVERY
+    ///      permission once toggled; only flip it inside tests that need it.
+    function _grantAllPermissions() internal {
+        daoMock.setHasPermissionReturnValueMock(true);
+    }
+
+    function _setFeeToken(address token) internal {
+        _grantAllPermissions();
+        adapter.setFeeToken(token);
+    }
+
+    /// @dev Registers `localAdapter`/`remote` as the controller's adapter pair
+    ///      for `chainId`, granting the adapter the right to call
+    ///      `receiveMessage` and enabling `forwardMessage`/`quoteFee` for it.
+    function _registerLane(uint256 chainId, address localAdapter, address remote) internal {
+        _grantAllPermissions();
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = chainId;
+        CrossChainController.AdapterByChain[] memory pairs = new CrossChainController.AdapterByChain[](1);
+        pairs[0] = CrossChainController.AdapterByChain({localAdapter: localAdapter, remoteAdapter: remote});
+        controller.updateConfig(ids, pairs);
+    }
+
+    function _buildInbound(
+        uint64 selector,
+        address sender,
+        bytes memory data
+    ) internal pure returns (Client.Any2EVMMessage memory) {
+        return
+            Client.Any2EVMMessage({
+                messageId: keccak256("default-inbound-message"),
+                sourceChainSelector: selector,
+                sender: abi.encode(sender),
+                data: data,
+                destTokenAmounts: new Client.EVMTokenAmount[](0)
+            });
+    }
+
+    // =========================================================================
+    // a) `_forwardMessage` must not be externally callable.
+    // =========================================================================
+
+    /// @dev The pre-hardening code had `_forwardMessage` `public`, letting
+    ///      anyone inject an arbitrary payload/origin chain straight into the
+    ///      controller's `receiveMessage`, bypassing both the `onlyRouter`
+    ///      check and the trusted-remote check in `ccipReceive`. It is now
+    ///      `internal` on `BaseAdapter`; `adapter._forwardMessage(...)` does
+    ///      not even compile from outside the contract, and there is no
+    ///      selector for it in the adapter's ABI. This test proves the
+    ///      low-level fallback path is closed too: a raw call with the old
+    ///      function's signature does not reach any code (the adapter has no
+    ///      fallback function), so it must simply fail.
+    function test_forwardMessage_isNotExternallyCallable() public {
+        (bool success, bytes memory returndata) = address(adapter).call(
+            abi.encodeWithSignature(
+                "_forwardMessage(bytes32,bytes,uint256)",
+                bytes32(0),
+                bytes(""),
+                CHAIN_ETH_MAINNET
+            )
+        );
+
+        assertFalse(success, "_forwardMessage must not be externally callable");
+        assertEq(returndata.length, 0, "no fallback exists to handle the unmatched selector");
+    }
+
+    // =========================================================================
+    // b) `ccipReceive`
+    // =========================================================================
+
+    function test_ccipReceive_revertsIfCallerNotRouter() public {
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteAdapter, "");
+
+        vm.expectRevert(Errors.CALLER_NOT_CCIP_ROUTER.selector);
+        vm.prank(alice);
+        adapter.ccipReceive(message);
+    }
+
+    function test_ccipReceive_revertsIfDecodedSenderIsZero() public {
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, address(0), "");
+
+        vm.expectRevert(Errors.REMOTE_NOT_TRUSTED.selector);
+        vm.prank(address(router));
+        adapter.ccipReceive(message);
+    }
+
+    function test_ccipReceive_revertsIfSenderNotConfiguredTrustedRemote() public {
+        address untrusted = makeAddr("untrusted");
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, untrusted, "");
+
+        vm.expectRevert(Errors.REMOTE_NOT_TRUSTED.selector);
+        vm.prank(address(router));
+        adapter.ccipReceive(message);
+    }
+
+    function test_ccipReceive_succeedsForTrustedRemoteAndForwardsToController() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
+
+        Action[] memory actions = new Action[](0);
+        bytes memory payload = abi.encode(actions);
+        bytes32 messageId = keccak256("msg-1");
+
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteAdapter, payload);
+        message.messageId = messageId;
+
+        bytes32 expectedCallId = controller.deriveCallId(CHAIN_ETH_MAINNET, messageId);
+
+        vm.expectEmit(true, true, true, true, address(controller));
+        emit MessageReceived(CHAIN_ETH_MAINNET, messageId, expectedCallId);
+
+        vm.prank(address(router));
+        adapter.ccipReceive(message);
+    }
+
+    // =========================================================================
+    // c) chain-id <-> selector mapping
+    // =========================================================================
+
+    function test_toNativeChainId_returnsConfiguredSelector() public view {
+        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_ETH_MAINNET));
+    }
+
+    function test_toNativeChainId_revertsForUnmappedChain() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, uint256(999)));
+        adapter.toNativeChainId(999);
+    }
+
+    function test_fromNativeChainId_isExactInverseOfToNativeChainId() public view {
+        assertEq(adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET)), CHAIN_ETH_MAINNET);
+        assertEq(adapter.fromNativeChainId(uint256(SEL_BASE)), CHAIN_BASE);
+        assertEq(adapter.fromNativeChainId(uint256(SEL_ARBITRUM_ONE)), CHAIN_ARBITRUM_ONE);
+    }
+
+    function test_fromNativeChainId_revertsForUnmappedSelector() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_SEPOLIA)));
+        adapter.fromNativeChainId(uint256(SEL_SEPOLIA));
+    }
+
+    function test_chainIdMapping_roundTripsOverSeveralConfiguredChains() public view {
+        uint256[3] memory chains = [CHAIN_ETH_MAINNET, CHAIN_BASE, CHAIN_ARBITRUM_ONE];
+        for (uint256 i = 0; i < chains.length; i++) {
+            assertEq(adapter.fromNativeChainId(adapter.toNativeChainId(chains[i])), chains[i]);
+        }
+    }
+
+    /// @dev A message arriving from a selector that was never mapped to a
+    ///      standard chain id must revert, not be silently treated as
+    ///      originating from chain `0`.
+    function test_ccipReceive_revertsForUnmappedSourceSelector() public {
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_SEPOLIA, remoteAdapter, "");
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_SEPOLIA)));
+        vm.prank(address(router));
+        adapter.ccipReceive(message);
+    }
+
+    function test_setChainSelectors_repointingChainClearsOldReverseMapping() public {
+        _grantAllPermissions();
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = SEL_BASE_SEPOLIA;
+        adapter.setChainSelectors(ids, sels);
+
+        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_BASE_SEPOLIA));
+        assertEq(adapter.fromNativeChainId(uint256(SEL_BASE_SEPOLIA)), CHAIN_ETH_MAINNET);
+
+        // The old selector's reverse entry must be cleared, not left dangling
+        // (which would let a message with the stale selector be misattributed).
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_ETH_MAINNET)));
+        adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET));
+    }
+
+    function test_setChainSelectors_zeroSelectorClearsLaneBothDirections() public {
+        _grantAllPermissions();
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = 0;
+        adapter.setChainSelectors(ids, sels);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, CHAIN_ETH_MAINNET));
+        adapter.toNativeChainId(CHAIN_ETH_MAINNET);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_ETH_MAINNET)));
+        adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET));
+    }
+
+    // =========================================================================
+    // d) `sendMessage` caller / receiver guards
+    // =========================================================================
+
+    function test_sendMessage_revertsIfCallerNotController() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_CROSS_CHAIN_CONTROLLER.selector, alice));
+        vm.prank(alice);
+        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_sendMessage_revertsIfReceiverIsZero() public {
+        vm.expectRevert(Errors.RECEIVER_ADDRESS_ZERO.selector);
+        vm.prank(address(controller));
+        adapter.sendMessage(address(0), 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    // =========================================================================
+    // e) Fees
+    // =========================================================================
+
+    /// @dev Regression test for the missing `forceApprove`: the old adapter
+    ///      never approved the router, so `CCIPRouterMock.ccipSend`'s
+    ///      `transferFrom` pull would revert on zero allowance. This test only
+    ///      passes if the adapter actually approves the router first.
+    function test_sendMessage_erc20Fee_approvesRouterAndRouterPullsExactFee() public {
+        _setFeeToken(address(feeTokenErc20));
+        uint256 feeAmount = 3 ether;
+        router.setFee(feeAmount);
+        feeTokenErc20.setBalance(address(adapter), feeAmount);
+
+        vm.prank(address(controller));
+        bytes32 messageId = adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "hello");
+
+        assertEq(router.ccipSendCallCount(), 1);
+        assertEq(feeTokenErc20.balanceOf(address(router)), feeAmount, "router must have pulled the fee");
+        assertEq(messageId, router.nextMessageId());
+    }
+
+    function test_sendMessage_erc20Fee_leavesZeroStandingAllowanceAfterSend() public {
+        _setFeeToken(address(feeTokenErc20));
+        uint256 feeAmount = 3 ether;
+        router.setFee(feeAmount);
+        feeTokenErc20.setBalance(address(adapter), feeAmount);
+
+        vm.prank(address(controller));
+        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+
+        assertEq(feeTokenErc20.allowance(address(adapter), address(router)), 0);
+    }
+
+    function test_sendMessage_erc20Fee_returnsLeftoverBalanceToController() public {
+        _setFeeToken(address(feeTokenErc20));
+        uint256 feeAmount = 3 ether;
+        uint256 extra = 1 ether;
+        router.setFee(feeAmount);
+        feeTokenErc20.setBalance(address(adapter), feeAmount + extra);
+
+        vm.prank(address(controller));
+        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+
+        assertEq(feeTokenErc20.balanceOf(address(adapter)), 0, "adapter must not retain custody");
+        assertEq(feeTokenErc20.balanceOf(address(controller)), extra, "leftover must return to controller");
+    }
+
+    function test_sendMessage_erc20Fee_revertsIfInsufficientBalance() public {
+        _setFeeToken(address(feeTokenErc20));
+        uint256 feeAmount = 1 ether;
+        uint256 available = 0.4 ether;
+        router.setFee(feeAmount);
+        feeTokenErc20.setBalance(address(adapter), available);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.INSUFFICIENT_FEE_BALANCE.selector,
+                address(feeTokenErc20),
+                feeAmount,
+                available
+            )
+        );
+        vm.prank(address(controller));
+        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_sendMessage_revertsIfNativeValueSentWhileErc20FeeTokenConfigured() public {
+        _setFeeToken(address(feeTokenErc20));
+        vm.deal(address(controller), 1 ether);
+
+        vm.expectRevert(Errors.UNEXPECTED_NATIVE_VALUE.selector);
+        vm.prank(address(controller));
+        adapter.sendMessage{value: 1 ether}(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_sendMessage_nativeFee_paysExactFeeAndReturnsLeftoverToController() public {
+        // Adapter defaults to native (address(0)) fee token from setUp.
+        uint256 feeAmount = 0.05 ether;
+        uint256 extra = 0.01 ether;
+        router.setFee(feeAmount);
+
+        // Simulate a stray pre-existing native balance on the adapter, on top
+        // of the exact fee the controller hands over as `msg.value`.
+        vm.deal(address(adapter), extra);
+        vm.deal(address(controller), feeAmount);
+
+        vm.prank(address(controller));
+        adapter.sendMessage{value: feeAmount}(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+
+        assertEq(router.lastMsgValue(), feeAmount, "router must receive exactly the quoted fee");
+        assertEq(address(adapter).balance, 0, "adapter must not retain custody");
+        assertEq(address(controller).balance, extra, "leftover must return to controller");
+    }
+
+    function test_sendMessage_nativeFee_revertsIfInsufficientBalance() public {
+        uint256 feeAmount = 1 ether;
+        uint256 available = 0.5 ether;
+        router.setFee(feeAmount);
+        vm.deal(address(controller), available);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(0), feeAmount, available)
+        );
+        vm.prank(address(controller));
+        adapter.sendMessage{value: available}(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_quoteFee_revertsIfReceiverIsZero() public {
+        vm.expectRevert(Errors.RECEIVER_ADDRESS_ZERO.selector);
+        adapter.quoteFee(address(0), 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_quoteFee_returnsRouterQuoteAndConfiguredFeeToken() public {
+        _setFeeToken(address(feeTokenErc20));
+        router.setFee(7 ether);
+
+        (address feeToken, uint256 fee) = adapter.quoteFee(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+
+        assertEq(feeToken, address(feeTokenErc20));
+        assertEq(fee, 7 ether);
+    }
+
+    // =========================================================================
+    // f) Config setters: permissioned + emit events
+    // =========================================================================
+
+    function test_setFeeToken_revertsIfUnauthorized() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(adapter),
+                alice,
+                adapter.UPDATE_ADAPTER_CONFIG_PERMISSION_ID()
+            )
+        );
+        vm.prank(alice);
+        adapter.setFeeToken(address(feeTokenErc20));
+    }
+
+    function test_setFeeToken_emitsEventAndUpdatesStorage() public {
+        _grantAllPermissions();
+
+        vm.expectEmit(true, true, true, true, address(adapter));
+        emit FeeTokenSet(address(feeTokenErc20));
+        adapter.setFeeToken(address(feeTokenErc20));
+
+        assertEq(adapter.feeToken(), address(feeTokenErc20));
+    }
+
+    function test_setChainSelectors_revertsIfUnauthorized() public {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_SEPOLIA;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = SEL_SEPOLIA;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(adapter),
+                alice,
+                adapter.UPDATE_ADAPTER_CONFIG_PERMISSION_ID()
+            )
+        );
+        vm.prank(alice);
+        adapter.setChainSelectors(ids, sels);
+    }
+
+    function test_setChainSelectors_emitsEventAndUpdatesStorage() public {
+        _grantAllPermissions();
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_SEPOLIA;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = SEL_SEPOLIA;
+
+        vm.expectEmit(true, true, true, true, address(adapter));
+        emit ChainSelectorSet(CHAIN_SEPOLIA, SEL_SEPOLIA);
+        adapter.setChainSelectors(ids, sels);
+
+        assertEq(adapter.toNativeChainId(CHAIN_SEPOLIA), uint256(SEL_SEPOLIA));
+    }
+
+    function test_setTrustedRemotes_revertsIfUnauthorized() public {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        address[] memory remotes = new address[](1);
+        remotes[0] = makeAddr("newRemote");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(adapter),
+                alice,
+                adapter.UPDATE_ADAPTER_CONFIG_PERMISSION_ID()
+            )
+        );
+        vm.prank(alice);
+        adapter.setTrustedRemotes(ids, remotes);
+    }
+
+    function test_setTrustedRemotes_emitsEventAndUpdatesStorage() public {
+        _grantAllPermissions();
+
+        address newRemote = makeAddr("newRemote");
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        address[] memory remotes = new address[](1);
+        remotes[0] = newRemote;
+
+        vm.expectEmit(true, true, true, true, address(adapter));
+        emit TrustedRemoteSet(CHAIN_ETH_MAINNET, newRemote);
+        adapter.setTrustedRemotes(ids, remotes);
+
+        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), newRemote);
+    }
+
+    function test_trustedRemote_returnsZeroForUnsetChain() public view {
+        assertEq(adapter.trustedRemote(CHAIN_BASE), address(0));
+    }
+
+    // =========================================================================
+    // g) `assertTrustedRemotesMatchController`
+    // =========================================================================
+
+    function test_assertTrustedRemotesMatchController_passesWhenBothSidesAgree() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        adapter.assertTrustedRemotesMatchController(ids); // must not revert
+    }
+
+    function test_assertTrustedRemotesMatchController_revertsWhenMismatched() public {
+        address controllerConfiguredRemote = makeAddr("controllerConfiguredRemote");
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), controllerConfiguredRemote);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.TRUSTED_REMOTE_MISMATCH.selector,
+                CHAIN_ETH_MAINNET,
+                remoteAdapter,
+                controllerConfiguredRemote
+            )
+        );
+        adapter.assertTrustedRemotesMatchController(ids);
+    }
+
+    function test_assertTrustedRemotesMatchController_revertsWhenControllerLaneUnconfigured() public {
+        // No `updateConfig` call: the controller's `remoteAdapter` for this
+        // chain stays `address(0)` while the adapter already trusts `remoteAdapter`.
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.TRUSTED_REMOTE_MISMATCH.selector, CHAIN_ETH_MAINNET, remoteAdapter, address(0))
+        );
+        adapter.assertTrustedRemotesMatchController(ids);
+    }
+
+    // =========================================================================
+    // h) ERC-165
+    // =========================================================================
+
+    function test_supportsInterface_IAny2EVMMessageReceiver() public view {
+        assertTrue(adapter.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId));
+    }
+
+    function test_supportsInterface_IERC165() public view {
+        assertTrue(adapter.supportsInterface(type(IERC165).interfaceId));
+    }
+
+    function test_supportsInterface_returnsFalseForUnknownInterface() public view {
+        assertFalse(adapter.supportsInterface(0xdeadbeef));
+    }
+
+    // =========================================================================
+    // i) End-to-end-ish: controller.forwardMessage -> adapter.sendMessage -> router
+    // =========================================================================
+
+    function test_forwardMessage_endToEnd_routesThroughAdapterToRouter() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
+
+        uint256 feeAmount = 0.02 ether;
+        router.setFee(feeAmount);
+        vm.deal(address(controller), feeAmount);
+
+        bytes32 expectedMessageId = keccak256("expected-message-id");
+        router.setNextMessageId(expectedMessageId);
+
+        Action[] memory actions = new Action[](0);
+        bytes memory payload = abi.encode(actions);
+        uint256 gasLimit = 300_000;
+
+        bytes32 messageId = controller.forwardMessage(CHAIN_ETH_MAINNET, gasLimit, payload);
+
+        assertEq(messageId, expectedMessageId, "controller must surface the router's messageId");
+
+        address decodedReceiver = abi.decode(router.lastReceiver(), (address));
+        assertEq(decodedReceiver, remoteAdapter, "router must target the remote adapter");
+        assertEq(router.lastData(), payload);
+        assertEq(router.lastFeeToken(), address(0));
+        assertEq(router.lastDestChainSelector(), SEL_ETH_MAINNET);
+        assertEq(router.lastMsgValue(), feeAmount);
+
+        bytes memory expectedExtraArgs = Client._argsToBytes(
+            Client.GenericExtraArgsV2({gasLimit: gasLimit, allowOutOfOrderExecution: true})
+        );
+        assertEq(router.lastExtraArgs(), expectedExtraArgs, "extraArgs must encode the requested gas limit");
+    }
+
+    // =========================================================================
+    // Constructor validation (bonus coverage)
+    // =========================================================================
+
+    function test_constructor_revertsIfRouterIsZeroAddress() public {
+        uint256[] memory empty;
+        address[] memory emptyAddr;
+
+        vm.expectRevert(Errors.ZERO_ADDRESS.selector);
+        new CCIPAdapter(address(controller), address(0), address(0), empty, emptyAddr, empty, new uint64[](0));
+    }
+
+    function test_constructor_revertsOnTrustedRemoteLengthMismatch() public {
+        uint256[] memory chainIds = new uint256[](2);
+        chainIds[0] = CHAIN_ETH_MAINNET;
+        chainIds[1] = CHAIN_BASE;
+        address[] memory remotes = new address[](1);
+        remotes[0] = remoteAdapter;
+
+        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
+        new CCIPAdapter(
+            address(controller),
+            address(router),
+            address(0),
+            chainIds,
+            remotes,
+            new uint256[](0),
+            new uint64[](0)
+        );
+    }
+
+    function test_constructor_revertsOnSelectorLengthMismatch() public {
+        uint256[] memory selChainIds = new uint256[](2);
+        selChainIds[0] = CHAIN_ETH_MAINNET;
+        selChainIds[1] = CHAIN_BASE;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = SEL_ETH_MAINNET;
+
+        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
+        new CCIPAdapter(
+            address(controller),
+            address(router),
+            address(0),
+            new uint256[](0),
+            new address[](0),
+            selChainIds,
+            sels
+        );
+    }
+
+    function test_constructor_wiresUpConfiguredTrustedRemoteAndSelector() public view {
+        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), remoteAdapter);
+        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_ETH_MAINNET));
+    }
+}

--- a/test/common/crosschain/CrossChainController.t.sol
+++ b/test/common/crosschain/CrossChainController.t.sol
@@ -1,0 +1,630 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {CrossChainController} from "../../../src/common/crosschain/CrossChainController.sol";
+import {Errors} from "../../../src/common/crosschain/lib/Errors.sol";
+import {Action} from "../../../src/common/executors/IExecutor.sol";
+import {DaoUnauthorized} from "../../../src/common/permission/auth/auth.sol";
+import {AdapterMock} from "../../mocks/commons/crosschain/AdapterMock.sol";
+import {CrossChainControllerDAOMock} from "../../mocks/commons/crosschain/CrossChainControllerDAOMock.sol";
+import {ERC20Mock} from "../../mocks/commons/token/ERC20Mock.sol";
+import {ActionExecute} from "../../mocks/commons/executors/ActionExecute.sol";
+
+/// @notice Regression suite for the hardened `CrossChainController`
+///         (`src/common/crosschain/CrossChainController.sol`).
+///
+/// Every test here targets a specific finding from the security review and is
+/// written to genuinely FAIL against the pre-hardening version of the
+/// contract:
+///  - `receiveMessage` inbound authentication (only a registered local
+///    adapter may call it) and correct refcounted adapter rotation.
+///  - `updateConfig` input validation (length mismatch, chain id 0,
+///    half-configured lanes) and its `ConfigUpdated` event payload.
+///  - The "silent no-op" footgun: `forwardMessage` to an unconfigured chain
+///    or to a codeless local adapter must revert, not silently succeed.
+///  - Fee custody: exact fee amounts moved for both ERC20 and native, and
+///    `INSUFFICIENT_FEE_BALANCE` when underfunded.
+///  - The defensive `try/catch` around inbound execution: a reverting or
+///    malformed payload is captured as a `FailedMessage` instead of
+///    reverting message delivery, and can later be retried.
+///  - `executeActions`'s `CALLER_NOT_SELF` self-call guard.
+///  - `sweep`'s auth check and zero-address guard.
+///  - `deriveCallId` determinism.
+contract CrossChainControllerTest is Test {
+    // Solc 0.8.17 (this repo's pinned version) cannot `emit Contract.Event(...)`
+    // for an externally-defined event, so the events under test are
+    // redeclared here with identical signatures purely so `vm.expectEmit`
+    // has something to match topics/data against (topic0 only depends on the
+    // signature, not on which contract declares it).
+    event ConfigUpdated(uint256 indexed chainId, address localAdapter, address remoteAdapter);
+    event MessageForwarded(
+        uint256 indexed destinationChainId,
+        bytes32 indexed messageId,
+        address indexed localAdapter,
+        address remoteAdapter,
+        uint256 gasLimit,
+        address feeToken,
+        uint256 fee
+    );
+    event MessageExecutionFailed(
+        uint256 indexed originChainId, bytes32 indexed messageId, bytes32 indexed callId, bytes reason
+    );
+    event MessageRetried(bytes32 indexed callId);
+    event Swept(address indexed token, address indexed to, uint256 amount);
+
+    uint256 internal constant CHAIN_ID = 10;
+    uint256 internal constant OTHER_CHAIN_ID = 20;
+    uint256 internal constant GAS_LIMIT = 200_000;
+
+    CrossChainControllerDAOMock internal daoMock;
+    CrossChainController internal controller;
+    AdapterMock internal adapterA;
+    AdapterMock internal adapterB;
+    ERC20Mock internal feeToken;
+    ActionExecute internal actionTarget;
+
+    address internal remoteAdapterA;
+    address internal remoteAdapterB;
+    address internal alice; // holds every permission
+    address internal bob; // holds none
+
+    bytes32 internal FORWARD_MESSAGE_PERMISSION_ID;
+    bytes32 internal UPDATE_CONFIG_PERMISSION_ID;
+    bytes32 internal RETRY_MESSAGE_PERMISSION_ID;
+    bytes32 internal SWEEP_PERMISSION_ID;
+
+    function setUp() public {
+        daoMock = new CrossChainControllerDAOMock();
+        controller = new CrossChainController(address(daoMock));
+
+        adapterA = new AdapterMock(address(controller));
+        adapterB = new AdapterMock(address(controller));
+        feeToken = new ERC20Mock("Fee", "FEE");
+        actionTarget = new ActionExecute();
+
+        remoteAdapterA = makeAddr("remoteAdapterA");
+        remoteAdapterB = makeAddr("remoteAdapterB");
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+
+        FORWARD_MESSAGE_PERMISSION_ID = controller.FORWARD_MESSAGE_PERMISSION_ID();
+        UPDATE_CONFIG_PERMISSION_ID = controller.UPDATE_CONFIG_PERMISSION_ID();
+        RETRY_MESSAGE_PERMISSION_ID = controller.RETRY_MESSAGE_PERMISSION_ID();
+        SWEEP_PERMISSION_ID = controller.SWEEP_PERMISSION_ID();
+
+        daoMock.setHasPermission(address(controller), alice, FORWARD_MESSAGE_PERMISSION_ID, true);
+        daoMock.setHasPermission(address(controller), alice, UPDATE_CONFIG_PERMISSION_ID, true);
+        daoMock.setHasPermission(address(controller), alice, RETRY_MESSAGE_PERMISSION_ID, true);
+        daoMock.setHasPermission(address(controller), alice, SWEEP_PERMISSION_ID, true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    function _lane(address _local, address _remote) internal pure returns (CrossChainController.AdapterByChain memory) {
+        return CrossChainController.AdapterByChain({localAdapter: _local, remoteAdapter: _remote});
+    }
+
+    function _configureLane(uint256 _chainId, address _local, address _remote) internal {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = _chainId;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(_local, _remote);
+
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function _emptyActionsPayload() internal pure returns (bytes memory) {
+        return abi.encode(new Action[](0));
+    }
+
+    // -------------------------------------------------------------------------
+    // a) receiveMessage inbound authentication
+    // -------------------------------------------------------------------------
+
+    function test_receiveMessage_revertsForCallerNotLocalAdapter() public {
+        address random = makeAddr("random");
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, random));
+        vm.prank(random);
+        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
+    }
+
+    function test_receiveMessage_revertsForUnregisteredContract() public {
+        // A deployed contract that was never configured as a lane's local
+        // adapter is just as unauthorized as an EOA.
+        AdapterMock strangerAdapter = new AdapterMock(address(controller));
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(strangerAdapter)));
+        vm.prank(address(strangerAdapter));
+        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
+    }
+
+    function test_receiveMessage_succeedsForRegisteredLocalAdapter() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        bytes32 messageId = bytes32(uint256(42));
+        vm.prank(address(adapterA));
+        bytes32 callId = controller.receiveMessage(messageId, _emptyActionsPayload(), CHAIN_ID);
+
+        assertEq(callId, controller.deriveCallId(CHAIN_ID, messageId));
+    }
+
+    function test_receiveMessage_revertsIfMessageAlreadyPending() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        Action[] memory actions = new Action[](1);
+        actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
+        bytes memory payload = abi.encode(actions);
+
+        bytes32 messageId = bytes32(uint256(7));
+        bytes32 callId = controller.deriveCallId(CHAIN_ID, messageId);
+
+        vm.prank(address(adapterA));
+        controller.receiveMessage(messageId, payload, CHAIN_ID);
+        assertTrue(controller.getFailedMessage(callId).pending);
+
+        // Redelivering the same (originChainId, messageId) while the first
+        // attempt is still pending must revert, not overwrite/duplicate it.
+        vm.expectRevert(abi.encodeWithSelector(Errors.MESSAGE_ALREADY_PENDING.selector, callId));
+        vm.prank(address(adapterA));
+        controller.receiveMessage(messageId, payload, CHAIN_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // b) Adapter rotation / refcounting
+    // -------------------------------------------------------------------------
+
+    function test_updateConfig_rotatingLocalAdapterRevokesOldAdapter() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        vm.prank(address(adapterA));
+        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
+
+        // Rotate the lane to adapterB.
+        _configureLane(CHAIN_ID, address(adapterB), remoteAdapterB);
+
+        assertFalse(controller.isRegisteredLocalAdapter(address(adapterA)));
+        assertEq(controller.localAdapterLaneCount(address(adapterA)), 0);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(adapterA)));
+        vm.prank(address(adapterA));
+        controller.receiveMessage(bytes32(uint256(2)), _emptyActionsPayload(), CHAIN_ID);
+
+        // The new adapter works.
+        vm.prank(address(adapterB));
+        controller.receiveMessage(bytes32(uint256(3)), _emptyActionsPayload(), CHAIN_ID);
+    }
+
+    function test_updateConfig_refcountKeepsAdapterAuthorizedUntilBothLanesCleared() public {
+        // adapterA serves two lanes.
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(OTHER_CHAIN_ID, address(adapterA), remoteAdapterB);
+
+        assertEq(controller.localAdapterLaneCount(address(adapterA)), 2);
+        assertTrue(controller.isRegisteredLocalAdapter(address(adapterA)));
+
+        // Clear the first lane only; adapterA must remain authorized.
+        _configureLane(CHAIN_ID, address(0), address(0));
+
+        assertEq(controller.localAdapterLaneCount(address(adapterA)), 1);
+        assertTrue(controller.isRegisteredLocalAdapter(address(adapterA)));
+
+        vm.prank(address(adapterA));
+        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), OTHER_CHAIN_ID);
+
+        // Clear the second (last) lane; adapterA now loses authorization.
+        _configureLane(OTHER_CHAIN_ID, address(0), address(0));
+
+        assertEq(controller.localAdapterLaneCount(address(adapterA)), 0);
+        assertFalse(controller.isRegisteredLocalAdapter(address(adapterA)));
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(adapterA)));
+        vm.prank(address(adapterA));
+        controller.receiveMessage(bytes32(uint256(2)), _emptyActionsPayload(), OTHER_CHAIN_ID);
+    }
+
+    function test_updateConfig_clearingLaneWithZeroPairResetsMapping() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(0), address(0));
+
+        (address local, address remote) = controller.chainToAdapter(CHAIN_ID);
+        assertEq(local, address(0));
+        assertEq(remote, address(0));
+
+        // A cleared lane is "unconfigured" again for sends.
+        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    // -------------------------------------------------------------------------
+    // c) updateConfig validation
+    // -------------------------------------------------------------------------
+
+    function test_updateConfig_revertsOnLengthMismatch() public {
+        uint256[] memory chainIds = new uint256[](2);
+        chainIds[0] = CHAIN_ID;
+        chainIds[1] = OTHER_CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+
+        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_revertsOnZeroChainId() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = 0;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+
+        vm.expectRevert(Errors.INVALID_CHAIN_ID.selector);
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_revertsOnHalfConfiguredLane_missingRemote() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), address(0));
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_revertsOnHalfConfiguredLane_missingLocal() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(0), remoteAdapterA);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_revertsIfCallerUnauthorized() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, UPDATE_CONFIG_PERMISSION_ID)
+        );
+        vm.prank(bob);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_emitsConfigUpdatedWithCorrectPayload() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+
+        vm.expectEmit(true, false, false, true, address(controller));
+        emit ConfigUpdated(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    // -------------------------------------------------------------------------
+    // d) forwardMessage silent no-op guards
+    // -------------------------------------------------------------------------
+
+    function test_forwardMessage_revertsIfChainNotConfigured() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_revertsIfLocalAdapterHasNoCode() public {
+        address codelessAdapter = makeAddr("codelessAdapter");
+        address codelessRemote = makeAddr("codelessRemote");
+        _configureLane(CHAIN_ID, codelessAdapter, codelessRemote);
+
+        assertEq(codelessAdapter.code.length, 0);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_HAS_NO_CODE.selector, codelessAdapter));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    // -------------------------------------------------------------------------
+    // e) forwardMessage auth + happy path
+    // -------------------------------------------------------------------------
+
+    function test_forwardMessage_revertsIfCallerUnauthorized() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, FORWARD_MESSAGE_PERMISSION_ID)
+        );
+        vm.prank(bob);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_happyPathEmitsMessageForwardedAndReturnsMessageId() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        adapterA.setFee(address(0), 0); // no fee due, no funding required
+        bytes32 expectedMessageId = bytes32(uint256(999));
+        adapterA.setMessageId(expectedMessageId);
+
+        bytes memory message = abi.encode("hello");
+
+        vm.expectEmit(true, true, true, true, address(controller));
+        emit MessageForwarded(
+            CHAIN_ID, expectedMessageId, address(adapterA), remoteAdapterA, GAS_LIMIT, address(0), 0
+        );
+
+        vm.prank(alice);
+        bytes32 messageId = controller.forwardMessage(CHAIN_ID, GAS_LIMIT, message);
+
+        assertEq(messageId, expectedMessageId);
+        assertEq(adapterA.lastReceiver(), remoteAdapterA);
+        assertEq(adapterA.lastGasLimit(), GAS_LIMIT);
+        assertEq(adapterA.lastDestinationChainId(), CHAIN_ID);
+        assertEq(adapterA.lastMessage(), message);
+        assertEq(adapterA.sendMessageCallCount(), 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // f) Fees
+    // -------------------------------------------------------------------------
+
+    function test_forwardMessage_erc20Fee_revertsIfControllerBalanceInsufficient() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        adapterA.setFee(address(feeToken), 100 ether);
+        // Controller holds 0 of feeToken.
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(feeToken), 100 ether, 0));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_erc20Fee_transfersExactFeeToAdapterWhenFunded() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        uint256 requiredFee = 100 ether;
+        adapterA.setFee(address(feeToken), requiredFee);
+        feeToken.setBalance(address(controller), requiredFee + 1 ether); // extra buffer left untouched
+
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+
+        assertEq(feeToken.balanceOf(address(adapterA)), requiredFee);
+        assertEq(feeToken.balanceOf(address(controller)), 1 ether);
+    }
+
+    function test_forwardMessage_nativeFee_revertsIfControllerBalanceInsufficient() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        adapterA.setFee(address(0), 1 ether);
+        // Controller holds 0 native.
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(0), 1 ether, 0));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_nativeFee_forwardsExactFeeWeiToAdapterWhenFunded() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        uint256 requiredFee = 1 ether;
+        adapterA.setFee(address(0), requiredFee);
+        vm.deal(address(controller), requiredFee + 3 ether);
+
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+
+        assertEq(address(adapterA).balance, requiredFee);
+        assertEq(address(controller).balance, 3 ether);
+        assertEq(adapterA.lastValueReceived(), requiredFee);
+    }
+
+    // -------------------------------------------------------------------------
+    // g) Defensive receive / retry
+    // -------------------------------------------------------------------------
+
+    function test_receiveMessage_capturesRevertingPayloadInsteadOfReverting() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        Action[] memory actions = new Action[](1);
+        actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
+        bytes memory payload = abi.encode(actions);
+
+        bytes32 messageId = bytes32(uint256(55));
+        bytes32 expectedCallId = controller.deriveCallId(CHAIN_ID, messageId);
+        // `CrossChainControllerDAOMock.execute` bubbles the low-level call's
+        // raw returndata on failure, which is `ActionExecute.fail`'s
+        // `Error(string)`-encoded revert reason.
+        bytes memory expectedReason = abi.encodeWithSignature("Error(string)", "ActionExecute:Revert");
+
+        vm.expectEmit(true, true, true, true, address(controller));
+        emit MessageExecutionFailed(CHAIN_ID, messageId, expectedCallId, expectedReason);
+
+        vm.prank(address(adapterA));
+        bytes32 callId = controller.receiveMessage(messageId, payload, CHAIN_ID); // must NOT revert
+        assertEq(callId, expectedCallId);
+
+        CrossChainController.FailedMessage memory failed = controller.getFailedMessage(callId);
+        assertTrue(failed.pending);
+        assertEq(failed.originChainId, CHAIN_ID);
+        assertEq(failed.messageId, messageId);
+        assertEq(failed.payload, payload);
+    }
+
+    function test_receiveMessage_capturesMalformedPayloadInsteadOfReverting() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        // Not a valid ABI-encoding of `Action[]`.
+        bytes memory garbage = hex"deadbeef";
+
+        bytes32 messageId = bytes32(uint256(56));
+        bytes32 expectedCallId = controller.deriveCallId(CHAIN_ID, messageId);
+
+        // Only check the indexed topics here (origin/message/call id); the
+        // exact revert bytes produced by a failed `abi.decode` are an
+        // implementation/compiler detail we don't want to pin.
+        vm.expectEmit(true, true, true, false, address(controller));
+        emit MessageExecutionFailed(CHAIN_ID, messageId, expectedCallId, "");
+
+        vm.prank(address(adapterA));
+        bytes32 callId = controller.receiveMessage(messageId, garbage, CHAIN_ID); // must NOT revert
+        assertEq(callId, expectedCallId);
+        assertTrue(controller.getFailedMessage(callId).pending);
+    }
+
+    function test_retryFailedMessage_revertsIfCallerUnauthorized() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        bytes32 callId = _causeFailure(bytes32(uint256(60)));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, RETRY_MESSAGE_PERMISSION_ID)
+        );
+        vm.prank(bob);
+        controller.retryFailedMessage(callId);
+    }
+
+    function test_retryFailedMessage_revertsForUnknownCallId() public {
+        bytes32 unknownCallId = keccak256("nope");
+        vm.expectRevert(abi.encodeWithSelector(Errors.NO_FAILED_MESSAGE.selector, unknownCallId));
+        vm.prank(alice);
+        controller.retryFailedMessage(unknownCallId);
+    }
+
+    function test_retryFailedMessage_succeedsOnceFailureConditionRemoved() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        FlakyTarget flaky = new FlakyTarget();
+        Action[] memory actions = new Action[](1);
+        actions[0] = Action({to: address(flaky), value: 0, data: abi.encodeCall(FlakyTarget.maybeRevert, ())});
+        bytes memory payload = abi.encode(actions);
+
+        bytes32 messageId = bytes32(uint256(61));
+        bytes32 callId = controller.deriveCallId(CHAIN_ID, messageId);
+
+        vm.prank(address(adapterA));
+        controller.receiveMessage(messageId, payload, CHAIN_ID);
+        assertTrue(controller.getFailedMessage(callId).pending);
+
+        // Fix the failure condition.
+        flaky.setShouldRevert(false);
+
+        vm.expectEmit(true, false, false, false, address(controller));
+        emit MessageRetried(callId);
+
+        vm.prank(alice);
+        controller.retryFailedMessage(callId);
+
+        CrossChainController.FailedMessage memory cleared = controller.getFailedMessage(callId);
+        assertFalse(cleared.pending);
+        assertTrue(flaky.wasCalled());
+    }
+
+    /// @dev Delivers a message whose payload always fails, leaving a stored
+    ///      `FailedMessage` at the returned call id.
+    function _causeFailure(bytes32 _messageId) internal returns (bytes32 callId) {
+        Action[] memory actions = new Action[](1);
+        actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
+        bytes memory payload = abi.encode(actions);
+
+        vm.prank(address(adapterA));
+        callId = controller.receiveMessage(_messageId, payload, CHAIN_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // h) executeActions self-call guard
+    // -------------------------------------------------------------------------
+
+    function test_executeActions_revertsIfCallerNotSelf() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_SELF.selector, address(this)));
+        controller.executeActions(bytes32(0), _emptyActionsPayload());
+    }
+
+    // -------------------------------------------------------------------------
+    // i) sweep
+    // -------------------------------------------------------------------------
+
+    function test_sweep_revertsIfCallerUnauthorized() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, SWEEP_PERMISSION_ID)
+        );
+        vm.prank(bob);
+        controller.sweep(address(0), bob, 1 ether);
+    }
+
+    function test_sweep_revertsIfRecipientIsZeroAddress() public {
+        vm.expectRevert(Errors.ZERO_ADDRESS.selector);
+        vm.prank(alice);
+        controller.sweep(address(0), address(0), 0);
+    }
+
+    function test_sweep_native_movesExactAmountAndEmits() public {
+        vm.deal(address(controller), 5 ether);
+        address recipient = makeAddr("recipient");
+
+        vm.expectEmit(true, true, false, true, address(controller));
+        emit Swept(address(0), recipient, 2 ether);
+
+        vm.prank(alice);
+        controller.sweep(address(0), recipient, 2 ether);
+
+        assertEq(recipient.balance, 2 ether);
+        assertEq(address(controller).balance, 3 ether);
+    }
+
+    function test_sweep_erc20_movesExactAmountAndEmits() public {
+        feeToken.setBalance(address(controller), 10 ether);
+        address recipient = makeAddr("recipient");
+
+        vm.expectEmit(true, true, false, true, address(controller));
+        emit Swept(address(feeToken), recipient, 4 ether);
+
+        vm.prank(alice);
+        controller.sweep(address(feeToken), recipient, 4 ether);
+
+        assertEq(feeToken.balanceOf(recipient), 4 ether);
+        assertEq(feeToken.balanceOf(address(controller)), 6 ether);
+    }
+
+    // -------------------------------------------------------------------------
+    // j) deriveCallId
+    // -------------------------------------------------------------------------
+
+    function test_deriveCallId_isDeterministicAndInputSensitive() public view {
+        bytes32 messageId = bytes32(uint256(123));
+
+        bytes32 callId1 = controller.deriveCallId(CHAIN_ID, messageId);
+        bytes32 callId2 = controller.deriveCallId(CHAIN_ID, messageId);
+        assertEq(callId1, callId2);
+        assertEq(callId1, keccak256(abi.encode(CHAIN_ID, messageId)));
+
+        bytes32 differentChain = controller.deriveCallId(OTHER_CHAIN_ID, messageId);
+        assertTrue(callId1 != differentChain);
+
+        bytes32 differentMessage = controller.deriveCallId(CHAIN_ID, bytes32(uint256(124)));
+        assertTrue(callId1 != differentMessage);
+    }
+}
+
+/// @dev Minimal target whose revert behaviour can be flipped on demand, used
+///      to prove `retryFailedMessage` succeeds once the underlying failure
+///      condition is actually fixed (as opposed to merely being re-run).
+contract FlakyTarget {
+    bool public shouldRevert = true;
+    bool public wasCalled;
+
+    function setShouldRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+
+    function maybeRevert() external {
+        if (shouldRevert) revert("FlakyTarget: still failing");
+        wasCalled = true;
+    }
+}

--- a/test/mocks/commons/crosschain/AdapterMock.sol
+++ b/test/mocks/commons/crosschain/AdapterMock.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IBaseAdapter} from "../../../../src/common/crosschain/adapters/IBaseAdapter.sol";
+
+/// @notice A fully configurable mock implementing `IBaseAdapter`, used to drive
+///         `CrossChainController`'s sending and receiving paths in isolation
+///         from any real bridge.
+/// @dev DO NOT USE IN PRODUCTION!
+contract AdapterMock is IBaseAdapter {
+    address private immutable _controller;
+
+    /// @notice The fee token/amount `quoteFee` and `sendMessage` will honor.
+    address public feeToken;
+    uint256 public fee;
+
+    /// @notice The messageId `sendMessage` will return.
+    bytes32 public messageIdToReturn;
+
+    /// @notice When true, `sendMessage` reverts instead of recording the call.
+    bool public revertOnSend;
+
+    /// @notice When true, `quoteFee` reverts instead of returning `(feeToken, fee)`.
+    bool public revertOnQuote;
+
+    /// @notice Number of times `sendMessage` was successfully called.
+    uint256 public sendMessageCallCount;
+
+    // Args recorded from the last successful `sendMessage` call.
+    address public lastReceiver;
+    uint256 public lastGasLimit;
+    uint256 public lastDestinationChainId;
+    bytes public lastMessage;
+    uint256 public lastValueReceived;
+
+    constructor(address _controllerAddr) {
+        _controller = _controllerAddr;
+    }
+
+    // -------------------------------------------------------------------------
+    // Test configuration
+    // -------------------------------------------------------------------------
+
+    function setFee(address _feeToken, uint256 _fee) external {
+        feeToken = _feeToken;
+        fee = _fee;
+    }
+
+    function setMessageId(bytes32 _messageId) external {
+        messageIdToReturn = _messageId;
+    }
+
+    function setRevertOnSend(bool _revert) external {
+        revertOnSend = _revert;
+    }
+
+    function setRevertOnQuote(bool _revert) external {
+        revertOnQuote = _revert;
+    }
+
+    /// @notice Convenience for tests: the ERC20 balance this mock currently
+    ///         holds of `_token`, i.e. what the controller transferred to it.
+    function tokenBalance(address _token) external view returns (uint256) {
+        return IERC20(_token).balanceOf(address(this));
+    }
+
+    // -------------------------------------------------------------------------
+    // IBaseAdapter
+    // -------------------------------------------------------------------------
+
+    function CROSS_CHAIN_CONTROLLER() external view override returns (address) {
+        return _controller;
+    }
+
+    function toNativeChainId(uint256 _chainId) external pure override returns (uint256) {
+        return _chainId;
+    }
+
+    function fromNativeChainId(uint256 _chainId) external pure override returns (uint256) {
+        return _chainId;
+    }
+
+    function quoteFee(
+        address _receiver,
+        uint256 _gasLimit,
+        uint256 _destinationChainId,
+        bytes calldata _message
+    ) external view override returns (address, uint256) {
+        (_receiver, _gasLimit, _destinationChainId, _message);
+        if (revertOnQuote) revert("AdapterMock: quoteFee reverted");
+        return (feeToken, fee);
+    }
+
+    function sendMessage(
+        address _receiver,
+        uint256 _gasLimit,
+        uint256 _destinationChainId,
+        bytes calldata _message
+    ) external payable override returns (bytes32) {
+        if (revertOnSend) revert("AdapterMock: sendMessage reverted");
+
+        lastReceiver = _receiver;
+        lastGasLimit = _gasLimit;
+        lastDestinationChainId = _destinationChainId;
+        lastMessage = _message;
+        lastValueReceived = msg.value;
+        sendMessageCallCount++;
+
+        return messageIdToReturn;
+    }
+}

--- a/test/mocks/commons/crosschain/CCIPRouterMock.sol
+++ b/test/mocks/commons/crosschain/CCIPRouterMock.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {
+    IRouterClient
+} from "@chainlink/contracts-ccip/contracts/interfaces/IRouterClient.sol";
+import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
+
+/// @notice Minimal CCIP Router mock used to regression-test `CCIPAdapter`.
+/// @dev DO NOT USE IN PRODUCTION!
+///      Deliberately pulls the ERC20 fee via `transferFrom` — exactly like the
+///      real Router does — instead of trusting a pre-existing balance. The old
+///      `CCIPAdapter` never approved the router, so a mock that trusted the
+///      balance instead of pulling it would silently pass on a broken adapter.
+///      This is the regression test for the missing-`forceApprove` bug.
+contract CCIPRouterMock is IRouterClient {
+    /// @notice The fee returned by `getFee` and required by `ccipSend`.
+    uint256 public fee;
+
+    /// @notice Toggle for `isChainSupported`.
+    bool public chainSupported = true;
+
+    /// @notice The `messageId` returned by the next `ccipSend` call.
+    bytes32 public nextMessageId = keccak256("CCIPRouterMock: default-message-id");
+
+    /// @notice Number of times `ccipSend` was called.
+    uint256 public ccipSendCallCount;
+
+    // -- Recorded data of the most recent `ccipSend` call --------------------
+    uint64 public lastDestChainSelector;
+    bytes public lastReceiver;
+    bytes public lastData;
+    address public lastFeeToken;
+    bytes public lastExtraArgs;
+    uint256 public lastMsgValue;
+    address public lastCaller;
+
+    /// @notice Sets the fee quoted by `getFee` / required by `ccipSend`.
+    function setFee(uint256 _fee) external {
+        fee = _fee;
+    }
+
+    /// @notice Sets whether `isChainSupported` reports a chain as supported.
+    function setChainSupported(bool _supported) external {
+        chainSupported = _supported;
+    }
+
+    /// @notice Sets the `messageId` the next `ccipSend` call will return.
+    function setNextMessageId(bytes32 _id) external {
+        nextMessageId = _id;
+    }
+
+    /// @inheritdoc IRouterClient
+    function isChainSupported(uint64) external view returns (bool) {
+        return chainSupported;
+    }
+
+    /// @inheritdoc IRouterClient
+    function getFee(
+        uint64,
+        Client.EVM2AnyMessage memory
+    ) external view returns (uint256) {
+        return fee;
+    }
+
+    /// @inheritdoc IRouterClient
+    function ccipSend(
+        uint64 destinationChainSelector,
+        Client.EVM2AnyMessage calldata message
+    ) external payable returns (bytes32) {
+        lastDestChainSelector = destinationChainSelector;
+        lastReceiver = message.receiver;
+        lastData = message.data;
+        lastFeeToken = message.feeToken;
+        lastExtraArgs = message.extraArgs;
+        lastMsgValue = msg.value;
+        lastCaller = msg.sender;
+        ccipSendCallCount++;
+
+        if (message.feeToken == address(0)) {
+            require(msg.value == fee, "CCIPRouterMock: bad native fee");
+        } else {
+            require(msg.value == 0, "CCIPRouterMock: unexpected native value");
+            // Pull the fee exactly like the real Router. Reverts if the
+            // caller never approved this contract for at least `fee`.
+            require(
+                IERC20(message.feeToken).transferFrom(
+                    msg.sender,
+                    address(this),
+                    fee
+                ),
+                "CCIPRouterMock: transferFrom failed"
+            );
+        }
+
+        return nextMessageId;
+    }
+}

--- a/test/mocks/commons/crosschain/CrossChainControllerDAOMock.sol
+++ b/test/mocks/commons/crosschain/CrossChainControllerDAOMock.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
+import {IExecutor, Action} from "../../../../src/common/executors/IExecutor.sol";
+
+/// @notice A DAO mock purpose-built for `CrossChainController` tests.
+/// @dev Differs from `DAOMock` in two ways the controller's suite needs:
+///      - `hasPermission` is granted per `(where, who, permissionId)` instead
+///        of one global bool, so a caller can be authorized for one
+///        permission (e.g. `RETRY_MESSAGE_PERMISSION`) but not another.
+///      - `execute` actually performs the actions (bubbling a real revert
+///        reason on failure) instead of being a silent no-op, and can
+///        additionally be forced to revert outright via
+///        `setExecuteReverts`. This is required to exercise
+///        `CrossChainController`'s defensive `try/catch` around
+///        `executeActions` and the retry path with genuine pass/fail
+///        outcomes.
+/// @dev DO NOT USE IN PRODUCTION!
+contract CrossChainControllerDAOMock is IDAO, IExecutor {
+    /// @notice where => who => permissionId => granted.
+    mapping(address => mapping(address => mapping(bytes32 => bool))) public permissions;
+
+    /// @notice When true, `execute` reverts unconditionally before touching
+    ///         any action, regardless of the granted permissions.
+    bool public executeReverts;
+
+    function setHasPermission(address _where, address _who, bytes32 _permissionId, bool _granted) external {
+        permissions[_where][_who][_permissionId] = _granted;
+    }
+
+    function setExecuteReverts(bool _reverts) external {
+        executeReverts = _reverts;
+    }
+
+    function hasPermission(
+        address _where,
+        address _who,
+        bytes32 _permissionId,
+        bytes memory _data
+    ) external view override returns (bool) {
+        (_data);
+        return permissions[_where][_who][_permissionId];
+    }
+
+    function getTrustedForwarder() public pure override returns (address) {
+        return address(0);
+    }
+
+    function setTrustedForwarder(address _trustedForwarder) external pure override {
+        (_trustedForwarder);
+    }
+
+    function setMetadata(bytes calldata _metadata) external pure override {
+        (_metadata);
+    }
+
+    /// @dev Actually calls every action and reverts (bubbling the original
+    ///      reason) on the first failure, mirroring the real `Executor`'s
+    ///      default (`allowFailureMap == 0`) behaviour closely enough for
+    ///      these tests: a reverting action makes `execute` revert.
+    function execute(
+        bytes32 callId,
+        Action[] memory _actions,
+        uint256 allowFailureMap
+    ) external override returns (bytes[] memory execResults, uint256 failureMap) {
+        if (executeReverts) {
+            // solhint-disable-next-line reason-string, custom-errors
+            revert("CrossChainControllerDAOMock: forced revert");
+        }
+
+        execResults = new bytes[](_actions.length);
+        for (uint256 i = 0; i < _actions.length; i++) {
+            (bool success, bytes memory result) = _actions[i].to.call{value: _actions[i].value}(_actions[i].data);
+            if (!success) {
+                assembly {
+                    revert(add(result, 32), mload(result))
+                }
+            }
+            execResults[i] = result;
+        }
+
+        emit Executed(msg.sender, callId, _actions, allowFailureMap, failureMap, execResults);
+    }
+
+    function deposit(address _token, uint256 _amount, string calldata _reference) external payable override {
+        (_token, _amount, _reference);
+    }
+
+    function setSignatureValidator(address _signatureValidator) external pure override {
+        (_signatureValidator);
+    }
+
+    function isValidSignature(bytes32 _hash, bytes memory _signature) external pure override returns (bytes4) {
+        (_hash, _signature);
+        return 0x0;
+    }
+
+    function registerStandardCallback(
+        bytes4 _interfaceId,
+        bytes4 _callbackSelector,
+        bytes4 _magicNumber
+    ) external pure override {
+        (_interfaceId, _callbackSelector, _magicNumber);
+    }
+}


### PR DESCRIPTION
## Security hardening of the WIP cross-chain module

This PR fixes the findings of a security review of `src/common/crosschain/` at
`e49e055`, carried out as part of the **Aragon / Makina guardian-integration
planning work**. The module had no tests; this PR adds a Foundry suite covering
every critical and high finding as a regression test.

The motivating downstream use case is a mainnet OSx DAO passing a proposal that
must cancel a pending action on a remote chain *before an on-chain timelock
expires*. That shapes several decisions below: silent failures are
unacceptable, and a message stranded past its deadline is a real loss.

### Finding 3 — the design fork: `delegatecall` → `call`

**Decision: the controller now invokes adapters with a plain `call`.**

Rationale:

1. **`delegatecall` is not repairable here.** Adapter storage reads land in the
   controller's slots: `feeToken` (adapter slot 1) read the controller's unset
   slot 1 and returned `address(0)`, and `_trustedRemotes` (slot 0) collided
   with `chainToAdapter`. The suggested alternative — make all send-path state
   `immutable` — is impossible for finding 5: a bidirectional chain-id ⇄ CCIP
   selector map *must* be a `mapping`, and mappings cannot be `immutable`. The
   same applies to the updatable trusted-remote and fee-token setters in
   finding 10. Keeping `delegatecall` would mean redeploying every adapter to
   add a lane.
2. **It defuses finding 7.** Under `delegatecall`, `UPDATE_CONFIG_PERMISSION`
   was arbitrary code execution *in the controller's context*, and the
   controller holds `EXECUTE_PERMISSION` — i.e. root. Under `call`, a malicious
   adapter can no longer touch controller storage or spend beyond the fee it is
   handed. (It can still forge inbound `receiveMessage` payloads, so the
   permission remains highly privileged — now documented loudly in NatSpec.)
3. **It makes finding 9 concrete.** Under `call`, CCIP sees the **adapter** as
   the sender, so `_trustedRemotes[chainId]` holds the remote **adapter**
   address — which is exactly what the controller already stores as
   `chainToAdapter[chainId].remoteAdapter`. One address, one meaning, on both
   sides. `BaseAdapter.assertTrustedRemotesMatchController(uint256[])` is a
   deployment-time check that the two sides agree.

**Fee custody.** Per the deployment model (one OSx DAO per chain, fees paid from
the cross-chain contract's own pre-funded balance rather than per-proposal from
the treasury), the **`CrossChainController` custodies the fee funds**, not the
adapters:

- It gained a `receive()` and a permissioned `sweep(token, to, amount)` (native
  and ERC20) so funds are never stranded and the fee token can be rotated.
- Per send it quotes `getFee`, checks its own balance, and hands the adapter
  **exactly** the quoted fee — native as `msg.value`, ERC20 by `safeTransfer`
  immediately before the call. The adapter never relies on a standing balance
  and returns any remainder to the controller in the same transaction.
- CCIP does **not** refund overpayment, hence quote-then-pay-exactly.
- `quoteFee(destChainId, gasLimit, message)` returns `(feeToken, fee,
  available)` so off-chain monitoring can answer "can we still afford a send?"
  and top up ahead of a deadline. This matters: with a 72h+ voting window, a
  fee quoted at proposal creation can be badly stale at execution. A dedicated
  `INSUFFICIENT_FEE_BALANCE(feeToken, required, available)` error exists
  precisely so ops can alert on that one condition.

**Ops note:** only the **sending** side needs a fee balance — destination gas is
bought by the source-side fee via `extraArgs.gasLimit`. In the target
deployment only the mainnet controller needs funding; spoke controllers are
receive-only and should not be over-funded.

### Findings

| # | Sev | Finding | Resolution |
|---|-----|---------|------------|
| 1 | CRITICAL | `receiveMessage()` public, no access control → unauthenticated DAO takeover | `onlyLocalAdapter`, backed by a refcounted `localAdapter → laneCount` registry maintained by `updateConfig`. A refcount (not a bool) is required because one adapter serves many lanes: it stays authorised until its **last** lane is cleared, and a rotated-out adapter loses access immediately. |
| 2 | CRITICAL | `BaseAdapter._forwardMessage()` declared `public` → second takeover path | Now `internal`. |
| 3 | HIGH | Storage collision under `delegatecall` | Send path switched to `call`; see above. |
| 4 | HIGH | Silent no-op for unconfigured chains | `_validatedAdapters()` reverts `ADAPTER_NOT_CONFIGURED` when either adapter is unset and `ADAPTER_HAS_NO_CODE` when the local adapter is codeless. `updateConfig` additionally rejects half-configured lanes (`INCOMPLETE_ADAPTER_CONFIG`) and chain id `0`. |
| 5 | HIGH | chain id vs CCIP selector (identity functions) | Real bidirectional `chainId ⇄ uint64 selector` maps, constructor-seeded and updatable via `setChainSelectors`. Both directions revert (`UNKNOWN_CHAIN_ID` / `UNKNOWN_NATIVE_CHAIN_ID`) instead of returning `0`. Re-pointing a chain id clears the stale reverse entry. |
| 6 | MEDIUM | No router approval; no native-fee support | `forceApprove(router, fee)` before `ccipSend`, reset to `0` after. Native fees supported via `feeToken == address(0)` (the `balanceOf` check is now branch-correct); `UNEXPECTED_NATIVE_VALUE` if value is sent while an ERC20 fee token is configured. Fee is quoted with `getFee` and paid exactly. |
| 7 | MEDIUM | `UPDATE_CONFIG_PERMISSION` effectively root | Risk substantially reduced by the move to `call` (no arbitrary code in the controller's context). Residual risk — a malicious adapter can still forge inbound messages — is documented in explicit NatSpec on the permission constant: grant to the DAO only, never an EOA. |
| 8 | MEDIUM | No defensive receive; reverting action strands the message | Execution is wrapped in `try this.executeActions(...) catch`; the self-call also covers `abi.decode`, so a malformed payload is captured too. Failures are stored and emitted as `MessageExecutionFailed(originChainId, messageId, callId, reason)` and retried via `retryFailedMessage(callId)` under a new `RETRY_MESSAGE_PERMISSION`. Delivery therefore never reverts on the bridge, and recovery does not depend on CCIP's ~8h manual-execution window. |
| 9 | LOW | Trusted-remote semantics ambiguity | Resolved by finding 3: trusted remote == remote adapter == `chainToAdapter[].remoteAdapter`. Documented on `IBaseAdapter`, `BaseAdapter` and the `AdapterByChain` struct; `assertTrustedRemotesMatchController()` added as a deployment check. |
| 10 | LOW | Zero call id, empty event, constructor-only config | `callId = keccak256(originChainId, messageId)` (also the failed-message key). Real event payloads: `MessageForwarded`, `MessageReceived`, `MessageExecutionFailed`, `MessageRetried`, `ConfigUpdated`, `TrustedRemoteSet`, `FeeTokenSet`, `ChainSelectorSet`, `Swept`. Permissioned setters `setTrustedRemotes`, `setFeeToken`, `setChainSelectors` under a new `UPDATE_ADAPTER_CONFIG_PERMISSION`. |

### Interface changes

- `IBaseAdapter.sendMessage` is now `payable` and returns `bytes32` (the bridge
  message id) instead of `uint256`; `quoteFee` added; the view functions are
  marked `view`.
- `CrossChainController.receiveMessage(bytes32 messageId, bytes payload,
  uint256 originChainId)` — gained the message id, for traceability and for
  call-id derivation.
- `BaseAdapter` is now `DaoAuthorizable`, adopting the DAO of its controller, so
  adapter administration reuses the OSx permission system rather than
  introducing a second ownership model.
- `CCIPAdapter`'s constructor takes the chain-id ⇄ selector seed arrays.

### For human review

- **`UPDATE_CONFIG_PERMISSION` / `UPDATE_ADAPTER_CONFIG_PERMISSION` grants.**
  Both must go to the DAO only. Consider an allowlist of vetted adapter
  implementations if adapter deployment is ever delegated.
- **`RETRY_MESSAGE_PERMISSION` grantee.** The payload was already authenticated
  by the bridge, so an ops multisig is defensible and much faster than a second
  governance round before a timelock deadline — but it is a policy call.
- **Defensive receive vs. fail-loud.** A reverting payload is now swallowed into
  storage with a loud event rather than reverting the bridge delivery. This is
  Chainlink's recommended pattern and the right trade-off for a deadline-bound
  use case, but it does mean monitoring must watch `MessageExecutionFailed`.
- **Fee funding levels and top-up alerting** are operational decisions; the
  contract only provides `quoteFee` and `INSUFFICIENT_FEE_BALANCE`.
- **Chain selectors are configuration, not constants.** The values must be
  verified against Chainlink's directory at deployment.
- No reentrancy guard was added on `forwardMessage`; the adapter is a
  DAO-configured trusted component and the controller performs no state
  mutation around the call. Worth a second opinion.

---

Attribution: review and fixes produced during the Aragon/Makina
guardian-integration planning work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
