### PR TITLE
fix(crosschain): harden cross-chain module, add test coverage

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,4 +1,13 @@
 {
+  "lib/chainlink-ccip": {
+    "rev": "aa3224792927b281308ee73a56e08eaaf1a9c2c2"
+  },
+  "lib/chainlink-evm": {
+    "rev": "7a535ccf3fa0e585a70e21ca41ceb1d5c44e6f8b"
+  },
+  "lib/chainlink-local": {
+    "rev": "f8c0efe8685660dac07e08f4558f1b578ae991aa"
+  },
   "lib/ens-contracts": {
     "rev": "f5f2ededccbb7e52be44925c0050620d71762e32"
   },

--- a/src/common/crosschain/CrossChainController.sol
+++ b/src/common/crosschain/CrossChainController.sol
@@ -2,6 +2,11 @@
 
 pragma solidity ^0.8.8;
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {
+    SafeERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import {IBaseAdapter} from "./adapters/IBaseAdapter.sol";
 import {DaoAuthorizable} from "../permission/auth/DaoAuthorizable.sol";
 import {Action, IExecutor} from "../executors/IExecutor.sol";
@@ -9,28 +14,150 @@ import {Action, IExecutor} from "../executors/IExecutor.sol";
 import {IDAO} from "../dao/IDAO.sol";
 import {Errors} from "./lib/Errors.sol";
 
+/// @title CrossChainController
+/// @notice Per-DAO hub for sending and receiving cross-chain messages. It holds
+///         `EXECUTE_PERMISSION` on its DAO, so every inbound path into
+///         `receiveMessage` is security critical.
+/// @dev Threat model / invariants:
+///      - `receiveMessage` is callable ONLY by a local adapter registered
+///        through `updateConfig`. The per-origin-chain authentication of the
+///        remote sender is the adapter's responsibility (trusted remotes).
+///      - Adapters are invoked with a plain `call`, never `delegatecall`.
+///        Adapter storage therefore belongs to the adapter, and the address the
+///        bridge sees as the sender is the ADAPTER (see `IBaseAdapter`).
+///      - This contract custodies the bridge fee funds (native and/or ERC20)
+///        and forwards exactly the quoted fee to the adapter per send. Only the
+///        sending side needs funding; receive-only deployments do not.
+/// @custom:security-contact sirt@aragon.org
 contract CrossChainController is DaoAuthorizable {
+    using SafeERC20 for IERC20;
+
+    /// @notice Permission to forward a message to a remote chain. Held by the
+    ///         DAO / the plugin whose proposals produce cross-chain actions.
     bytes32 public constant FORWARD_MESSAGE_PERMISSION_ID =
         keccak256("FORWARD_MESSAGE_PERMISSION");
 
+    /// @notice Permission to (re)configure the chainId -> adapters mapping.
+    /// @dev SECURITY: this permission is highly privileged. A holder can point
+    ///      a chain at an adapter it controls and, because that adapter becomes
+    ///      a registered local adapter, deliver arbitrary `Action[]` payloads
+    ///      into `receiveMessage` and thus execute anything on the DAO. It
+    ///      MUST be granted only to the DAO itself (i.e. only reachable through
+    ///      a passed proposal) and never to an EOA or a permissionless
+    ///      condition. Since adapters are called (not `delegatecall`ed), a
+    ///      malicious adapter cannot corrupt this contract's storage or spend
+    ///      more than the fee it is handed, but it CAN forge inbound messages.
     bytes32 public constant UPDATE_CONFIG_PERMISSION_ID =
         keccak256("UPDATE_CONFIG_PERMISSION");
 
+    /// @notice Permission to retry a message whose execution reverted on
+    ///         arrival. Intended for the DAO and/or an ops multisig, since the
+    ///         payload itself was already authenticated by the bridge.
+    bytes32 public constant RETRY_MESSAGE_PERMISSION_ID =
+        keccak256("RETRY_MESSAGE_PERMISSION");
+
+    /// @notice Permission to move pre-funded fee assets out of this contract.
+    bytes32 public constant SWEEP_PERMISSION_ID = keccak256("SWEEP_PERMISSION");
+
     /// @param localAdapter The address of adapter where cross chain controller will send a message on the same chain.
     /// @param remoteAdapter The address of adapter on remote chain that will receive the message.
+    /// @dev `remoteAdapter` is BOTH the bridge-level receiver of outbound
+    ///      messages AND the address the remote adapter must have configured as
+    ///      its trusted remote for this chain (because the sender seen on the
+    ///      far side is this chain's adapter). Use
+    ///      `BaseAdapter.assertTrustedRemotesMatchController` after deployment
+    ///      to check the two sides agree.
     struct AdapterByChain {
         address localAdapter;
         address remoteAdapter;
     }
 
-    // TODO: add
-    event MessageForwarded();
+    /// @notice A message whose execution reverted on arrival, kept for retry.
+    /// @param pending Whether a retry is still outstanding.
+    /// @param originChainId The standard chain id the message came from.
+    /// @param messageId The bridge-level message identifier.
+    /// @param payload The encoded `Action[]`.
+    struct FailedMessage {
+        bool pending;
+        uint256 originChainId;
+        bytes32 messageId;
+        bytes payload;
+    }
 
+    /// @notice Emitted when a lane is configured or cleared.
+    event ConfigUpdated(
+        uint256 indexed chainId,
+        address localAdapter,
+        address remoteAdapter
+    );
+
+    /// @notice Emitted when a message was handed to the local adapter.
+    event MessageForwarded(
+        uint256 indexed destinationChainId,
+        bytes32 indexed messageId,
+        address indexed localAdapter,
+        address remoteAdapter,
+        uint256 gasLimit,
+        address feeToken,
+        uint256 fee
+    );
+
+    /// @notice Emitted when an inbound message executed successfully.
+    event MessageReceived(
+        uint256 indexed originChainId,
+        bytes32 indexed messageId,
+        bytes32 indexed callId
+    );
+
+    /// @notice Emitted when an inbound message reverted and was stored.
+    event MessageExecutionFailed(
+        uint256 indexed originChainId,
+        bytes32 indexed messageId,
+        bytes32 indexed callId,
+        bytes reason
+    );
+
+    /// @notice Emitted when a stored failed message was successfully retried.
+    event MessageRetried(bytes32 indexed callId);
+
+    /// @notice Emitted when fee assets are moved out of the contract.
+    event Swept(address indexed token, address indexed to, uint256 amount);
+
+    /// @notice standard chain id -> adapter pair.
     mapping(uint256 => AdapterByChain) public chainToAdapter;
+
+    /// @notice local adapter -> number of chain ids it is registered for.
+    /// @dev A single adapter (e.g. one CCIP adapter) usually serves many lanes,
+    ///      so a refcount is required for correct removal/rotation: the
+    ///      adapter only stops being trusted once its last lane is cleared.
+    mapping(address => uint256) private _localAdapterLaneCount;
+
+    /// @notice callId -> stored failed message.
+    mapping(bytes32 => FailedMessage) private _failedMessages;
+
+    /// @notice Restricts a function to local adapters registered via `updateConfig`.
+    modifier onlyLocalAdapter() {
+        if (_localAdapterLaneCount[msg.sender] == 0) {
+            revert Errors.CALLER_NOT_LOCAL_ADAPTER(msg.sender);
+        }
+        _;
+    }
 
     constructor(address _dao) DaoAuthorizable(IDAO(_dao)) {}
 
+    /// @notice Accepts native pre-funding used to pay bridge fees.
+    receive() external payable {}
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
     /// @notice Allows to update adapters per each chain.
+    /// @dev Pass the zero pair (`address(0)`, `address(0)`) to clear a lane;
+    ///      this also decrements the local adapter's refcount so a rotated-out
+    ///      adapter loses the right to call `receiveMessage`.
+    /// @param _chainIds The standard chain ids to configure.
+    /// @param _adapters The adapter pair per chain id.
     function updateConfig(
         uint256[] memory _chainIds,
         AdapterByChain[] memory _adapters
@@ -39,51 +166,299 @@ contract CrossChainController is DaoAuthorizable {
             revert Errors.INVALID_LENGTH_MISMATCH();
 
         for (uint256 i = 0; i < _chainIds.length; i++) {
-            chainToAdapter[_chainIds[i]] = _adapters[i];
+            uint256 chainId = _chainIds[i];
+            if (chainId == 0) revert Errors.INVALID_CHAIN_ID();
+
+            AdapterByChain memory newConfig = _adapters[i];
+
+            // A lane is either fully set or fully cleared; a half-configured
+            // lane is the "silent no-op" footgun.
+            if (
+                (newConfig.localAdapter == address(0)) !=
+                (newConfig.remoteAdapter == address(0))
+            ) {
+                revert Errors.INCOMPLETE_ADAPTER_CONFIG(chainId);
+            }
+
+            address oldLocalAdapter = chainToAdapter[chainId].localAdapter;
+
+            if (oldLocalAdapter != newConfig.localAdapter) {
+                if (oldLocalAdapter != address(0)) {
+                    _localAdapterLaneCount[oldLocalAdapter] -= 1;
+                }
+                if (newConfig.localAdapter != address(0)) {
+                    _localAdapterLaneCount[newConfig.localAdapter] += 1;
+                }
+            }
+
+            chainToAdapter[chainId] = newConfig;
+
+            emit ConfigUpdated(
+                chainId,
+                newConfig.localAdapter,
+                newConfig.remoteAdapter
+            );
         }
     }
 
-    /// @notice The final destination for a message that arrives on remote chain.
-    /// @param _payload The encoded Action[] message.
-    /// @param _originChainId The origin chain id from which cross-chain message originated.
-    function receiveMessage(
-        bytes memory _payload,
-        uint256 _originChainId
-    ) public {
-        Action[] memory actions = abi.decode(_payload, (Action[]));
+    /// @notice Whether an address is currently registered as a local adapter.
+    /// @param _adapter The address to check.
+    /// @return True if the address may call `receiveMessage`.
+    function isRegisteredLocalAdapter(
+        address _adapter
+    ) public view returns (bool) {
+        return _adapter != address(0) && _localAdapterLaneCount[_adapter] != 0;
+    }
 
-        IExecutor(address(dao())).execute(bytes32(0), actions, 0);
+    /// @notice The number of lanes an adapter is registered for.
+    /// @param _adapter The adapter address.
+    /// @return The lane count.
+    function localAdapterLaneCount(
+        address _adapter
+    ) public view returns (uint256) {
+        return _localAdapterLaneCount[_adapter];
+    }
+
+    // -------------------------------------------------------------------------
+    // Sending
+    // -------------------------------------------------------------------------
+
+    /// @notice Quotes the bridge fee for a prospective send.
+    /// @dev Off-chain monitoring should poll this and top the contract up ahead
+    ///      of a deadline: a quote taken when a proposal is created can be
+    ///      badly stale by the time the voting window closes.
+    /// @param _destinationChainId The standard chain id of remote chain.
+    /// @param _gasLimit The gas limit that will be used for crosschain message execution.
+    /// @param _message The encoded Action[] message.
+    /// @return feeToken The fee token (`address(0)` for native).
+    /// @return fee The required fee amount.
+    /// @return available The balance this contract currently holds of `feeToken`.
+    function quoteFee(
+        uint256 _destinationChainId,
+        uint256 _gasLimit,
+        bytes memory _message
+    ) public view returns (address feeToken, uint256 fee, uint256 available) {
+        AdapterByChain memory adapters = _validatedAdapters(
+            _destinationChainId
+        );
+
+        (feeToken, fee) = IBaseAdapter(adapters.localAdapter).quoteFee(
+            adapters.remoteAdapter,
+            _gasLimit,
+            _destinationChainId,
+            _message
+        );
+
+        available = feeToken == address(0)
+            ? address(this).balance
+            : IERC20(feeToken).balanceOf(address(this));
     }
 
     /// @notice Entry point to receive a message and send it to cross-chain.
     /// @param _destinationChainId The standard chain id of remote chain.
     /// @param _gasLimit The gas limit that will be used for crosschain message execution.
     /// @param _message The encoded Action[] message.
+    /// @return messageId The bridge-level identifier of the sent message.
     function forwardMessage(
         uint256 _destinationChainId,
         uint256 _gasLimit,
         bytes memory _message
-    ) public auth(FORWARD_MESSAGE_PERMISSION_ID) {
-        AdapterByChain storage adapters = chainToAdapter[_destinationChainId];
+    ) public auth(FORWARD_MESSAGE_PERMISSION_ID) returns (bytes32 messageId) {
+        AdapterByChain memory adapters = _validatedAdapters(
+            _destinationChainId
+        );
 
-        (bool success, bytes memory returnData) = adapters
-            .localAdapter
-            .delegatecall(
-                abi.encodeCall(
-                    IBaseAdapter.sendMessage,
-                    (
-                        adapters.remoteAdapter,
-                        _gasLimit,
-                        _destinationChainId,
-                        _message
-                    )
-                )
+        (address feeToken, uint256 fee) = IBaseAdapter(adapters.localAdapter)
+            .quoteFee(
+                adapters.remoteAdapter,
+                _gasLimit,
+                _destinationChainId,
+                _message
             );
 
-        if (!success) {
-            revert Errors.SEND_MESSAGE_TO_ADAPTER_FAILED(returnData);
+        uint256 nativeValue;
+
+        if (feeToken == address(0)) {
+            if (address(this).balance < fee) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(
+                    feeToken,
+                    fee,
+                    address(this).balance
+                );
+            }
+            nativeValue = fee;
+        } else {
+            uint256 balance = IERC20(feeToken).balanceOf(address(this));
+            if (balance < fee) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(feeToken, fee, balance);
+            }
+            // Hand the adapter exactly the quoted fee for this send; the
+            // adapter returns any remainder in the same transaction.
+            if (fee != 0) {
+                IERC20(feeToken).safeTransfer(adapters.localAdapter, fee);
+            }
         }
 
-        emit MessageForwarded();
+        messageId = IBaseAdapter(adapters.localAdapter).sendMessage{
+            value: nativeValue
+        }(adapters.remoteAdapter, _gasLimit, _destinationChainId, _message);
+
+        emit MessageForwarded(
+            _destinationChainId,
+            messageId,
+            adapters.localAdapter,
+            adapters.remoteAdapter,
+            _gasLimit,
+            feeToken,
+            fee
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Receiving
+    // -------------------------------------------------------------------------
+
+    /// @notice The final destination for a message that arrives on remote chain.
+    /// @dev Only a registered local adapter may call this. The adapter is
+    ///      responsible for having authenticated the remote sender. Execution
+    ///      is wrapped defensively: a reverting payload is stored and can be
+    ///      retried later instead of being stranded until the bridge's manual
+    ///      execution window (~8h for CCIP) closes.
+    /// @param _messageId The bridge-level message identifier.
+    /// @param _payload The encoded Action[] message.
+    /// @param _originChainId The origin chain id from which cross-chain message originated.
+    /// @return callId The deterministic call id used for the DAO execution.
+    function receiveMessage(
+        bytes32 _messageId,
+        bytes memory _payload,
+        uint256 _originChainId
+    ) public onlyLocalAdapter returns (bytes32 callId) {
+        callId = deriveCallId(_originChainId, _messageId);
+
+        if (_failedMessages[callId].pending) {
+            revert Errors.MESSAGE_ALREADY_PENDING(callId);
+        }
+
+        // The self-call also contains payload decoding, so a malformed payload
+        // is captured for retry rather than reverting the bridge delivery.
+        try this.executeActions(callId, _payload) {
+            emit MessageReceived(_originChainId, _messageId, callId);
+        } catch (bytes memory reason) {
+            _failedMessages[callId] = FailedMessage({
+                pending: true,
+                originChainId: _originChainId,
+                messageId: _messageId,
+                payload: _payload
+            });
+
+            emit MessageExecutionFailed(
+                _originChainId,
+                _messageId,
+                callId,
+                reason
+            );
+        }
+    }
+
+    /// @notice Decodes and executes an authenticated payload on the DAO.
+    /// @dev External only so it can be wrapped in `try/catch`; callable
+    ///      exclusively by this contract.
+    /// @param _callId The call id passed to the executor.
+    /// @param _payload The encoded Action[] message.
+    function executeActions(bytes32 _callId, bytes memory _payload) external {
+        if (msg.sender != address(this)) {
+            revert Errors.CALLER_NOT_SELF(msg.sender);
+        }
+
+        Action[] memory actions = abi.decode(_payload, (Action[]));
+
+        IExecutor(address(dao())).execute(_callId, actions, 0);
+    }
+
+    /// @notice Retries a previously failed inbound message.
+    /// @dev Reverts (bubbling the failure) if the retry fails again, so the
+    ///      stored message stays pending.
+    /// @param _callId The call id emitted by `MessageExecutionFailed`.
+    function retryFailedMessage(
+        bytes32 _callId
+    ) public auth(RETRY_MESSAGE_PERMISSION_ID) {
+        FailedMessage memory failed = _failedMessages[_callId];
+        if (!failed.pending) revert Errors.NO_FAILED_MESSAGE(_callId);
+
+        delete _failedMessages[_callId];
+
+        this.executeActions(_callId, failed.payload);
+
+        emit MessageRetried(_callId);
+    }
+
+    /// @notice Returns a stored failed message.
+    /// @param _callId The call id.
+    /// @return The stored message; `pending` is false if there is none.
+    function getFailedMessage(
+        bytes32 _callId
+    ) public view returns (FailedMessage memory) {
+        return _failedMessages[_callId];
+    }
+
+    /// @notice Derives the DAO call id / failed-message key of a message.
+    /// @param _originChainId The standard origin chain id.
+    /// @param _messageId The bridge-level message identifier.
+    /// @return The call id.
+    function deriveCallId(
+        uint256 _originChainId,
+        bytes32 _messageId
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(_originChainId, _messageId));
+    }
+
+    // -------------------------------------------------------------------------
+    // Fee custody
+    // -------------------------------------------------------------------------
+
+    /// @notice Moves pre-funded fee assets out of this contract.
+    /// @param _token The asset to move; `address(0)` for native currency.
+    /// @param _to The recipient (typically the DAO).
+    /// @param _amount The amount to move.
+    function sweep(
+        address _token,
+        address _to,
+        uint256 _amount
+    ) public auth(SWEEP_PERMISSION_ID) {
+        if (_to == address(0)) revert Errors.ZERO_ADDRESS();
+
+        if (_token == address(0)) {
+            (bool ok, ) = _to.call{value: _amount}("");
+            if (!ok) revert Errors.NATIVE_TRANSFER_FAILED(_to, _amount);
+        } else {
+            IERC20(_token).safeTransfer(_to, _amount);
+        }
+
+        emit Swept(_token, _to, _amount);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    /// @notice Loads and validates the adapter pair for a destination chain.
+    /// @dev Reverts instead of silently no-op'ing: a `call`/`delegatecall` to a
+    ///      codeless address reports success, which would let a proposal
+    ///      "execute" while nothing was ever bridged.
+    function _validatedAdapters(
+        uint256 _destinationChainId
+    ) internal view returns (AdapterByChain memory adapters) {
+        adapters = chainToAdapter[_destinationChainId];
+
+        if (
+            adapters.localAdapter == address(0) ||
+            adapters.remoteAdapter == address(0)
+        ) {
+            revert Errors.ADAPTER_NOT_CONFIGURED(_destinationChainId);
+        }
+
+        if (adapters.localAdapter.code.length == 0) {
+            revert Errors.ADAPTER_HAS_NO_CODE(adapters.localAdapter);
+        }
     }
 }

--- a/src/common/crosschain/CrossChainController.sol
+++ b/src/common/crosschain/CrossChainController.sol
@@ -22,12 +22,22 @@ import {Errors} from "./lib/Errors.sol";
 ///      - `receiveMessage` is callable ONLY by a local adapter registered
 ///        through `updateConfig`. The per-origin-chain authentication of the
 ///        remote sender is the adapter's responsibility (trusted remotes).
-///      - Adapters are invoked with a plain `call`, never `delegatecall`.
-///        Adapter storage therefore belongs to the adapter, and the address the
-///        bridge sees as the sender is the ADAPTER (see `IBaseAdapter`).
-///      - This contract custodies the bridge fee funds (native and/or ERC20)
-///        and forwards exactly the quoted fee to the adapter per send. Only the
-///        sending side needs funding; receive-only deployments do not.
+///      - SEND is a `delegatecall` into the local adapter. Consequences, all
+///        deliberate:
+///        * every send-path parameter that would otherwise be adapter storage
+///          lives HERE, in `chainToAdapter`, and is passed as an argument —
+///          including `bridgeChainId`, the bridge-native destination id. The
+///          adapter's send path reads no storage at all, so there is no
+///          storage collision to have.
+///        * the bridge sees THIS CONTRACT as the message sender. The remote
+///          side's trusted remote must therefore be the remote CONTROLLER,
+///          while `chainToAdapter[].remoteAdapter` is the remote ADAPTER (the
+///          bridge-level receiver). Two different addresses; see `ChainConfig`.
+///        * this contract pays the bridge fee directly out of its own balance,
+///          since it is the account executing the bridge call. There is no fee
+///          hand-over and no change to return.
+///      - RECEIVE is a normal call: router -> adapter -> `receiveMessage`. The
+///        adapter's own storage is authoritative there.
 /// @custom:security-contact sirt@aragon.org
 contract CrossChainController is DaoAuthorizable {
     using SafeERC20 for IERC20;
@@ -37,16 +47,30 @@ contract CrossChainController is DaoAuthorizable {
     bytes32 public constant FORWARD_MESSAGE_PERMISSION_ID =
         keccak256("FORWARD_MESSAGE_PERMISSION");
 
-    /// @notice Permission to (re)configure the chainId -> adapters mapping.
-    /// @dev SECURITY: this permission is highly privileged. A holder can point
-    ///      a chain at an adapter it controls and, because that adapter becomes
-    ///      a registered local adapter, deliver arbitrary `Action[]` payloads
-    ///      into `receiveMessage` and thus execute anything on the DAO. It
-    ///      MUST be granted only to the DAO itself (i.e. only reachable through
-    ///      a passed proposal) and never to an EOA or a permissionless
-    ///      condition. Since adapters are called (not `delegatecall`ed), a
-    ///      malicious adapter cannot corrupt this contract's storage or spend
-    ///      more than the fee it is handed, but it CAN forge inbound messages.
+    /// @notice Permission to (re)configure the chainId -> lane mapping.
+    /// @dev SECURITY — READ THIS. This permission is EFFECTIVELY ROOT ON THE
+    ///      DAO, and this design does not reduce that.
+    ///
+    ///      Because `forwardMessage` `delegatecall`s `localAdapter`, whoever
+    ///      can set `localAdapter` can execute ARBITRARY CODE IN THIS
+    ///      CONTRACT'S CONTEXT: it can overwrite any storage slot here
+    ///      (including `chainToAdapter` and the local-adapter registry), spend
+    ///      this contract's entire balance, and — since this contract holds
+    ///      `EXECUTE_PERMISSION` on the DAO — make the DAO execute anything.
+    ///      A single malicious `updateConfig` plus a single `forwardMessage`
+    ///      is a complete DAO takeover.
+    ///
+    ///      This is the accepted residual risk of keeping `delegatecall`. It is
+    ///      NOT mitigated by anything in this contract. Mitigation is
+    ///      operational and must be treated as a hard requirement:
+    ///      - grant `UPDATE_CONFIG_PERMISSION` to the DAO ITSELF ONLY, i.e.
+    ///        reachable only through a passed proposal. Never to an EOA, never
+    ///        to a multisig shortcut, never behind a permissionless condition.
+    ///      - consider gating it further with a permission condition that
+    ///        allows only an allowlist of audited adapter implementations.
+    ///      - note that the blast radius is strictly larger than under a plain
+    ///        `call` design, where a malicious adapter could only forge inbound
+    ///        messages.
     bytes32 public constant UPDATE_CONFIG_PERMISSION_ID =
         keccak256("UPDATE_CONFIG_PERMISSION");
 
@@ -59,17 +83,27 @@ contract CrossChainController is DaoAuthorizable {
     /// @notice Permission to move pre-funded fee assets out of this contract.
     bytes32 public constant SWEEP_PERMISSION_ID = keccak256("SWEEP_PERMISSION");
 
-    /// @param localAdapter The address of adapter where cross chain controller will send a message on the same chain.
-    /// @param remoteAdapter The address of adapter on remote chain that will receive the message.
-    /// @dev `remoteAdapter` is BOTH the bridge-level receiver of outbound
-    ///      messages AND the address the remote adapter must have configured as
-    ///      its trusted remote for this chain (because the sender seen on the
-    ///      far side is this chain's adapter). Use
-    ///      `BaseAdapter.assertTrustedRemotesMatchController` after deployment
-    ///      to check the two sides agree.
-    struct AdapterByChain {
+    /// @notice Everything the send path needs, held by the controller so that
+    ///         the `delegatecall`ed adapter code never touches storage.
+    /// @param localAdapter The adapter whose code is `delegatecall`ed to send.
+    /// @param remoteAdapter The bridge-level RECEIVER on the remote chain, i.e.
+    ///        the remote chain's ADAPTER address.
+    /// @param bridgeChainId The bridge-native destination chain id (for CCIP,
+    ///        the chain selector). Kept here rather than in an adapter mapping
+    ///        precisely because mappings cannot be `immutable` and the send
+    ///        path must not read storage.
+    /// @dev NOTE THE ASYMMETRY. `remoteAdapter` is the remote ADAPTER, because
+    ///      that is what the bridge delivers to. The remote adapter's
+    ///      `trustedRemote(thisChainId)` must be THIS CONTROLLER, because under
+    ///      `delegatecall` the bridge sees this controller as the sender. Do
+    ///      not set the remote adapter as a trusted remote and do not set a
+    ///      controller address as `remoteAdapter`. Verify with
+    ///      `BaseAdapter.assertTrustedRemotesMatchControllers` and
+    ///      `BaseAdapter.assertChainSelectorsMatchController` after deployment.
+    struct ChainConfig {
         address localAdapter;
         address remoteAdapter;
+        uint64 bridgeChainId;
     }
 
     /// @notice A message whose execution reverted on arrival, kept for retry.
@@ -88,7 +122,8 @@ contract CrossChainController is DaoAuthorizable {
     event ConfigUpdated(
         uint256 indexed chainId,
         address localAdapter,
-        address remoteAdapter
+        address remoteAdapter,
+        uint64 bridgeChainId
     );
 
     /// @notice Emitted when a message was handed to the local adapter.
@@ -123,8 +158,8 @@ contract CrossChainController is DaoAuthorizable {
     /// @notice Emitted when fee assets are moved out of the contract.
     event Swept(address indexed token, address indexed to, uint256 amount);
 
-    /// @notice standard chain id -> adapter pair.
-    mapping(uint256 => AdapterByChain) public chainToAdapter;
+    /// @notice standard chain id -> lane configuration.
+    mapping(uint256 => ChainConfig) public chainToAdapter;
 
     /// @notice local adapter -> number of chain ids it is registered for.
     /// @dev A single adapter (e.g. one CCIP adapter) usually serves many lanes,
@@ -152,31 +187,36 @@ contract CrossChainController is DaoAuthorizable {
     // Configuration
     // -------------------------------------------------------------------------
 
-    /// @notice Allows to update adapters per each chain.
-    /// @dev Pass the zero pair (`address(0)`, `address(0)`) to clear a lane;
-    ///      this also decrements the local adapter's refcount so a rotated-out
-    ///      adapter loses the right to call `receiveMessage`.
+    /// @notice Allows to update the lane configuration per chain.
+    /// @dev Pass an all-zero `ChainConfig` to clear a lane; this also
+    ///      decrements the local adapter's refcount so a rotated-out adapter
+    ///      loses the right to call `receiveMessage`.
     /// @param _chainIds The standard chain ids to configure.
-    /// @param _adapters The adapter pair per chain id.
+    /// @param _configs The lane configuration per chain id.
     function updateConfig(
         uint256[] memory _chainIds,
-        AdapterByChain[] memory _adapters
+        ChainConfig[] memory _configs
     ) public auth(UPDATE_CONFIG_PERMISSION_ID) {
-        if (_chainIds.length != _adapters.length)
+        if (_chainIds.length != _configs.length)
             revert Errors.INVALID_LENGTH_MISMATCH();
 
         for (uint256 i = 0; i < _chainIds.length; i++) {
             uint256 chainId = _chainIds[i];
             if (chainId == 0) revert Errors.INVALID_CHAIN_ID();
 
-            AdapterByChain memory newConfig = _adapters[i];
+            ChainConfig memory newConfig = _configs[i];
 
             // A lane is either fully set or fully cleared; a half-configured
-            // lane is the "silent no-op" footgun.
-            if (
-                (newConfig.localAdapter == address(0)) !=
-                (newConfig.remoteAdapter == address(0))
-            ) {
+            // lane is the "silent no-op" footgun. `bridgeChainId == 0` in
+            // particular would otherwise mean "send to selector 0".
+            bool anySet = newConfig.localAdapter != address(0) ||
+                newConfig.remoteAdapter != address(0) ||
+                newConfig.bridgeChainId != 0;
+            bool allSet = newConfig.localAdapter != address(0) &&
+                newConfig.remoteAdapter != address(0) &&
+                newConfig.bridgeChainId != 0;
+
+            if (anySet != allSet) {
                 revert Errors.INCOMPLETE_ADAPTER_CONFIG(chainId);
             }
 
@@ -196,7 +236,8 @@ contract CrossChainController is DaoAuthorizable {
             emit ConfigUpdated(
                 chainId,
                 newConfig.localAdapter,
-                newConfig.remoteAdapter
+                newConfig.remoteAdapter,
+                newConfig.bridgeChainId
             );
         }
     }
@@ -224,7 +265,12 @@ contract CrossChainController is DaoAuthorizable {
     // -------------------------------------------------------------------------
 
     /// @notice Quotes the bridge fee for a prospective send.
-    /// @dev Off-chain monitoring should poll this and top the contract up ahead
+    /// @dev Invoked as a normal `view` call on the adapter, which is safe and
+    ///      equivalent to what the `delegatecall`ed send path computes only
+    ///      because the adapter's quote path reads no storage either (fee token
+    ///      and router are `immutable`).
+    ///
+    ///      Off-chain monitoring should poll this and top the contract up ahead
     ///      of a deadline: a quote taken when a proposal is created can be
     ///      badly stale by the time the voting window closes.
     /// @param _destinationChainId The standard chain id of remote chain.
@@ -238,14 +284,12 @@ contract CrossChainController is DaoAuthorizable {
         uint256 _gasLimit,
         bytes memory _message
     ) public view returns (address feeToken, uint256 fee, uint256 available) {
-        AdapterByChain memory adapters = _validatedAdapters(
-            _destinationChainId
-        );
+        ChainConfig memory config = _validatedConfig(_destinationChainId);
 
-        (feeToken, fee) = IBaseAdapter(adapters.localAdapter).quoteFee(
-            adapters.remoteAdapter,
+        (feeToken, fee) = IBaseAdapter(config.localAdapter).quoteFee(
+            config.remoteAdapter,
+            config.bridgeChainId,
             _gasLimit,
-            _destinationChainId,
             _message
         );
 
@@ -255,6 +299,9 @@ contract CrossChainController is DaoAuthorizable {
     }
 
     /// @notice Entry point to receive a message and send it to cross-chain.
+    /// @dev Executes the adapter's send code IN THIS CONTRACT'S CONTEXT. The
+    ///      bridge fee is paid straight from this contract's balance, and the
+    ///      bridge attributes the message to this contract's address.
     /// @param _destinationChainId The standard chain id of remote chain.
     /// @param _gasLimit The gas limit that will be used for crosschain message execution.
     /// @param _message The encoded Action[] message.
@@ -264,50 +311,54 @@ contract CrossChainController is DaoAuthorizable {
         uint256 _gasLimit,
         bytes memory _message
     ) public auth(FORWARD_MESSAGE_PERMISSION_ID) returns (bytes32 messageId) {
-        AdapterByChain memory adapters = _validatedAdapters(
-            _destinationChainId
+        ChainConfig memory config = _validatedConfig(_destinationChainId);
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = config.localAdapter.delegatecall(
+            abi.encodeCall(
+                IBaseAdapter.sendMessage,
+                (
+                    config.remoteAdapter,
+                    config.bridgeChainId,
+                    _gasLimit,
+                    _message
+                )
+            )
         );
 
-        (address feeToken, uint256 fee) = IBaseAdapter(adapters.localAdapter)
-            .quoteFee(
-                adapters.remoteAdapter,
-                _gasLimit,
-                _destinationChainId,
-                _message
-            );
-
-        uint256 nativeValue;
-
-        if (feeToken == address(0)) {
-            if (address(this).balance < fee) {
-                revert Errors.INSUFFICIENT_FEE_BALANCE(
-                    feeToken,
-                    fee,
-                    address(this).balance
-                );
-            }
-            nativeValue = fee;
-        } else {
-            uint256 balance = IERC20(feeToken).balanceOf(address(this));
-            if (balance < fee) {
-                revert Errors.INSUFFICIENT_FEE_BALANCE(feeToken, fee, balance);
-            }
-            // Hand the adapter exactly the quoted fee for this send; the
-            // adapter returns any remainder in the same transaction.
-            if (fee != 0) {
-                IERC20(feeToken).safeTransfer(adapters.localAdapter, fee);
+        // FAIL LOUDLY. This function must never return successfully having
+        // bridged nothing: the caller is a governance proposal racing an
+        // on-chain deadline, and a silent no-op would let the proposal execute,
+        // emit, and look healthy while the message never left the chain. Every
+        // way the dispatch can fail — unset lane, codeless adapter, adapter
+        // revert, insufficient fee, or a "successful" call that did not return
+        // a well-formed result — reverts here.
+        if (!success) {
+            // Bubble the adapter's revert reason verbatim (e.g.
+            // `INSUFFICIENT_FEE_BALANCE`), or fail loudly if there is none.
+            if (returndata.length == 0) revert Errors.MESSAGE_SEND_FAILED();
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                revert(add(returndata, 32), mload(returndata))
             }
         }
 
-        messageId = IBaseAdapter(adapters.localAdapter).sendMessage{
-            value: nativeValue
-        }(adapters.remoteAdapter, _gasLimit, _destinationChainId, _message);
+        // A conforming `sendMessage` returns (bytes32, address, uint256).
+        // Anything shorter did not dispatch a message.
+        if (returndata.length < 96) revert Errors.MESSAGE_SEND_FAILED();
+
+        address feeToken;
+        uint256 fee;
+        (messageId, feeToken, fee) = abi.decode(
+            returndata,
+            (bytes32, address, uint256)
+        );
 
         emit MessageForwarded(
             _destinationChainId,
             messageId,
-            adapters.localAdapter,
-            adapters.remoteAdapter,
+            config.localAdapter,
+            config.remoteAdapter,
             _gasLimit,
             feeToken,
             fee
@@ -417,6 +468,10 @@ contract CrossChainController is DaoAuthorizable {
     // -------------------------------------------------------------------------
 
     /// @notice Moves pre-funded fee assets out of this contract.
+    /// @dev This contract is the fee payer: under `delegatecall` the bridge
+    ///      call is made by this account, so the fee (native `msg.value` or an
+    ///      ERC20 pulled by the router) comes straight from here. No funds are
+    ///      ever handed to the adapter and none can be stranded there.
     /// @param _token The asset to move; `address(0)` for native currency.
     /// @param _to The recipient (typically the DAO).
     /// @param _amount The amount to move.
@@ -428,6 +483,7 @@ contract CrossChainController is DaoAuthorizable {
         if (_to == address(0)) revert Errors.ZERO_ADDRESS();
 
         if (_token == address(0)) {
+            // solhint-disable-next-line avoid-low-level-calls
             (bool ok, ) = _to.call{value: _amount}("");
             if (!ok) revert Errors.NATIVE_TRANSFER_FAILED(_to, _amount);
         } else {
@@ -441,24 +497,26 @@ contract CrossChainController is DaoAuthorizable {
     // Internal
     // -------------------------------------------------------------------------
 
-    /// @notice Loads and validates the adapter pair for a destination chain.
-    /// @dev Reverts instead of silently no-op'ing: a `call`/`delegatecall` to a
+    /// @notice Loads and validates the lane configuration for a destination.
+    /// @dev Reverts instead of silently no-op'ing: a `delegatecall` to a
     ///      codeless address reports success, which would let a proposal
-    ///      "execute" while nothing was ever bridged.
-    function _validatedAdapters(
+    ///      "execute" while nothing was ever bridged. A zero `bridgeChainId`
+    ///      is rejected for the same reason: it would address bridge lane `0`.
+    function _validatedConfig(
         uint256 _destinationChainId
-    ) internal view returns (AdapterByChain memory adapters) {
-        adapters = chainToAdapter[_destinationChainId];
+    ) internal view returns (ChainConfig memory config) {
+        config = chainToAdapter[_destinationChainId];
 
         if (
-            adapters.localAdapter == address(0) ||
-            adapters.remoteAdapter == address(0)
+            config.localAdapter == address(0) ||
+            config.remoteAdapter == address(0) ||
+            config.bridgeChainId == 0
         ) {
             revert Errors.ADAPTER_NOT_CONFIGURED(_destinationChainId);
         }
 
-        if (adapters.localAdapter.code.length == 0) {
-            revert Errors.ADAPTER_HAS_NO_CODE(adapters.localAdapter);
+        if (config.localAdapter.code.length == 0) {
+            revert Errors.ADAPTER_HAS_NO_CODE(config.localAdapter);
         }
     }
 }

--- a/src/common/crosschain/CrossChainController.sol
+++ b/src/common/crosschain/CrossChainController.sol
@@ -15,62 +15,21 @@ import {IDAO} from "../dao/IDAO.sol";
 import {Errors} from "./lib/Errors.sol";
 
 /// @title CrossChainController
-/// @notice Per-DAO hub for sending and receiving cross-chain messages. It holds
-///         `EXECUTE_PERMISSION` on its DAO, so every inbound path into
-///         `receiveMessage` is security critical.
-/// @dev Threat model / invariants:
-///      - `receiveMessage` is callable ONLY by a local adapter registered
-///        through `updateConfig`. The per-origin-chain authentication of the
-///        remote sender is the adapter's responsibility (trusted remotes).
-///      - SEND is a `delegatecall` into the local adapter. Consequences, all
-///        deliberate:
-///        * every send-path parameter that would otherwise be adapter storage
-///          lives HERE, in `chainToAdapter`, and is passed as an argument —
-///          including `bridgeChainId`, the bridge-native destination id. The
-///          adapter's send path reads no storage at all, so there is no
-///          storage collision to have.
-///        * the bridge sees THIS CONTRACT as the message sender. The remote
-///          side's trusted remote must therefore be the remote CONTROLLER,
-///          while `chainToAdapter[].remoteAdapter` is the remote ADAPTER (the
-///          bridge-level receiver). Two different addresses; see `ChainConfig`.
-///        * this contract pays the bridge fee directly out of its own balance,
-///          since it is the account executing the bridge call. There is no fee
-///          hand-over and no change to return.
-///      - RECEIVE is a normal call: router -> adapter -> `receiveMessage`. The
-///        adapter's own storage is authoritative there.
+/// @notice The entry point for sending a message cross chain.
+/// @dev Maps each standard chain id to the bridge adapter used to reach that
+///      chain; the adapter, not this contract, translates the standard chain id
+///      into the bridge's native one. Adapters are `delegatecall`ed, so the
+///      bridge sees this controller (not the adapter) as the message sender on
+///      the receiver side, and the send-side fee is paid by this controller.
 /// @custom:security-contact sirt@aragon.org
 contract CrossChainController is DaoAuthorizable {
     using SafeERC20 for IERC20;
 
-    /// @notice Permission to forward a message to a remote chain. Held by the
-    ///         DAO / the plugin whose proposals produce cross-chain actions.
+    /// @notice Permission to forward a message to a remote chain.
     bytes32 public constant FORWARD_MESSAGE_PERMISSION_ID =
         keccak256("FORWARD_MESSAGE_PERMISSION");
 
-    /// @notice Permission to (re)configure the chainId -> lane mapping.
-    /// @dev SECURITY — READ THIS. This permission is EFFECTIVELY ROOT ON THE
-    ///      DAO, and this design does not reduce that.
-    ///
-    ///      Because `forwardMessage` `delegatecall`s `localAdapter`, whoever
-    ///      can set `localAdapter` can execute ARBITRARY CODE IN THIS
-    ///      CONTRACT'S CONTEXT: it can overwrite any storage slot here
-    ///      (including `chainToAdapter` and the local-adapter registry), spend
-    ///      this contract's entire balance, and — since this contract holds
-    ///      `EXECUTE_PERMISSION` on the DAO — make the DAO execute anything.
-    ///      A single malicious `updateConfig` plus a single `forwardMessage`
-    ///      is a complete DAO takeover.
-    ///
-    ///      This is the accepted residual risk of keeping `delegatecall`. It is
-    ///      NOT mitigated by anything in this contract. Mitigation is
-    ///      operational and must be treated as a hard requirement:
-    ///      - grant `UPDATE_CONFIG_PERMISSION` to the DAO ITSELF ONLY, i.e.
-    ///        reachable only through a passed proposal. Never to an EOA, never
-    ///        to a multisig shortcut, never behind a permissionless condition.
-    ///      - consider gating it further with a permission condition that
-    ///        allows only an allowlist of audited adapter implementations.
-    ///      - note that the blast radius is strictly larger than under a plain
-    ///        `call` design, where a malicious adapter could only forge inbound
-    ///        messages.
+    /// @notice Permission to (re)configure the config.
     bytes32 public constant UPDATE_CONFIG_PERMISSION_ID =
         keccak256("UPDATE_CONFIG_PERMISSION");
 
@@ -83,27 +42,11 @@ contract CrossChainController is DaoAuthorizable {
     /// @notice Permission to move pre-funded fee assets out of this contract.
     bytes32 public constant SWEEP_PERMISSION_ID = keccak256("SWEEP_PERMISSION");
 
-    /// @notice Everything the send path needs, held by the controller so that
-    ///         the `delegatecall`ed adapter code never touches storage.
-    /// @param localAdapter The adapter whose code is `delegatecall`ed to send.
-    /// @param remoteAdapter The bridge-level RECEIVER on the remote chain, i.e.
-    ///        the remote chain's ADAPTER address.
-    /// @param bridgeChainId The bridge-native destination chain id (for CCIP,
-    ///        the chain selector). Kept here rather than in an adapter mapping
-    ///        precisely because mappings cannot be `immutable` and the send
-    ///        path must not read storage.
-    /// @dev NOTE THE ASYMMETRY. `remoteAdapter` is the remote ADAPTER, because
-    ///      that is what the bridge delivers to. The remote adapter's
-    ///      `trustedRemote(thisChainId)` must be THIS CONTROLLER, because under
-    ///      `delegatecall` the bridge sees this controller as the sender. Do
-    ///      not set the remote adapter as a trusted remote and do not set a
-    ///      controller address as `remoteAdapter`. Verify with
-    ///      `BaseAdapter.assertTrustedRemotesMatchControllers` and
-    ///      `BaseAdapter.assertChainSelectorsMatchController` after deployment.
+    /// @param localAdapter The adapter where message will be forwarded to.
+    /// @param remoteAdapter The bridge-level RECEIVER on the remote chain.
     struct ChainConfig {
         address localAdapter;
         address remoteAdapter;
-        uint64 bridgeChainId;
     }
 
     /// @notice A message whose execution reverted on arrival, kept for retry.
@@ -118,12 +61,11 @@ contract CrossChainController is DaoAuthorizable {
         bytes payload;
     }
 
-    /// @notice Emitted when a lane is configured or cleared.
+    /// @notice Emitted when a config is configured or cleared.
     event ConfigUpdated(
         uint256 indexed chainId,
         address localAdapter,
-        address remoteAdapter,
-        uint64 bridgeChainId
+        address remoteAdapter
     );
 
     /// @notice Emitted when a message was handed to the local adapter.
@@ -133,7 +75,6 @@ contract CrossChainController is DaoAuthorizable {
         address indexed localAdapter,
         address remoteAdapter,
         uint256 gasLimit,
-        address feeToken,
         uint256 fee
     );
 
@@ -161,20 +102,15 @@ contract CrossChainController is DaoAuthorizable {
     /// @notice standard chain id -> lane configuration.
     mapping(uint256 => ChainConfig) public chainToAdapter;
 
-    /// @notice local adapter -> number of chain ids it is registered for.
-    /// @dev A single adapter (e.g. one CCIP adapter) usually serves many lanes,
-    ///      so a refcount is required for correct removal/rotation: the
-    ///      adapter only stops being trusted once its last lane is cleared.
-    mapping(address => uint256) private _localAdapterLaneCount;
-
     /// @notice callId -> stored failed message.
-    mapping(bytes32 => FailedMessage) private _failedMessages;
+    mapping(bytes32 => FailedMessage) private failedMessages;
 
     /// @notice Restricts a function to local adapters registered via `updateConfig`.
-    modifier onlyLocalAdapter() {
-        if (_localAdapterLaneCount[msg.sender] == 0) {
+    modifier onlyLocalAdapter(uint256 _srcChainId) {
+        if (msg.sender != chainToAdapter[_srcChainId].localAdapter) {
             revert Errors.CALLER_NOT_LOCAL_ADAPTER(msg.sender);
         }
+
         _;
     }
 
@@ -187,18 +123,21 @@ contract CrossChainController is DaoAuthorizable {
     // Configuration
     // -------------------------------------------------------------------------
 
-    /// @notice Allows to update the lane configuration per chain.
-    /// @dev Pass an all-zero `ChainConfig` to clear a lane; this also
-    ///      decrements the local adapter's refcount so a rotated-out adapter
-    ///      loses the right to call `receiveMessage`.
-    /// @param _chainIds The standard chain ids to configure.
-    /// @param _configs The lane configuration per chain id.
+    /// @notice Allows to update configuration per chain.
+    /// @dev Pass an all-zero `ChainConfig` to clear/remove
+    ///      or a fully set one to configure it.
+    /// @param _chainIds The standard chain ids to configure. These are the
+    ///        REMOTE (destination/origin) chain ids, never this chain's own id:
+    ///        each entry keys the lane used to send to, and receive from, that
+    ///        remote chain.
+    /// @param _configs The configuration per chain id.
     function updateConfig(
         uint256[] memory _chainIds,
         ChainConfig[] memory _configs
     ) public auth(UPDATE_CONFIG_PERMISSION_ID) {
-        if (_chainIds.length != _configs.length)
+        if (_chainIds.length != _configs.length) {
             revert Errors.INVALID_LENGTH_MISMATCH();
+        }
 
         for (uint256 i = 0; i < _chainIds.length; i++) {
             uint256 chainId = _chainIds[i];
@@ -206,29 +145,11 @@ contract CrossChainController is DaoAuthorizable {
 
             ChainConfig memory newConfig = _configs[i];
 
-            // A lane is either fully set or fully cleared; a half-configured
-            // lane is the "silent no-op" footgun. `bridgeChainId == 0` in
-            // particular would otherwise mean "send to selector 0".
-            bool anySet = newConfig.localAdapter != address(0) ||
-                newConfig.remoteAdapter != address(0) ||
-                newConfig.bridgeChainId != 0;
-            bool allSet = newConfig.localAdapter != address(0) &&
-                newConfig.remoteAdapter != address(0) &&
-                newConfig.bridgeChainId != 0;
+            bool hasLocal = newConfig.localAdapter != address(0);
+            bool hasRemote = newConfig.remoteAdapter != address(0);
 
-            if (anySet != allSet) {
+            if (hasLocal != hasRemote) {
                 revert Errors.INCOMPLETE_ADAPTER_CONFIG(chainId);
-            }
-
-            address oldLocalAdapter = chainToAdapter[chainId].localAdapter;
-
-            if (oldLocalAdapter != newConfig.localAdapter) {
-                if (oldLocalAdapter != address(0)) {
-                    _localAdapterLaneCount[oldLocalAdapter] -= 1;
-                }
-                if (newConfig.localAdapter != address(0)) {
-                    _localAdapterLaneCount[newConfig.localAdapter] += 1;
-                }
             }
 
             chainToAdapter[chainId] = newConfig;
@@ -236,43 +157,22 @@ contract CrossChainController is DaoAuthorizable {
             emit ConfigUpdated(
                 chainId,
                 newConfig.localAdapter,
-                newConfig.remoteAdapter,
-                newConfig.bridgeChainId
+                newConfig.remoteAdapter
             );
         }
     }
 
     /// @notice Whether an address is currently registered as a local adapter.
     /// @param _adapter The address to check.
-    /// @return True if the address may call `receiveMessage`.
+    /// @param _chainId The chain id of remote chain.
     function isRegisteredLocalAdapter(
-        address _adapter
+        address _adapter,
+        uint256 _chainId
     ) public view returns (bool) {
-        return _adapter != address(0) && _localAdapterLaneCount[_adapter] != 0;
+        return chainToAdapter[_chainId].localAdapter == _adapter;
     }
 
-    /// @notice The number of lanes an adapter is registered for.
-    /// @param _adapter The adapter address.
-    /// @return The lane count.
-    function localAdapterLaneCount(
-        address _adapter
-    ) public view returns (uint256) {
-        return _localAdapterLaneCount[_adapter];
-    }
-
-    // -------------------------------------------------------------------------
-    // Sending
-    // -------------------------------------------------------------------------
-
-    /// @notice Quotes the bridge fee for a prospective send.
-    /// @dev Invoked as a normal `view` call on the adapter, which is safe and
-    ///      equivalent to what the `delegatecall`ed send path computes only
-    ///      because the adapter's quote path reads no storage either (fee token
-    ///      and router are `immutable`).
-    ///
-    ///      Off-chain monitoring should poll this and top the contract up ahead
-    ///      of a deadline: a quote taken when a proposal is created can be
-    ///      badly stale by the time the voting window closes.
+    /// @notice Quotes the bridge fee for a send.
     /// @param _destinationChainId The standard chain id of remote chain.
     /// @param _gasLimit The gas limit that will be used for crosschain message execution.
     /// @param _message The encoded Action[] message.
@@ -288,7 +188,7 @@ contract CrossChainController is DaoAuthorizable {
 
         (feeToken, fee) = IBaseAdapter(config.localAdapter).quoteFee(
             config.remoteAdapter,
-            config.bridgeChainId,
+            _destinationChainId,
             _gasLimit,
             _message
         );
@@ -313,46 +213,32 @@ contract CrossChainController is DaoAuthorizable {
     ) public auth(FORWARD_MESSAGE_PERMISSION_ID) returns (bytes32 messageId) {
         ChainConfig memory config = _validatedConfig(_destinationChainId);
 
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool success, bytes memory returndata) = config.localAdapter.delegatecall(
-            abi.encodeCall(
-                IBaseAdapter.sendMessage,
-                (
-                    config.remoteAdapter,
-                    config.bridgeChainId,
-                    _gasLimit,
-                    _message
-                )
-            )
+        bytes memory encodedCall = abi.encodeCall(
+            IBaseAdapter.sendMessage,
+            (config.remoteAdapter, _destinationChainId, _gasLimit, _message)
         );
 
-        // FAIL LOUDLY. This function must never return successfully having
-        // bridged nothing: the caller is a governance proposal racing an
-        // on-chain deadline, and a silent no-op would let the proposal execute,
-        // emit, and look healthy while the message never left the chain. Every
-        // way the dispatch can fail — unset lane, codeless adapter, adapter
-        // revert, insufficient fee, or a "successful" call that did not return
-        // a well-formed result — reverts here.
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = config
+            .localAdapter
+            .delegatecall(encodedCall);
+
+        // If failed, it means it failed on the same chain,
+        // not at arrival to remote chain.
         if (!success) {
-            // Bubble the adapter's revert reason verbatim (e.g.
-            // `INSUFFICIENT_FEE_BALANCE`), or fail loudly if there is none.
             if (returndata.length == 0) revert Errors.MESSAGE_SEND_FAILED();
+
             // solhint-disable-next-line no-inline-assembly
             assembly {
                 revert(add(returndata, 32), mload(returndata))
             }
         }
 
-        // A conforming `sendMessage` returns (bytes32, address, uint256).
-        // Anything shorter did not dispatch a message.
-        if (returndata.length < 96) revert Errors.MESSAGE_SEND_FAILED();
+        // Make sure adapter returns the right length parameters.
+        if (returndata.length < 64) revert Errors.MESSAGE_SEND_FAILED();
 
-        address feeToken;
         uint256 fee;
-        (messageId, feeToken, fee) = abi.decode(
-            returndata,
-            (bytes32, address, uint256)
-        );
+        (messageId, fee) = abi.decode(returndata, (bytes32, uint256));
 
         emit MessageForwarded(
             _destinationChainId,
@@ -360,7 +246,6 @@ contract CrossChainController is DaoAuthorizable {
             config.localAdapter,
             config.remoteAdapter,
             _gasLimit,
-            feeToken,
             fee
         );
     }
@@ -371,10 +256,7 @@ contract CrossChainController is DaoAuthorizable {
 
     /// @notice The final destination for a message that arrives on remote chain.
     /// @dev Only a registered local adapter may call this. The adapter is
-    ///      responsible for having authenticated the remote sender. Execution
-    ///      is wrapped defensively: a reverting payload is stored and can be
-    ///      retried later instead of being stranded until the bridge's manual
-    ///      execution window (~8h for CCIP) closes.
+    ///      responsible for having authenticated the remote sender.
     /// @param _messageId The bridge-level message identifier.
     /// @param _payload The encoded Action[] message.
     /// @param _originChainId The origin chain id from which cross-chain message originated.
@@ -383,10 +265,10 @@ contract CrossChainController is DaoAuthorizable {
         bytes32 _messageId,
         bytes memory _payload,
         uint256 _originChainId
-    ) public onlyLocalAdapter returns (bytes32 callId) {
+    ) public onlyLocalAdapter(_originChainId) returns (bytes32 callId) {
         callId = deriveCallId(_originChainId, _messageId);
 
-        if (_failedMessages[callId].pending) {
+        if (failedMessages[callId].pending) {
             revert Errors.MESSAGE_ALREADY_PENDING(callId);
         }
 
@@ -395,7 +277,7 @@ contract CrossChainController is DaoAuthorizable {
         try this.executeActions(callId, _payload) {
             emit MessageReceived(_originChainId, _messageId, callId);
         } catch (bytes memory reason) {
-            _failedMessages[callId] = FailedMessage({
+            failedMessages[callId] = FailedMessage({
                 pending: true,
                 originChainId: _originChainId,
                 messageId: _messageId,
@@ -433,10 +315,10 @@ contract CrossChainController is DaoAuthorizable {
     function retryFailedMessage(
         bytes32 _callId
     ) public auth(RETRY_MESSAGE_PERMISSION_ID) {
-        FailedMessage memory failed = _failedMessages[_callId];
+        FailedMessage memory failed = failedMessages[_callId];
         if (!failed.pending) revert Errors.NO_FAILED_MESSAGE(_callId);
 
-        delete _failedMessages[_callId];
+        delete failedMessages[_callId];
 
         this.executeActions(_callId, failed.payload);
 
@@ -449,7 +331,7 @@ contract CrossChainController is DaoAuthorizable {
     function getFailedMessage(
         bytes32 _callId
     ) public view returns (FailedMessage memory) {
-        return _failedMessages[_callId];
+        return failedMessages[_callId];
     }
 
     /// @notice Derives the DAO call id / failed-message key of a message.
@@ -462,10 +344,6 @@ contract CrossChainController is DaoAuthorizable {
     ) public pure returns (bytes32) {
         return keccak256(abi.encode(_originChainId, _messageId));
     }
-
-    // -------------------------------------------------------------------------
-    // Fee custody
-    // -------------------------------------------------------------------------
 
     /// @notice Moves pre-funded fee assets out of this contract.
     /// @dev This contract is the fee payer: under `delegatecall` the bridge
@@ -509,14 +387,9 @@ contract CrossChainController is DaoAuthorizable {
 
         if (
             config.localAdapter == address(0) ||
-            config.remoteAdapter == address(0) ||
-            config.bridgeChainId == 0
+            config.remoteAdapter == address(0)
         ) {
             revert Errors.ADAPTER_NOT_CONFIGURED(_destinationChainId);
-        }
-
-        if (config.localAdapter.code.length == 0) {
-            revert Errors.ADAPTER_HAS_NO_CODE(config.localAdapter);
         }
     }
 }

--- a/src/common/crosschain/adapters/BaseAdapter.sol
+++ b/src/common/crosschain/adapters/BaseAdapter.sol
@@ -9,33 +9,67 @@ import {IBaseAdapter} from "./IBaseAdapter.sol";
 
 /// @title BaseAdapter
 /// @notice Shared logic for bridge adapters owned by a `CrossChainController`.
-/// @dev The controller invokes adapters with a plain `call`, so:
-///      - adapter storage is the adapter's own (no `delegatecall` collisions);
-///      - the sender address the bridge reports on the destination chain is
-///        THIS ADAPTER. Consequently `_trustedRemotes[chainId]` must hold the
-///        REMOTE ADAPTER address, which is exactly what the controller stores
-///        as `chainToAdapter[chainId].remoteAdapter`. Use
-///        `assertTrustedRemotesMatchController` to verify both sides agree.
-///      Adapter administration is authorized through the same DAO that owns the
-///      controller, so no separate ownership system is introduced.
+/// @dev  TWO EXECUTION CONTEXTS. Read this before touching anything here.
+///
+///       1. SEND — `delegatecall` from the controller. `address(this)` is the
+///          CONTROLLER. Any `SLOAD`/`SSTORE` executed here reads or writes the
+///          CONTROLLER's storage, so the send path MUST be storage-free:
+///          `immutable`s only (they are baked into the adapter's bytecode and
+///          therefore resolve correctly under `delegatecall`) plus arguments
+///          passed in by the controller. `onlyDelegatecallFromController`
+///          enforces the context.
+///
+///       2. RECEIVE — a NORMAL call from the bridge router into the adapter.
+///          `address(this)` is the adapter, so the adapter's own storage
+///          applies and mutable, permissioned configuration is fine. That is
+///          where `_trustedRemotes` and the chain-id maps live.
+///
+///       TRUSTED REMOTE == REMOTE **CONTROLLER**. Because the send is a
+///       `delegatecall`, the account that calls the bridge router is the
+///       controller, and the sender address delivered on the far side is the
+///       remote chain's CONTROLLER. `_trustedRemotes[chainId]` must therefore
+///       hold the remote CONTROLLER address, while the controller's
+///       `chainToAdapter[chainId].remoteAdapter` holds the remote ADAPTER
+///       address (the bridge-level receiver). These are two DIFFERENT
+///       addresses; setting the remote adapter as the trusted remote is a
+///       silent, total loss of inbound liveness. See
+///       `assertTrustedRemotesMatchControllers`.
+///
+///       Adapter administration is authorized through the same DAO that owns
+///       the controller, so no separate ownership system is introduced. Note
+///       that `auth()` MUST NOT be used on the send path: `DaoAuthorizable`
+///       holds the DAO as an `immutable` (fine) but permission lookups are
+///       keyed on `address(this)`, which differs between the two contexts.
 /// @custom:security-contact sirt@aragon.org
 abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
     /// @notice Permission to change adapter configuration (trusted remotes,
-    ///         fee token, chain-id mappings).
+    ///         chain-id mappings). Receive-path configuration only; the send
+    ///         path is configured on the controller.
     bytes32 public constant UPDATE_ADAPTER_CONFIG_PERMISSION_ID =
         keccak256("UPDATE_ADAPTER_CONFIG_PERMISSION");
 
     /// @notice The address of crosschain controller.
+    /// @dev `immutable`, so it is readable both from the adapter's own context
+    ///      and from the controller's context under `delegatecall`.
     address public immutable override CROSS_CHAIN_CONTROLLER;
 
-    /// @notice standard chain id -> remote adapter address allowed to originate
-    ///         messages for that chain.
+    /// @notice This adapter's own address, captured at construction.
+    /// @dev `immutable`, so it is baked into the bytecode and keeps its value
+    ///      even when that bytecode is executed in someone else's context.
+    ///      Comparing it to `address(this)` is how the receive path detects
+    ///      that it is running under `delegatecall`.
+    address private immutable _selfAddress;
+
+    /// @notice standard chain id -> remote CONTROLLER address allowed to
+    ///         originate messages for that chain.
+    /// @dev NOT the remote adapter. See the contract-level docs.
     mapping(uint256 => address) internal _trustedRemotes;
 
     /// @notice Emitted when a trusted remote is set or cleared.
     event TrustedRemoteSet(uint256 indexed chainId, address trustedRemote);
 
-    /// @notice Restricts a function to the owning `CrossChainController`.
+    /// @notice Restricts a function to the owning `CrossChainController`
+    ///         (receive-side / administrative direction: a real call).
     modifier onlyCrossChainController() {
         if (msg.sender != CROSS_CHAIN_CONTROLLER) {
             revert Errors.CALLER_NOT_CROSS_CHAIN_CONTROLLER(msg.sender);
@@ -43,31 +77,55 @@ abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
         _;
     }
 
+    /// @notice Restricts a function to being `delegatecall`ed by the owning
+    ///         `CrossChainController`.
+    /// @dev Under `delegatecall` from the controller, `address(this)` IS the
+    ///      controller. A direct call to the adapter fails this check. This is
+    ///      the mirror image of `onlyCrossChainController`: `msg.sender` is
+    ///      whoever called `forwardMessage` and carries no meaning here, so the
+    ///      *context* is what must be asserted. Authorization of the send
+    ///      itself is `FORWARD_MESSAGE_PERMISSION` on the controller.
+    modifier onlyDelegatecallFromController() {
+        if (address(this) != CROSS_CHAIN_CONTROLLER) {
+            revert Errors.SEND_PATH_NOT_DELEGATECALLED(address(this));
+        }
+        _;
+    }
+
     /// @param _crossChainController The controller that owns this adapter. Its
     ///        DAO is adopted as the adapter's permission manager.
     /// @param _remoteChainIds The standard chain ids of the remote lanes.
-    /// @param _remoteTrustedSenders The remote ADAPTER address per lane.
+    /// @param _remoteTrustedSenders The remote CONTROLLER address per lane.
     constructor(
         address _crossChainController,
         uint256[] memory _remoteChainIds,
         address[] memory _remoteTrustedSenders
     ) DaoAuthorizable(CrossChainController(payable(_crossChainController)).dao()) {
         CROSS_CHAIN_CONTROLLER = _crossChainController;
+        _selfAddress = address(this);
 
         _setTrustedRemotes(_remoteChainIds, _remoteTrustedSenders);
     }
 
-    /// @notice The remote adapter trusted to originate messages for a chain.
+    /// @inheritdoc IBaseAdapter
+    /// @dev Redeclared as `public` so the consistency helpers below can call it
+    ///      internally; implemented by the concrete adapter.
+    function toNativeChainId(
+        uint256 _chainId
+    ) public view virtual override returns (uint256);
+
+    /// @notice The remote CONTROLLER trusted to originate messages for a chain.
     /// @param _chainId The standard chain id.
-    /// @return The trusted remote adapter address, or zero if unset.
+    /// @return The trusted remote controller address, or zero if unset.
     function trustedRemote(uint256 _chainId) public view returns (address) {
         return _trustedRemotes[_chainId];
     }
 
     /// @notice Sets or clears trusted remotes.
-    /// @dev Pass `address(0)` for a sender to clear a lane.
+    /// @dev Pass `address(0)` for a sender to clear a lane. The values are
+    ///      remote CONTROLLER addresses, NOT remote adapter addresses.
     /// @param _remoteChainIds The standard chain ids.
-    /// @param _remoteTrustedSenders The remote adapter addresses.
+    /// @param _remoteTrustedSenders The remote controller addresses.
     function setTrustedRemotes(
         uint256[] memory _remoteChainIds,
         address[] memory _remoteTrustedSenders
@@ -75,31 +133,91 @@ abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
         _setTrustedRemotes(_remoteChainIds, _remoteTrustedSenders);
     }
 
-    /// @notice Reverts unless, for every given chain, this adapter's trusted
-    ///         remote equals the controller's configured `remoteAdapter`.
-    /// @dev Deployment-time sanity check for the easily-misconfigured pair
-    ///      described in the contract-level docs.
+    /// @notice Deployment-time check that this adapter's trusted remotes are
+    ///         the expected remote CONTROLLER addresses, and specifically that
+    ///         they are NOT the remote ADAPTER addresses the controller has
+    ///         configured as bridge receivers.
+    /// @dev The expected values must be supplied by the deployer: the local
+    ///      controller stores the remote ADAPTER (the bridge receiver), not the
+    ///      remote controller, so there is nothing on-chain to cross-check
+    ///      against. What CAN be checked mechanically — and is — is that the
+    ///      two were not confused for one another.
     /// @param _chainIds The standard chain ids to check.
-    function assertTrustedRemotesMatchController(
+    /// @param _expectedRemoteControllers The remote CONTROLLER per chain id.
+    function assertTrustedRemotesMatchControllers(
+        uint256[] memory _chainIds,
+        address[] memory _expectedRemoteControllers
+    ) public view {
+        if (_chainIds.length != _expectedRemoteControllers.length) {
+            revert Errors.INVALID_LENGTH_MISMATCH();
+        }
+
+        for (uint256 i = 0; i < _chainIds.length; i++) {
+            uint256 chainId = _chainIds[i];
+            address trusted = _trustedRemotes[chainId];
+
+            if (trusted == address(0) || trusted != _expectedRemoteControllers[i]) {
+                revert Errors.TRUSTED_REMOTE_MISMATCH(
+                    chainId,
+                    trusted,
+                    _expectedRemoteControllers[i]
+                );
+            }
+
+            (, address remoteAdapter, ) = CrossChainController(
+                payable(CROSS_CHAIN_CONTROLLER)
+            ).chainToAdapter(chainId);
+
+            if (remoteAdapter != address(0) && trusted == remoteAdapter) {
+                revert Errors.TRUSTED_REMOTE_IS_REMOTE_ADAPTER(
+                    chainId,
+                    trusted
+                );
+            }
+        }
+    }
+
+    /// @notice Deployment-time check that the controller's send-side
+    ///         `bridgeChainId` agrees with this adapter's receive-side
+    ///         chain-id map for the same chains.
+    /// @dev The same mapping necessarily exists twice: the send path may not
+    ///      read storage, so the controller carries chainId -> bridge id in its
+    ///      lane config, while the receive path needs bridge id -> chainId in
+    ///      adapter storage. A desync silently sends to the wrong lane (or to
+    ///      a lane whose inbound messages the far side cannot attribute), so
+    ///      run this after every `updateConfig`/`setChainSelectors`.
+    /// @param _chainIds The standard chain ids to check.
+    function assertChainSelectorsMatchController(
         uint256[] memory _chainIds
     ) public view {
         for (uint256 i = 0; i < _chainIds.length; i++) {
             uint256 chainId = _chainIds[i];
 
-            (, address remoteAdapter) = CrossChainController(
+            (, , uint64 controllerBridgeChainId) = CrossChainController(
                 payable(CROSS_CHAIN_CONTROLLER)
             ).chainToAdapter(chainId);
 
-            address trusted = _trustedRemotes[chainId];
+            if (controllerBridgeChainId == 0) {
+                revert Errors.ADAPTER_NOT_CONFIGURED(chainId);
+            }
 
-            if (trusted == address(0) || trusted != remoteAdapter) {
-                revert Errors.TRUSTED_REMOTE_MISMATCH(
+            // Reverts `UNKNOWN_CHAIN_ID` if the adapter has no entry at all.
+            uint64 adapterBridgeChainId = uint64(toNativeChainId(chainId));
+
+            if (controllerBridgeChainId != adapterBridgeChainId) {
+                revert Errors.CHAIN_ID_DESYNC(
                     chainId,
-                    trusted,
-                    remoteAdapter
+                    controllerBridgeChainId,
+                    adapterBridgeChainId
                 );
             }
         }
+    }
+
+    /// @notice The address this adapter was deployed at.
+    /// @return The adapter's own address, from bytecode.
+    function selfAddress() public view returns (address) {
+        return _selfAddress;
     }
 
     /// @notice Once adapter receives a message, this must be called
@@ -107,6 +225,16 @@ abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
     /// @dev MUST stay `internal`: it is the unauthenticated side of the receive
     ///      path, reachable only after the bridge-specific caller and
     ///      trusted-remote checks have passed.
+    ///
+    ///      GUARDS THE SEND/RECEIVE ASYMMETRY. This is the last common point of
+    ///      the receive path, and everything upstream of it (trusted remotes,
+    ///      chain-id maps) is STORAGE — which is only meaningful when this code
+    ///      runs in the adapter's own context. If it were ever reached under
+    ///      `delegatecall` (from the controller's send path, or from anything
+    ///      else), those reads would resolve against foreign slots and the
+    ///      authentication they perform would be meaningless. `address(this)`
+    ///      is compared against the `immutable` `_selfAddress` to make that
+    ///      impossible rather than merely unlikely.
     /// @param _messageId The bridge-level message identifier.
     /// @param _payload The encoded Action[] message.
     /// @param _originChainId The standard chain id the message came from.
@@ -115,6 +243,10 @@ abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
         bytes memory _payload,
         uint256 _originChainId
     ) internal {
+        if (address(this) != _selfAddress) {
+            revert Errors.DELEGATE_CALL_FORBIDDEN(address(this), _selfAddress);
+        }
+
         CrossChainController(payable(CROSS_CHAIN_CONTROLLER)).receiveMessage(
             _messageId,
             _payload,

--- a/src/common/crosschain/adapters/BaseAdapter.sol
+++ b/src/common/crosschain/adapters/BaseAdapter.sol
@@ -4,45 +4,139 @@ pragma solidity ^0.8.8;
 
 import {Errors} from "../lib/Errors.sol";
 import {CrossChainController} from "../CrossChainController.sol";
+import {DaoAuthorizable} from "../../permission/auth/DaoAuthorizable.sol";
 import {IBaseAdapter} from "./IBaseAdapter.sol";
 
-abstract contract BaseAdapter is IBaseAdapter {
-    /// @notice The address of crosschain controller.
-    address public immutable CROSS_CHAIN_CONTROLLER;
+/// @title BaseAdapter
+/// @notice Shared logic for bridge adapters owned by a `CrossChainController`.
+/// @dev The controller invokes adapters with a plain `call`, so:
+///      - adapter storage is the adapter's own (no `delegatecall` collisions);
+///      - the sender address the bridge reports on the destination chain is
+///        THIS ADAPTER. Consequently `_trustedRemotes[chainId]` must hold the
+///        REMOTE ADAPTER address, which is exactly what the controller stores
+///        as `chainToAdapter[chainId].remoteAdapter`. Use
+///        `assertTrustedRemotesMatchController` to verify both sides agree.
+///      Adapter administration is authorized through the same DAO that owns the
+///      controller, so no separate ownership system is introduced.
+/// @custom:security-contact sirt@aragon.org
+abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
+    /// @notice Permission to change adapter configuration (trusted remotes,
+    ///         fee token, chain-id mappings).
+    bytes32 public constant UPDATE_ADAPTER_CONFIG_PERMISSION_ID =
+        keccak256("UPDATE_ADAPTER_CONFIG_PERMISSION");
 
-    /// @notice standard chain id -> origin forwarder address.
+    /// @notice The address of crosschain controller.
+    address public immutable override CROSS_CHAIN_CONTROLLER;
+
+    /// @notice standard chain id -> remote adapter address allowed to originate
+    ///         messages for that chain.
     mapping(uint256 => address) internal _trustedRemotes;
 
+    /// @notice Emitted when a trusted remote is set or cleared.
+    event TrustedRemoteSet(uint256 indexed chainId, address trustedRemote);
+
+    /// @notice Restricts a function to the owning `CrossChainController`.
+    modifier onlyCrossChainController() {
+        if (msg.sender != CROSS_CHAIN_CONTROLLER) {
+            revert Errors.CALLER_NOT_CROSS_CHAIN_CONTROLLER(msg.sender);
+        }
+        _;
+    }
+
+    /// @param _crossChainController The controller that owns this adapter. Its
+    ///        DAO is adopted as the adapter's permission manager.
+    /// @param _remoteChainIds The standard chain ids of the remote lanes.
+    /// @param _remoteTrustedSenders The remote ADAPTER address per lane.
     constructor(
         address _crossChainController,
         uint256[] memory _remoteChainIds,
         address[] memory _remoteTrustedSenders
-    ) {
+    ) DaoAuthorizable(CrossChainController(payable(_crossChainController)).dao()) {
         CROSS_CHAIN_CONTROLLER = _crossChainController;
 
-        if (_remoteChainIds.length != _remoteTrustedSenders.length) {
-            revert Errors.INVALID_LENGTH_MISMATCH();
-        }
+        _setTrustedRemotes(_remoteChainIds, _remoteTrustedSenders);
+    }
 
-        for (uint256 i = 0; i < _remoteChainIds.length; i++) {
-            address remoteTrustedSender = _remoteTrustedSenders[i];
-            if (remoteTrustedSender == address(0)) {
-                revert Errors.TRUSTED_REMOTE_NOT_SET();
+    /// @notice The remote adapter trusted to originate messages for a chain.
+    /// @param _chainId The standard chain id.
+    /// @return The trusted remote adapter address, or zero if unset.
+    function trustedRemote(uint256 _chainId) public view returns (address) {
+        return _trustedRemotes[_chainId];
+    }
+
+    /// @notice Sets or clears trusted remotes.
+    /// @dev Pass `address(0)` for a sender to clear a lane.
+    /// @param _remoteChainIds The standard chain ids.
+    /// @param _remoteTrustedSenders The remote adapter addresses.
+    function setTrustedRemotes(
+        uint256[] memory _remoteChainIds,
+        address[] memory _remoteTrustedSenders
+    ) public auth(UPDATE_ADAPTER_CONFIG_PERMISSION_ID) {
+        _setTrustedRemotes(_remoteChainIds, _remoteTrustedSenders);
+    }
+
+    /// @notice Reverts unless, for every given chain, this adapter's trusted
+    ///         remote equals the controller's configured `remoteAdapter`.
+    /// @dev Deployment-time sanity check for the easily-misconfigured pair
+    ///      described in the contract-level docs.
+    /// @param _chainIds The standard chain ids to check.
+    function assertTrustedRemotesMatchController(
+        uint256[] memory _chainIds
+    ) public view {
+        for (uint256 i = 0; i < _chainIds.length; i++) {
+            uint256 chainId = _chainIds[i];
+
+            (, address remoteAdapter) = CrossChainController(
+                payable(CROSS_CHAIN_CONTROLLER)
+            ).chainToAdapter(chainId);
+
+            address trusted = _trustedRemotes[chainId];
+
+            if (trusted == address(0) || trusted != remoteAdapter) {
+                revert Errors.TRUSTED_REMOTE_MISMATCH(
+                    chainId,
+                    trusted,
+                    remoteAdapter
+                );
             }
-
-            _trustedRemotes[_remoteChainIds[i]] = _remoteTrustedSenders[i];
         }
     }
 
     /// @notice Once adapter receives a message, this must be called
     ///         to redirect/forward it to CrossChainController.
+    /// @dev MUST stay `internal`: it is the unauthenticated side of the receive
+    ///      path, reachable only after the bridge-specific caller and
+    ///      trusted-remote checks have passed.
+    /// @param _messageId The bridge-level message identifier.
+    /// @param _payload The encoded Action[] message.
+    /// @param _originChainId The standard chain id the message came from.
     function _forwardMessage(
+        bytes32 _messageId,
         bytes memory _payload,
-        uint256 originChainId
-    ) public {
-        CrossChainController(CROSS_CHAIN_CONTROLLER).receiveMessage(
+        uint256 _originChainId
+    ) internal {
+        CrossChainController(payable(CROSS_CHAIN_CONTROLLER)).receiveMessage(
+            _messageId,
             _payload,
-            originChainId
+            _originChainId
         );
+    }
+
+    function _setTrustedRemotes(
+        uint256[] memory _remoteChainIds,
+        address[] memory _remoteTrustedSenders
+    ) internal {
+        if (_remoteChainIds.length != _remoteTrustedSenders.length) {
+            revert Errors.INVALID_LENGTH_MISMATCH();
+        }
+
+        for (uint256 i = 0; i < _remoteChainIds.length; i++) {
+            uint256 chainId = _remoteChainIds[i];
+            if (chainId == 0) revert Errors.INVALID_CHAIN_ID();
+
+            _trustedRemotes[chainId] = _remoteTrustedSenders[i];
+
+            emit TrustedRemoteSet(chainId, _remoteTrustedSenders[i]);
+        }
     }
 }

--- a/src/common/crosschain/adapters/BaseAdapter.sol
+++ b/src/common/crosschain/adapters/BaseAdapter.sol
@@ -9,39 +9,8 @@ import {IBaseAdapter} from "./IBaseAdapter.sol";
 
 /// @title BaseAdapter
 /// @notice Shared logic for bridge adapters owned by a `CrossChainController`.
-/// @dev  TWO EXECUTION CONTEXTS. Read this before touching anything here.
-///
-///       1. SEND — `delegatecall` from the controller. `address(this)` is the
-///          CONTROLLER. Any `SLOAD`/`SSTORE` executed here reads or writes the
-///          CONTROLLER's storage, so the send path MUST be storage-free:
-///          `immutable`s only (they are baked into the adapter's bytecode and
-///          therefore resolve correctly under `delegatecall`) plus arguments
-///          passed in by the controller. `onlyDelegatecallFromController`
-///          enforces the context.
-///
-///       2. RECEIVE — a NORMAL call from the bridge router into the adapter.
-///          `address(this)` is the adapter, so the adapter's own storage
-///          applies and mutable, permissioned configuration is fine. That is
-///          where `_trustedRemotes` and the chain-id maps live.
-///
-///       TRUSTED REMOTE == REMOTE **CONTROLLER**. Because the send is a
-///       `delegatecall`, the account that calls the bridge router is the
-///       controller, and the sender address delivered on the far side is the
-///       remote chain's CONTROLLER. `_trustedRemotes[chainId]` must therefore
-///       hold the remote CONTROLLER address, while the controller's
-///       `chainToAdapter[chainId].remoteAdapter` holds the remote ADAPTER
-///       address (the bridge-level receiver). These are two DIFFERENT
-///       addresses; setting the remote adapter as the trusted remote is a
-///       silent, total loss of inbound liveness. See
-///       `assertTrustedRemotesMatchControllers`.
-///
-///       Adapter administration is authorized through the same DAO that owns
-///       the controller, so no separate ownership system is introduced. Note
-///       that `auth()` MUST NOT be used on the send path: `DaoAuthorizable`
-///       holds the DAO as an `immutable` (fine) but permission lookups are
-///       keyed on `address(this)`, which differs between the two contexts.
 /// @custom:security-contact sirt@aragon.org
-abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
+abstract contract BaseAdapter is IBaseAdapter {
     /// @notice Permission to change adapter configuration (trusted remotes,
     ///         chain-id mappings). Receive-path configuration only; the send
     ///         path is configured on the controller.
@@ -49,20 +18,21 @@ abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
         keccak256("UPDATE_ADAPTER_CONFIG_PERMISSION");
 
     /// @notice The address of crosschain controller.
-    /// @dev `immutable`, so it is readable both from the adapter's own context
-    ///      and from the controller's context under `delegatecall`.
     address public immutable override CROSS_CHAIN_CONTROLLER;
 
     /// @notice This adapter's own address, captured at construction.
-    /// @dev `immutable`, so it is baked into the bytecode and keeps its value
-    ///      even when that bytecode is executed in someone else's context.
-    ///      Comparing it to `address(this)` is how the receive path detects
-    ///      that it is running under `delegatecall`.
     address private immutable _selfAddress;
 
-    /// @notice standard chain id -> remote CONTROLLER address allowed to
-    ///         originate messages for that chain.
-    /// @dev NOT the remote adapter. See the contract-level docs.
+    /// @notice A standard chain id paired with the remote trusted sender.
+    /// @param standardChainId The standard chain id of remote chain.
+    /// @param trustedRemote The remote trusted address(i.e origin forwarder)
+    struct TrustedRemoteConfig {
+        uint256 standardChainId;
+        address trustedRemote;
+    }
+
+    /// @notice standard chain id -> remote trusted address allowed
+    ///         to originate messages for that chain.
     mapping(uint256 => address) internal _trustedRemotes;
 
     /// @notice Emitted when a trusted remote is set or cleared.
@@ -94,22 +64,18 @@ abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
 
     /// @param _crossChainController The controller that owns this adapter. Its
     ///        DAO is adopted as the adapter's permission manager.
-    /// @param _remoteChainIds The standard chain ids of the remote lanes.
-    /// @param _remoteTrustedSenders The remote CONTROLLER address per lane.
+    /// @param _trustedRemoteConfigs The remote trusted config.
     constructor(
         address _crossChainController,
-        uint256[] memory _remoteChainIds,
-        address[] memory _remoteTrustedSenders
-    ) DaoAuthorizable(CrossChainController(payable(_crossChainController)).dao()) {
+        TrustedRemoteConfig[] memory _trustedRemoteConfigs
+    ) {
         CROSS_CHAIN_CONTROLLER = _crossChainController;
         _selfAddress = address(this);
 
-        _setTrustedRemotes(_remoteChainIds, _remoteTrustedSenders);
+        _setTrustedRemotes(_trustedRemoteConfigs);
     }
 
     /// @inheritdoc IBaseAdapter
-    /// @dev Redeclared as `public` so the consistency helpers below can call it
-    ///      internally; implemented by the concrete adapter.
     function toNativeChainId(
         uint256 _chainId
     ) public view virtual override returns (uint256);
@@ -121,128 +87,23 @@ abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
         return _trustedRemotes[_chainId];
     }
 
-    /// @notice Sets or clears trusted remotes.
-    /// @dev Pass `address(0)` for a sender to clear a lane. The values are
-    ///      remote CONTROLLER addresses, NOT remote adapter addresses.
-    /// @param _remoteChainIds The standard chain ids.
-    /// @param _remoteTrustedSenders The remote controller addresses.
-    function setTrustedRemotes(
-        uint256[] memory _remoteChainIds,
-        address[] memory _remoteTrustedSenders
-    ) public auth(UPDATE_ADAPTER_CONFIG_PERMISSION_ID) {
-        _setTrustedRemotes(_remoteChainIds, _remoteTrustedSenders);
-    }
-
-    /// @notice Deployment-time check that this adapter's trusted remotes are
-    ///         the expected remote CONTROLLER addresses, and specifically that
-    ///         they are NOT the remote ADAPTER addresses the controller has
-    ///         configured as bridge receivers.
-    /// @dev The expected values must be supplied by the deployer: the local
-    ///      controller stores the remote ADAPTER (the bridge receiver), not the
-    ///      remote controller, so there is nothing on-chain to cross-check
-    ///      against. What CAN be checked mechanically — and is — is that the
-    ///      two were not confused for one another.
-    /// @param _chainIds The standard chain ids to check.
-    /// @param _expectedRemoteControllers The remote CONTROLLER per chain id.
-    function assertTrustedRemotesMatchControllers(
-        uint256[] memory _chainIds,
-        address[] memory _expectedRemoteControllers
-    ) public view {
-        if (_chainIds.length != _expectedRemoteControllers.length) {
-            revert Errors.INVALID_LENGTH_MISMATCH();
-        }
-
-        for (uint256 i = 0; i < _chainIds.length; i++) {
-            uint256 chainId = _chainIds[i];
-            address trusted = _trustedRemotes[chainId];
-
-            if (trusted == address(0) || trusted != _expectedRemoteControllers[i]) {
-                revert Errors.TRUSTED_REMOTE_MISMATCH(
-                    chainId,
-                    trusted,
-                    _expectedRemoteControllers[i]
-                );
-            }
-
-            (, address remoteAdapter, ) = CrossChainController(
-                payable(CROSS_CHAIN_CONTROLLER)
-            ).chainToAdapter(chainId);
-
-            if (remoteAdapter != address(0) && trusted == remoteAdapter) {
-                revert Errors.TRUSTED_REMOTE_IS_REMOTE_ADAPTER(
-                    chainId,
-                    trusted
-                );
-            }
-        }
-    }
-
-    /// @notice Deployment-time check that the controller's send-side
-    ///         `bridgeChainId` agrees with this adapter's receive-side
-    ///         chain-id map for the same chains.
-    /// @dev The same mapping necessarily exists twice: the send path may not
-    ///      read storage, so the controller carries chainId -> bridge id in its
-    ///      lane config, while the receive path needs bridge id -> chainId in
-    ///      adapter storage. A desync silently sends to the wrong lane (or to
-    ///      a lane whose inbound messages the far side cannot attribute), so
-    ///      run this after every `updateConfig`/`setChainSelectors`.
-    /// @param _chainIds The standard chain ids to check.
-    function assertChainSelectorsMatchController(
-        uint256[] memory _chainIds
-    ) public view {
-        for (uint256 i = 0; i < _chainIds.length; i++) {
-            uint256 chainId = _chainIds[i];
-
-            (, , uint64 controllerBridgeChainId) = CrossChainController(
-                payable(CROSS_CHAIN_CONTROLLER)
-            ).chainToAdapter(chainId);
-
-            if (controllerBridgeChainId == 0) {
-                revert Errors.ADAPTER_NOT_CONFIGURED(chainId);
-            }
-
-            // Reverts `UNKNOWN_CHAIN_ID` if the adapter has no entry at all.
-            uint64 adapterBridgeChainId = uint64(toNativeChainId(chainId));
-
-            if (controllerBridgeChainId != adapterBridgeChainId) {
-                revert Errors.CHAIN_ID_DESYNC(
-                    chainId,
-                    controllerBridgeChainId,
-                    adapterBridgeChainId
-                );
-            }
-        }
-    }
-
     /// @notice The address this adapter was deployed at.
     /// @return The adapter's own address, from bytecode.
     function selfAddress() public view returns (address) {
         return _selfAddress;
     }
 
-    /// @notice Once adapter receives a message, this must be called
-    ///         to redirect/forward it to CrossChainController.
-    /// @dev MUST stay `internal`: it is the unauthenticated side of the receive
-    ///      path, reachable only after the bridge-specific caller and
-    ///      trusted-remote checks have passed.
-    ///
-    ///      GUARDS THE SEND/RECEIVE ASYMMETRY. This is the last common point of
-    ///      the receive path, and everything upstream of it (trusted remotes,
-    ///      chain-id maps) is STORAGE — which is only meaningful when this code
-    ///      runs in the adapter's own context. If it were ever reached under
-    ///      `delegatecall` (from the controller's send path, or from anything
-    ///      else), those reads would resolve against foreign slots and the
-    ///      authentication they perform would be meaningless. `address(this)`
-    ///      is compared against the `immutable` `_selfAddress` to make that
-    ///      impossible rather than merely unlikely.
+    /// @notice Once adapter receives a message, this forwards it to the CrossChainController.
     /// @param _messageId The bridge-level message identifier.
-    /// @param _payload The encoded Action[] message.
+    /// @param _payload The encoded payload message.
     /// @param _originChainId The standard chain id the message came from.
     function _forwardMessage(
         bytes32 _messageId,
         bytes memory _payload,
         uint256 _originChainId
     ) internal {
+        // Extra defense to ensure that caller on controller will always be
+        // Adapter and not the contract that called adapter with delegatecall.
         if (address(this) != _selfAddress) {
             revert Errors.DELEGATE_CALL_FORBIDDEN(address(this), _selfAddress);
         }
@@ -254,21 +115,20 @@ abstract contract BaseAdapter is IBaseAdapter, DaoAuthorizable {
         );
     }
 
+    /// @notice Sets the trusted remotes for receiving messages.
+    ///        Generally, it should be the cross chain controller
+    ///        of source chain.
     function _setTrustedRemotes(
-        uint256[] memory _remoteChainIds,
-        address[] memory _remoteTrustedSenders
+        TrustedRemoteConfig[] memory _trustedRemoteConfigs
     ) internal {
-        if (_remoteChainIds.length != _remoteTrustedSenders.length) {
-            revert Errors.INVALID_LENGTH_MISMATCH();
-        }
-
-        for (uint256 i = 0; i < _remoteChainIds.length; i++) {
-            uint256 chainId = _remoteChainIds[i];
+        for (uint256 i = 0; i < _trustedRemoteConfigs.length; i++) {
+            uint256 chainId = _trustedRemoteConfigs[i].standardChainId;
             if (chainId == 0) revert Errors.INVALID_CHAIN_ID();
 
-            _trustedRemotes[chainId] = _remoteTrustedSenders[i];
+            address trustedRemote_ = _trustedRemoteConfigs[i].trustedRemote;
+            _trustedRemotes[chainId] = trustedRemote_;
 
-            emit TrustedRemoteSet(chainId, _remoteTrustedSenders[i]);
+            emit TrustedRemoteSet(chainId, trustedRemote_);
         }
     }
 }

--- a/src/common/crosschain/adapters/CCIP/CCIPAdapter.sol
+++ b/src/common/crosschain/adapters/CCIP/CCIPAdapter.sol
@@ -7,9 +7,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {
     SafeERC20
 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {
-    SafeCast
-} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import {
     IRouterClient
@@ -20,78 +18,29 @@ import {
 } from "@chainlink/contracts-ccip/contracts/interfaces/IAny2EVMMessageReceiver.sol";
 
 import {Errors} from "../../lib/Errors.sol";
+import {ChainIds} from "../../lib/ChainIds.sol";
 
 import {BaseAdapter} from "../BaseAdapter.sol";
 import {IBaseAdapter} from "../IBaseAdapter.sol";
 
 /// @title CCIPAdapter
 /// @notice Chainlink CCIP implementation of `IBaseAdapter`.
-/// @dev  SEND is `delegatecall`ed by the `CrossChainController`; RECEIVE is a
-///       normal call from the CCIP Router. The two halves of this contract
-///       therefore run in different contexts and obey different rules.
-///
-///       Send half (`sendMessage`, `quoteFee`) — STORAGE-FREE BY CONSTRUCTION.
-///       `CCIP_ROUTER` and `FEE_TOKEN` are `immutable`, so they live in this
-///       contract's deployed bytecode and resolve identically whether the code
-///       runs here or in the controller's context. The destination chain
-///       selector is not looked up at all: the controller passes it in as
-///       `_bridgeChainId`. There is consequently no storage slot for the send
-///       path to collide with.
-///
-///       Trade-off, accepted deliberately: THE FEE TOKEN CANNOT BE CHANGED.
-///       Rotating it means deploying a new `CCIPAdapter` with the new
-///       `FEE_TOKEN` and pointing the affected lanes at it with
-///       `CrossChainController.updateConfig`. `updateConfig` already handles
-///       adapter rotation correctly (refcounted local-adapter registry), and
-///       the new adapter must be seeded with the same trusted remotes and
-///       selector map. Same applies to changing the router.
-///
-///       Receive half (`ccipReceive`) — the Router calls this contract
-///       directly, so `_trustedRemotes` and the selector maps are this
-///       contract's own storage and are updatable under
-///       `UPDATE_ADAPTER_CONFIG_PERMISSION`.
-///
-///       `_trustedRemotes[chainId]` HOLDS THE REMOTE **CONTROLLER**. Under
-///       `delegatecall` the account calling `ccipSend` on the source chain is
-///       the source CONTROLLER, so that is the sender CCIP reports here. The
-///       remote ADAPTER address is what the source controller stores as
-///       `chainToAdapter[].remoteAdapter` (the CCIP `receiver`). Do not
-///       conflate them.
-///
-///       Fee handling: the controller pays. Under `delegatecall`, `msg.sender`
-///       towards the Router and `address(this)` are the controller, so
-///       `ccipSend{value: fee}` spends the controller's native balance and
-///       `forceApprove` grants the Router an allowance over the CONTROLLER's
-///       ERC20 balance. This adapter never custodies funds.
+/// @dev  The caller must call `sendMessage` via delegate call because:
+///          1. It's a controller that pays, not adapter.
+///          2. sender on the remote adapter must be crosschain controller, not the adapter.
 /// @custom:security-contact sirt@aragon.org
 contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     using SafeERC20 for IERC20;
 
     /// @notice The CCIP Router address.
-    /// @dev `immutable`: read on the `delegatecall`ed send path.
     IRouterClient public immutable CCIP_ROUTER;
 
-    /// @notice The fee token used to pay bridge fees. `address(0)` means the
-    ///         chain's native currency.
-    /// @dev `immutable` by necessity, not by preference: a storage read here
-    ///      would resolve against the controller's slots under `delegatecall`.
-    ///      Changing the fee token requires a new adapter deployment plus
-    ///      `CrossChainController.updateConfig`.
+    /// @notice The fee token used to pay bridge fees.
+    ///         `address(0)` = chain's native currency.
+    /// @dev a storage read here would resolve against
+    ///      the controller's slots under `delegatecall`.
+    ///      Changing the fee token requires a new adapter.
     address public immutable FEE_TOKEN;
-
-    /// @notice standard chain id -> CCIP chain selector.
-    /// @dev RECEIVE-SIDE / OPERATIONAL ONLY. The send path does NOT read this;
-    ///      the controller carries the selector in its lane config. Kept so the
-    ///      reverse map can be maintained coherently and so
-    ///      `assertChainSelectorsMatchController` can detect a desync between
-    ///      the two copies.
-    mapping(uint256 => uint64) internal _chainIdToSelector;
-
-    /// @notice CCIP chain selector -> standard chain id. Used by `ccipReceive`.
-    mapping(uint64 => uint256) internal _selectorToChainId;
-
-    /// @notice Emitted when a chain-id <-> selector pair is set or cleared.
-    event ChainSelectorSet(uint256 indexed chainId, uint64 chainSelector);
 
     /// @notice The receive function must only allow CCIP router.
     modifier onlyRouter() {
@@ -105,116 +54,68 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     /// @param _crosschainController The owning controller.
     /// @param _ccipRouter The CCIP router on this chain.
     /// @param _feeToken The fee token, or `address(0)` for native. IMMUTABLE.
-    /// @param _chainIds The standard chain ids of the configured lanes.
-    /// @param _trustedRemoteSenders The remote CONTROLLER address per lane.
-    /// @param _selectorChainIds The standard chain ids of the selector mapping.
-    /// @param _chainSelectors The CCIP selector per entry of `_selectorChainIds`.
+    /// @param _trustedRemoteConfigs The remote trusted config.
     constructor(
         address _crosschainController,
         address _ccipRouter,
         address _feeToken,
-        uint256[] memory _chainIds,
-        address[] memory _trustedRemoteSenders,
-        uint256[] memory _selectorChainIds,
-        uint64[] memory _chainSelectors
-    ) BaseAdapter(_crosschainController, _chainIds, _trustedRemoteSenders) {
+        TrustedRemoteConfig[] memory _trustedRemoteConfigs
+    ) BaseAdapter(_crosschainController, _trustedRemoteConfigs) {
         if (_ccipRouter == address(0)) revert Errors.ZERO_ADDRESS();
 
         CCIP_ROUTER = IRouterClient(_ccipRouter);
         FEE_TOKEN = _feeToken;
-
-        _setChainSelectors(_selectorChainIds, _chainSelectors);
     }
-
-    // -------------------------------------------------------------------------
-    // Configuration (receive side only)
-    // -------------------------------------------------------------------------
-
-    /// @notice Sets or clears standard chain id <-> CCIP selector pairs.
-    /// @dev New CCIP lanes appear over time, so the RECEIVE side must be
-    ///      updatable without redeploying the adapter. The SEND side is
-    ///      configured on the controller (`ChainConfig.bridgeChainId`); after
-    ///      changing either, run `assertChainSelectorsMatchController`.
-    ///      Pass selector `0` to clear a mapping.
-    /// @param _chainIds The standard chain ids.
-    /// @param _chainSelectors The CCIP chain selectors.
-    function setChainSelectors(
-        uint256[] memory _chainIds,
-        uint64[] memory _chainSelectors
-    ) public auth(UPDATE_ADAPTER_CONFIG_PERMISSION_ID) {
-        _setChainSelectors(_chainIds, _chainSelectors);
-    }
-
-    // -------------------------------------------------------------------------
-    // Sending -- MUST NOT TOUCH STORAGE
-    // -------------------------------------------------------------------------
 
     /// @inheritdoc IBaseAdapter
     function quoteFee(
         address _receiver,
-        uint64 _bridgeChainId,
+        uint256 _destinationChainId,
         uint256 _gasLimit,
         bytes calldata _message
     ) public view override returns (address, uint256) {
         if (_receiver == address(0)) revert Errors.RECEIVER_ADDRESS_ZERO();
-        if (_bridgeChainId == 0) revert Errors.UNKNOWN_CHAIN_ID(0);
+
+        // Reverts if not set.
+        uint64 nativeChainId = SafeCast.toUint64(
+            toNativeChainId(_destinationChainId)
+        );
 
         return (
             FEE_TOKEN,
             CCIP_ROUTER.getFee(
-                _bridgeChainId,
+                nativeChainId,
                 _buildMessage(_receiver, _gasLimit, _message, FEE_TOKEN)
             )
         );
     }
 
     /// @inheritdoc IBaseAdapter
-    /// @dev Every value used here is an `immutable` or an argument. Adding a
-    ///      storage read to this function would corrupt the controller.
-    ///
-    ///      REACHABILITY NOTE, so a reviewer does not have to derive it: two of
-    ///      the guards below are UNREACHABLE from the only production entry
-    ///      point today, and are kept deliberately.
-    ///      - `RECEIVER_ADDRESS_ZERO`: `CrossChainController._validatedConfig`
-    ///        already rejects a zero `remoteAdapter` before it will
-    ///        `delegatecall` at all, so `_receiver` cannot be zero in practice.
-    ///      - `UNEXPECTED_NATIVE_VALUE`: `forwardMessage` is not `payable`, so
-    ///        the `msg.value` inherited by this frame is always `0`.
-    ///      Both are retained so that making `forwardMessage` payable, or
-    ///      relaxing the lane validation, cannot silently turn a stranded-funds
-    ///      or wrong-receiver bug into a live one. They are cheap. Do not
-    ///      delete them without re-checking those two call-site invariants.
     function sendMessage(
         address _receiver,
-        uint64 _bridgeChainId,
+        uint256 _destinationChainId,
         uint256 _gasLimit,
         bytes calldata _message
-    )
-        public
-        payable
-        override
-        onlyDelegatecallFromController
-        returns (bytes32 messageId, address feeToken, uint256 fee)
-    {
+    ) public payable override returns (bytes32 messageId, uint256 fee) {
         if (_receiver == address(0)) revert Errors.RECEIVER_ADDRESS_ZERO();
-        // Defence in depth: the controller already rejects an unset lane, but
-        // selector 0 must never reach the Router.
-        if (_bridgeChainId == 0) revert Errors.UNKNOWN_CHAIN_ID(0);
 
-        feeToken = FEE_TOKEN;
+        // Reverts if not set.
+        uint64 nativeChainId = SafeCast.toUint64(
+            toNativeChainId(_destinationChainId)
+        );
 
         Client.EVM2AnyMessage memory ccipMessage = _buildMessage(
             _receiver,
             _gasLimit,
             _message,
-            feeToken
+            FEE_TOKEN
         );
 
         // CCIP does not refund overpayment, so quote and pay exactly.
-        fee = CCIP_ROUTER.getFee(_bridgeChainId, ccipMessage);
+        fee = CCIP_ROUTER.getFee(nativeChainId, ccipMessage);
 
         // `address(this)` is the CONTROLLER here: it is the fee payer.
-        if (feeToken == address(0)) {
+        if (FEE_TOKEN == address(0)) {
             uint256 balance = address(this).balance;
             if (balance < fee) {
                 revert Errors.INSUFFICIENT_FEE_BALANCE(
@@ -225,7 +126,7 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
             }
 
             messageId = CCIP_ROUTER.ccipSend{value: fee}(
-                _bridgeChainId,
+                nativeChainId,
                 ccipMessage
             );
         } else {
@@ -233,30 +134,23 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
             // an ERC20 fee is due; surface the mistake instead.
             if (msg.value != 0) revert Errors.UNEXPECTED_NATIVE_VALUE();
 
-            uint256 balance = IERC20(feeToken).balanceOf(address(this));
+            uint256 balance = IERC20(FEE_TOKEN).balanceOf(address(this));
             if (balance < fee) {
-                revert Errors.INSUFFICIENT_FEE_BALANCE(feeToken, fee, balance);
+                revert Errors.INSUFFICIENT_FEE_BALANCE(FEE_TOKEN, fee, balance);
             }
 
             // The Router pulls the fee via `transferFrom` from the CONTROLLER,
             // which is the account granting the allowance under `delegatecall`.
-            IERC20(feeToken).forceApprove(address(CCIP_ROUTER), fee);
+            IERC20(FEE_TOKEN).forceApprove(address(CCIP_ROUTER), fee);
 
-            messageId = CCIP_ROUTER.ccipSend(_bridgeChainId, ccipMessage);
+            messageId = CCIP_ROUTER.ccipSend(nativeChainId, ccipMessage);
 
             // Leave no standing allowance on the controller.
-            IERC20(feeToken).forceApprove(address(CCIP_ROUTER), 0);
+            IERC20(FEE_TOKEN).forceApprove(address(CCIP_ROUTER), 0);
         }
     }
 
-    // -------------------------------------------------------------------------
-    // Receiving -- normal call, this contract's own storage
-    // -------------------------------------------------------------------------
-
     /// @inheritdoc IAny2EVMMessageReceiver
-    /// @dev `message.sender` is the remote CONTROLLER (it `delegatecall`ed its
-    ///      adapter's send code, so it is the account that called the remote
-    ///      Router), which is what `_trustedRemotes` stores.
     function ccipReceive(
         Client.Any2EVMMessage calldata message
     ) external onlyRouter {
@@ -280,32 +174,6 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
         return
             interfaceId == type(IAny2EVMMessageReceiver).interfaceId ||
             interfaceId == type(IERC165).interfaceId;
-    }
-
-    // -------------------------------------------------------------------------
-    // Chain id mapping
-    // -------------------------------------------------------------------------
-
-    /// @inheritdoc IBaseAdapter
-    /// @dev CCIP addresses lanes by chain SELECTOR, not by EVM chain id. Not
-    ///      consulted when sending (the controller supplies the selector);
-    ///      exposed for operations and for the consistency assertion.
-    ///      Unknown ids revert rather than returning `0`.
-    function toNativeChainId(
-        uint256 _chainId
-    ) public view virtual override returns (uint256) {
-        uint64 selector = _chainIdToSelector[_chainId];
-        if (selector == 0) revert Errors.UNKNOWN_CHAIN_ID(_chainId);
-        return selector;
-    }
-
-    /// @inheritdoc IBaseAdapter
-    function fromNativeChainId(
-        uint256 _chainId
-    ) public view virtual override returns (uint256) {
-        uint256 chainId = _selectorToChainId[SafeCast.toUint64(_chainId)];
-        if (chainId == 0) revert Errors.UNKNOWN_NATIVE_CHAIN_ID(_chainId);
-        return chainId;
     }
 
     // -------------------------------------------------------------------------
@@ -335,30 +203,63 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
             });
     }
 
-    function _setChainSelectors(
-        uint256[] memory _chainIds,
-        uint64[] memory _chainSelectors
-    ) internal {
-        if (_chainIds.length != _chainSelectors.length) {
-            revert Errors.INVALID_LENGTH_MISMATCH();
+    // -------------------------------------------------------------------------
+    // Chain id mapping
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IBaseAdapter
+    function toNativeChainId(
+        uint256 _chainId
+    ) public view virtual override returns (uint256) {
+        if (_chainId == ChainIds.ETHEREUM) {
+            return uint64(5009297550715157269);
+        } else if (_chainId == ChainIds.AVALANCHE) {
+            return uint64(6433500567565415381);
+        } else if (_chainId == ChainIds.POLYGON) {
+            return uint64(4051577828743386545);
+        } else if (_chainId == ChainIds.BNB) {
+            return uint64(11344663589394136015);
+        } else if (_chainId == ChainIds.CELO) {
+            return uint64(1346049177634351622);
+        } else if (_chainId == ChainIds.SONIC) {
+            return uint64(1673871237479749969);
+        } else if (_chainId == ChainIds.PLASMA) {
+            return uint64(9335212494177455608);
+        } else if (_chainId == ChainIds.MONAD) {
+            return uint64(8481857512324358265);
+        } else if (_chainId == ChainIds.BASE) {
+            return uint64(15971525489660198786);
+        } else if (_chainId == ChainIds.ARBITRUM_ONE) {
+            return uint64(4949039107694359620);
         }
+        revert Errors.UNKNOWN_CHAIN_ID(_chainId);
+    }
 
-        for (uint256 i = 0; i < _chainIds.length; i++) {
-            uint256 chainId = _chainIds[i];
-            if (chainId == 0) revert Errors.INVALID_CHAIN_ID();
-
-            uint64 previousSelector = _chainIdToSelector[chainId];
-            if (previousSelector != 0) {
-                delete _selectorToChainId[previousSelector];
-            }
-
-            uint64 selector = _chainSelectors[i];
-            _chainIdToSelector[chainId] = selector;
-            if (selector != 0) {
-                _selectorToChainId[selector] = chainId;
-            }
-
-            emit ChainSelectorSet(chainId, selector);
+    /// @inheritdoc IBaseAdapter
+    function fromNativeChainId(
+        uint256 _chainId
+    ) public view virtual override returns (uint256) {
+        if (_chainId == uint64(5009297550715157269)) {
+            return ChainIds.ETHEREUM;
+        } else if (_chainId == uint64(6433500567565415381)) {
+            return ChainIds.AVALANCHE;
+        } else if (_chainId == uint64(4051577828743386545)) {
+            return ChainIds.POLYGON;
+        } else if (_chainId == uint64(11344663589394136015)) {
+            return ChainIds.BNB;
+        } else if (_chainId == uint64(1346049177634351622)) {
+            return ChainIds.CELO;
+        } else if (_chainId == uint64(1673871237479749969)) {
+            return ChainIds.SONIC;
+        } else if (_chainId == uint64(9335212494177455608)) {
+            return ChainIds.PLASMA;
+        } else if (_chainId == uint64(8481857512324358265)) {
+            return ChainIds.MONAD;
+        } else if (_chainId == uint64(15971525489660198786)) {
+            return ChainIds.BASE;
+        } else if (_chainId == uint64(4949039107694359620)) {
+            return ChainIds.ARBITRUM_ONE;
         }
+        revert Errors.UNKNOWN_NATIVE_CHAIN_ID(_chainId);
     }
 }

--- a/src/common/crosschain/adapters/CCIP/CCIPAdapter.sol
+++ b/src/common/crosschain/adapters/CCIP/CCIPAdapter.sol
@@ -6,10 +6,10 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {
     SafeERC20
-} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {
     SafeCast
-} from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import {
     IRouterClient
@@ -24,6 +24,19 @@ import {Errors} from "../../lib/Errors.sol";
 import {BaseAdapter} from "../BaseAdapter.sol";
 import {IBaseAdapter} from "../IBaseAdapter.sol";
 
+/// @title CCIPAdapter
+/// @notice Chainlink CCIP implementation of `IBaseAdapter`.
+/// @dev Called (never `delegatecall`ed) by the `CrossChainController`, so this
+///      contract's storage is its own and CCIP sees THIS ADAPTER as the sender.
+///      The remote side must therefore trust this adapter's address, and
+///      `_trustedRemotes[chainId]` here must hold the remote ADAPTER address.
+///
+///      Fee handling: the controller custodies the funds and hands this adapter
+///      exactly the quoted fee per send (native as `msg.value`, ERC20 by
+///      transfer immediately before the call). Any remainder is returned to the
+///      controller in the same transaction. CCIP does NOT refund overpayment,
+///      so the fee is quoted with `getFee` and paid exactly.
+/// @custom:security-contact sirt@aragon.org
 contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     using SafeERC20 for IERC20;
 
@@ -31,7 +44,20 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     IRouterClient public immutable CCIP_ROUTER;
 
     /// @notice The fee token that will be used to pay for bridge fees.
+    ///         `address(0)` means the chain's native currency.
     address public feeToken;
+
+    /// @notice standard chain id -> CCIP chain selector.
+    mapping(uint256 => uint64) internal _chainIdToSelector;
+
+    /// @notice CCIP chain selector -> standard chain id.
+    mapping(uint64 => uint256) internal _selectorToChainId;
+
+    /// @notice Emitted when the fee token is changed.
+    event FeeTokenSet(address feeToken);
+
+    /// @notice Emitted when a chain-id <-> selector pair is set or cleared.
+    event ChainSelectorSet(uint256 indexed chainId, uint64 chainSelector);
 
     /// @notice The receive function must only allow CCIP router.
     modifier onlyRouter() {
@@ -42,59 +68,159 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
         _;
     }
 
+    /// @param _crosschainController The owning controller.
+    /// @param _ccipRouter The CCIP router on this chain.
+    /// @param _feeToken The fee token, or `address(0)` for native.
+    /// @param _chainIds The standard chain ids of the configured lanes.
+    /// @param _trustedRemoteSenders The remote ADAPTER address per lane.
+    /// @param _selectorChainIds The standard chain ids of the selector mapping.
+    /// @param _chainSelectors The CCIP selector per entry of `_selectorChainIds`.
     constructor(
         address _crosschainController,
         address _ccipRouter,
         address _feeToken,
         uint256[] memory _chainIds,
-        address[] memory _trustedRemoteSenders
+        address[] memory _trustedRemoteSenders,
+        uint256[] memory _selectorChainIds,
+        uint64[] memory _chainSelectors
     ) BaseAdapter(_crosschainController, _chainIds, _trustedRemoteSenders) {
+        if (_ccipRouter == address(0)) revert Errors.ZERO_ADDRESS();
+
         CCIP_ROUTER = IRouterClient(_ccipRouter);
         feeToken = _feeToken;
+
+        _setChainSelectors(_selectorChainIds, _chainSelectors);
     }
 
+    /// @notice Accepts the native fee handed over by the controller.
+    receive() external payable {}
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    /// @notice Sets the fee token used for subsequent sends.
+    /// @param _feeToken The new fee token, or `address(0)` for native.
+    function setFeeToken(
+        address _feeToken
+    ) public auth(UPDATE_ADAPTER_CONFIG_PERMISSION_ID) {
+        feeToken = _feeToken;
+
+        emit FeeTokenSet(_feeToken);
+    }
+
+    /// @notice Sets or clears standard chain id <-> CCIP selector pairs.
+    /// @dev New CCIP lanes appear over time, so this must be updatable without
+    ///      redeploying the adapter. Pass selector `0` to clear a mapping.
+    /// @param _chainIds The standard chain ids.
+    /// @param _chainSelectors The CCIP chain selectors.
+    function setChainSelectors(
+        uint256[] memory _chainIds,
+        uint64[] memory _chainSelectors
+    ) public auth(UPDATE_ADAPTER_CONFIG_PERMISSION_ID) {
+        _setChainSelectors(_chainIds, _chainSelectors);
+    }
+
+    // -------------------------------------------------------------------------
+    // Sending
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IBaseAdapter
+    function quoteFee(
+        address _receiver,
+        uint256 _gasLimit,
+        uint256 _destinationChainId,
+        bytes calldata _message
+    ) public view override returns (address, uint256) {
+        if (_receiver == address(0)) revert Errors.RECEIVER_ADDRESS_ZERO();
+
+        uint64 destChainSelector = SafeCast.toUint64(
+            toNativeChainId(_destinationChainId)
+        );
+
+        address currentFeeToken = feeToken;
+
+        return (
+            currentFeeToken,
+            CCIP_ROUTER.getFee(
+                destChainSelector,
+                _buildMessage(_receiver, _gasLimit, _message, currentFeeToken)
+            )
+        );
+    }
+
+    /// @inheritdoc IBaseAdapter
     function sendMessage(
         address _receiver,
         uint256 _gasLimit,
         uint256 _destinationChainId,
         bytes calldata _message
-    ) public returns (uint256) {
+    ) public payable override onlyCrossChainController returns (bytes32) {
         if (_receiver == address(0)) revert Errors.RECEIVER_ADDRESS_ZERO();
 
-        // TODO: shall we add to only be allowed to call from crosschain controller.
-
-        // Transform standard chain id into chainlink's custom chainId.
-        uint64 destChainId = SafeCast.toUint64(
+        // Transform standard chain id into chainlink's chain selector.
+        uint64 destChainSelector = SafeCast.toUint64(
             toNativeChainId(_destinationChainId)
         );
 
-        // Build CCIP message.
-        bytes memory extraArgs = Client._argsToBytes(
-            Client.GenericExtraArgsV2({
-                gasLimit: _gasLimit,
-                allowOutOfOrderExecution: true
-            })
+        address currentFeeToken = feeToken;
+
+        Client.EVM2AnyMessage memory ccipMessage = _buildMessage(
+            _receiver,
+            _gasLimit,
+            _message,
+            currentFeeToken
         );
 
-        Client.EVM2AnyMessage memory ccipMessage = Client.EVM2AnyMessage({
-            receiver: abi.encode(_receiver),
-            data: _message,
-            tokenAmounts: new Client.EVMTokenAmount[](0),
-            extraArgs: extraArgs,
-            feeToken: address(feeToken)
-        });
+        // CCIP does not refund overpayment, so quote and pay exactly.
+        uint256 fees = CCIP_ROUTER.getFee(destChainSelector, ccipMessage);
 
-        // get fees of how much it will cost to send a message.
-        uint256 fees = CCIP_ROUTER.getFee(destChainId, ccipMessage);
+        bytes32 messageId;
 
-        if (IERC20(feeToken).balanceOf(address(this)) < fees) {
-            revert Errors.NOT_ENOUGH_TO_PAY_BRIDGE();
+        if (currentFeeToken == address(0)) {
+            uint256 balance = address(this).balance;
+            if (balance < fees) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(
+                    address(0),
+                    fees,
+                    balance
+                );
+            }
+
+            messageId = CCIP_ROUTER.ccipSend{value: fees}(
+                destChainSelector,
+                ccipMessage
+            );
+        } else {
+            // Native value would be stranded here; the controller custodies it.
+            if (msg.value != 0) revert Errors.UNEXPECTED_NATIVE_VALUE();
+
+            uint256 balance = IERC20(currentFeeToken).balanceOf(address(this));
+            if (balance < fees) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(
+                    currentFeeToken,
+                    fees,
+                    balance
+                );
+            }
+
+            // The Router pulls the fee via `transferFrom`.
+            IERC20(currentFeeToken).forceApprove(address(CCIP_ROUTER), fees);
+
+            messageId = CCIP_ROUTER.ccipSend(destChainSelector, ccipMessage);
+
+            // Leave no standing allowance.
+            IERC20(currentFeeToken).forceApprove(address(CCIP_ROUTER), 0);
         }
 
-        bytes32 messageId = CCIP_ROUTER.ccipSend(destChainId, ccipMessage);
+        _returnRemainder(currentFeeToken);
 
-        return uint256(messageId);
+        return messageId;
     }
+
+    // -------------------------------------------------------------------------
+    // Receiving
+    // -------------------------------------------------------------------------
 
     /// @inheritdoc IAny2EVMMessageReceiver
     function ccipReceive(
@@ -102,7 +228,7 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     ) external onlyRouter {
         address srcAddress = abi.decode(message.sender, (address));
 
-        // Transform adapter's chainId into standard chain Id.
+        // Transform CCIP's chain selector into the standard chain Id.
         uint256 originChainId = fromNativeChainId(message.sourceChainSelector);
 
         if (
@@ -112,7 +238,7 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
             revert Errors.REMOTE_NOT_TRUSTED();
         }
 
-        _forwardMessage(message.data, originChainId);
+        _forwardMessage(message.messageId, message.data, originChainId);
     }
 
     /// @inheritdoc IERC165
@@ -122,17 +248,107 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
             interfaceId == type(IERC165).interfaceId;
     }
 
+    // -------------------------------------------------------------------------
+    // Chain id mapping
+    // -------------------------------------------------------------------------
+
     /// @inheritdoc IBaseAdapter
+    /// @dev CCIP addresses lanes by chain SELECTOR, not by EVM chain id, so
+    ///      this is a real lookup. Unknown ids revert rather than returning `0`
+    ///      (which would target a nonexistent lane).
     function toNativeChainId(
         uint256 _chainId
-    ) public pure virtual override returns (uint256) {
-        return _chainId;
+    ) public view virtual override returns (uint256) {
+        uint64 selector = _chainIdToSelector[_chainId];
+        if (selector == 0) revert Errors.UNKNOWN_CHAIN_ID(_chainId);
+        return selector;
     }
 
     /// @inheritdoc IBaseAdapter
     function fromNativeChainId(
         uint256 _chainId
-    ) public pure virtual override returns (uint256) {
-        return _chainId;
+    ) public view virtual override returns (uint256) {
+        uint256 chainId = _selectorToChainId[SafeCast.toUint64(_chainId)];
+        if (chainId == 0) revert Errors.UNKNOWN_NATIVE_CHAIN_ID(_chainId);
+        return chainId;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    function _buildMessage(
+        address _receiver,
+        uint256 _gasLimit,
+        bytes memory _message,
+        address _feeToken
+    ) internal pure returns (Client.EVM2AnyMessage memory) {
+        bytes memory extraArgs = Client._argsToBytes(
+            Client.GenericExtraArgsV2({
+                gasLimit: _gasLimit,
+                allowOutOfOrderExecution: true
+            })
+        );
+
+        return
+            Client.EVM2AnyMessage({
+                receiver: abi.encode(_receiver),
+                data: _message,
+                tokenAmounts: new Client.EVMTokenAmount[](0),
+                extraArgs: extraArgs,
+                feeToken: _feeToken
+            });
+    }
+
+    /// @dev Returns anything left over after paying the bridge to the
+    ///      controller, so the adapter never accumulates custody.
+    function _returnRemainder(address _feeToken) internal {
+        if (_feeToken == address(0)) {
+            uint256 remainder = address(this).balance;
+            if (remainder != 0) {
+                (bool ok, ) = CROSS_CHAIN_CONTROLLER.call{value: remainder}("");
+                if (!ok) {
+                    revert Errors.NATIVE_TRANSFER_FAILED(
+                        CROSS_CHAIN_CONTROLLER,
+                        remainder
+                    );
+                }
+            }
+        } else {
+            uint256 remainder = IERC20(_feeToken).balanceOf(address(this));
+            if (remainder != 0) {
+                IERC20(_feeToken).safeTransfer(
+                    CROSS_CHAIN_CONTROLLER,
+                    remainder
+                );
+            }
+        }
+    }
+
+    function _setChainSelectors(
+        uint256[] memory _chainIds,
+        uint64[] memory _chainSelectors
+    ) internal {
+        if (_chainIds.length != _chainSelectors.length) {
+            revert Errors.INVALID_LENGTH_MISMATCH();
+        }
+
+        for (uint256 i = 0; i < _chainIds.length; i++) {
+            uint256 chainId = _chainIds[i];
+            if (chainId == 0) revert Errors.INVALID_CHAIN_ID();
+
+            uint64 previousSelector = _chainIdToSelector[chainId];
+            if (previousSelector != 0) {
+                delete _selectorToChainId[previousSelector];
+            }
+
+            uint64 selector = _chainSelectors[i];
+            _chainIdToSelector[chainId] = selector;
+            if (selector != 0) {
+                _selectorToChainId[selector] = chainId;
+            }
+
+            emit ChainSelectorSet(chainId, selector);
+        }
     }
 }

--- a/src/common/crosschain/adapters/CCIP/CCIPAdapter.sol
+++ b/src/common/crosschain/adapters/CCIP/CCIPAdapter.sol
@@ -26,35 +26,69 @@ import {IBaseAdapter} from "../IBaseAdapter.sol";
 
 /// @title CCIPAdapter
 /// @notice Chainlink CCIP implementation of `IBaseAdapter`.
-/// @dev Called (never `delegatecall`ed) by the `CrossChainController`, so this
-///      contract's storage is its own and CCIP sees THIS ADAPTER as the sender.
-///      The remote side must therefore trust this adapter's address, and
-///      `_trustedRemotes[chainId]` here must hold the remote ADAPTER address.
+/// @dev  SEND is `delegatecall`ed by the `CrossChainController`; RECEIVE is a
+///       normal call from the CCIP Router. The two halves of this contract
+///       therefore run in different contexts and obey different rules.
 ///
-///      Fee handling: the controller custodies the funds and hands this adapter
-///      exactly the quoted fee per send (native as `msg.value`, ERC20 by
-///      transfer immediately before the call). Any remainder is returned to the
-///      controller in the same transaction. CCIP does NOT refund overpayment,
-///      so the fee is quoted with `getFee` and paid exactly.
+///       Send half (`sendMessage`, `quoteFee`) — STORAGE-FREE BY CONSTRUCTION.
+///       `CCIP_ROUTER` and `FEE_TOKEN` are `immutable`, so they live in this
+///       contract's deployed bytecode and resolve identically whether the code
+///       runs here or in the controller's context. The destination chain
+///       selector is not looked up at all: the controller passes it in as
+///       `_bridgeChainId`. There is consequently no storage slot for the send
+///       path to collide with.
+///
+///       Trade-off, accepted deliberately: THE FEE TOKEN CANNOT BE CHANGED.
+///       Rotating it means deploying a new `CCIPAdapter` with the new
+///       `FEE_TOKEN` and pointing the affected lanes at it with
+///       `CrossChainController.updateConfig`. `updateConfig` already handles
+///       adapter rotation correctly (refcounted local-adapter registry), and
+///       the new adapter must be seeded with the same trusted remotes and
+///       selector map. Same applies to changing the router.
+///
+///       Receive half (`ccipReceive`) — the Router calls this contract
+///       directly, so `_trustedRemotes` and the selector maps are this
+///       contract's own storage and are updatable under
+///       `UPDATE_ADAPTER_CONFIG_PERMISSION`.
+///
+///       `_trustedRemotes[chainId]` HOLDS THE REMOTE **CONTROLLER**. Under
+///       `delegatecall` the account calling `ccipSend` on the source chain is
+///       the source CONTROLLER, so that is the sender CCIP reports here. The
+///       remote ADAPTER address is what the source controller stores as
+///       `chainToAdapter[].remoteAdapter` (the CCIP `receiver`). Do not
+///       conflate them.
+///
+///       Fee handling: the controller pays. Under `delegatecall`, `msg.sender`
+///       towards the Router and `address(this)` are the controller, so
+///       `ccipSend{value: fee}` spends the controller's native balance and
+///       `forceApprove` grants the Router an allowance over the CONTROLLER's
+///       ERC20 balance. This adapter never custodies funds.
 /// @custom:security-contact sirt@aragon.org
 contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     using SafeERC20 for IERC20;
 
     /// @notice The CCIP Router address.
+    /// @dev `immutable`: read on the `delegatecall`ed send path.
     IRouterClient public immutable CCIP_ROUTER;
 
-    /// @notice The fee token that will be used to pay for bridge fees.
-    ///         `address(0)` means the chain's native currency.
-    address public feeToken;
+    /// @notice The fee token used to pay bridge fees. `address(0)` means the
+    ///         chain's native currency.
+    /// @dev `immutable` by necessity, not by preference: a storage read here
+    ///      would resolve against the controller's slots under `delegatecall`.
+    ///      Changing the fee token requires a new adapter deployment plus
+    ///      `CrossChainController.updateConfig`.
+    address public immutable FEE_TOKEN;
 
     /// @notice standard chain id -> CCIP chain selector.
+    /// @dev RECEIVE-SIDE / OPERATIONAL ONLY. The send path does NOT read this;
+    ///      the controller carries the selector in its lane config. Kept so the
+    ///      reverse map can be maintained coherently and so
+    ///      `assertChainSelectorsMatchController` can detect a desync between
+    ///      the two copies.
     mapping(uint256 => uint64) internal _chainIdToSelector;
 
-    /// @notice CCIP chain selector -> standard chain id.
+    /// @notice CCIP chain selector -> standard chain id. Used by `ccipReceive`.
     mapping(uint64 => uint256) internal _selectorToChainId;
-
-    /// @notice Emitted when the fee token is changed.
-    event FeeTokenSet(address feeToken);
 
     /// @notice Emitted when a chain-id <-> selector pair is set or cleared.
     event ChainSelectorSet(uint256 indexed chainId, uint64 chainSelector);
@@ -70,9 +104,9 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
 
     /// @param _crosschainController The owning controller.
     /// @param _ccipRouter The CCIP router on this chain.
-    /// @param _feeToken The fee token, or `address(0)` for native.
+    /// @param _feeToken The fee token, or `address(0)` for native. IMMUTABLE.
     /// @param _chainIds The standard chain ids of the configured lanes.
-    /// @param _trustedRemoteSenders The remote ADAPTER address per lane.
+    /// @param _trustedRemoteSenders The remote CONTROLLER address per lane.
     /// @param _selectorChainIds The standard chain ids of the selector mapping.
     /// @param _chainSelectors The CCIP selector per entry of `_selectorChainIds`.
     constructor(
@@ -87,31 +121,21 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
         if (_ccipRouter == address(0)) revert Errors.ZERO_ADDRESS();
 
         CCIP_ROUTER = IRouterClient(_ccipRouter);
-        feeToken = _feeToken;
+        FEE_TOKEN = _feeToken;
 
         _setChainSelectors(_selectorChainIds, _chainSelectors);
     }
 
-    /// @notice Accepts the native fee handed over by the controller.
-    receive() external payable {}
-
     // -------------------------------------------------------------------------
-    // Configuration
+    // Configuration (receive side only)
     // -------------------------------------------------------------------------
-
-    /// @notice Sets the fee token used for subsequent sends.
-    /// @param _feeToken The new fee token, or `address(0)` for native.
-    function setFeeToken(
-        address _feeToken
-    ) public auth(UPDATE_ADAPTER_CONFIG_PERMISSION_ID) {
-        feeToken = _feeToken;
-
-        emit FeeTokenSet(_feeToken);
-    }
 
     /// @notice Sets or clears standard chain id <-> CCIP selector pairs.
-    /// @dev New CCIP lanes appear over time, so this must be updatable without
-    ///      redeploying the adapter. Pass selector `0` to clear a mapping.
+    /// @dev New CCIP lanes appear over time, so the RECEIVE side must be
+    ///      updatable without redeploying the adapter. The SEND side is
+    ///      configured on the controller (`ChainConfig.bridgeChainId`); after
+    ///      changing either, run `assertChainSelectorsMatchController`.
+    ///      Pass selector `0` to clear a mapping.
     /// @param _chainIds The standard chain ids.
     /// @param _chainSelectors The CCIP chain selectors.
     function setChainSelectors(
@@ -122,107 +146,117 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     }
 
     // -------------------------------------------------------------------------
-    // Sending
+    // Sending -- MUST NOT TOUCH STORAGE
     // -------------------------------------------------------------------------
 
     /// @inheritdoc IBaseAdapter
     function quoteFee(
         address _receiver,
+        uint64 _bridgeChainId,
         uint256 _gasLimit,
-        uint256 _destinationChainId,
         bytes calldata _message
     ) public view override returns (address, uint256) {
         if (_receiver == address(0)) revert Errors.RECEIVER_ADDRESS_ZERO();
-
-        uint64 destChainSelector = SafeCast.toUint64(
-            toNativeChainId(_destinationChainId)
-        );
-
-        address currentFeeToken = feeToken;
+        if (_bridgeChainId == 0) revert Errors.UNKNOWN_CHAIN_ID(0);
 
         return (
-            currentFeeToken,
+            FEE_TOKEN,
             CCIP_ROUTER.getFee(
-                destChainSelector,
-                _buildMessage(_receiver, _gasLimit, _message, currentFeeToken)
+                _bridgeChainId,
+                _buildMessage(_receiver, _gasLimit, _message, FEE_TOKEN)
             )
         );
     }
 
     /// @inheritdoc IBaseAdapter
+    /// @dev Every value used here is an `immutable` or an argument. Adding a
+    ///      storage read to this function would corrupt the controller.
+    ///
+    ///      REACHABILITY NOTE, so a reviewer does not have to derive it: two of
+    ///      the guards below are UNREACHABLE from the only production entry
+    ///      point today, and are kept deliberately.
+    ///      - `RECEIVER_ADDRESS_ZERO`: `CrossChainController._validatedConfig`
+    ///        already rejects a zero `remoteAdapter` before it will
+    ///        `delegatecall` at all, so `_receiver` cannot be zero in practice.
+    ///      - `UNEXPECTED_NATIVE_VALUE`: `forwardMessage` is not `payable`, so
+    ///        the `msg.value` inherited by this frame is always `0`.
+    ///      Both are retained so that making `forwardMessage` payable, or
+    ///      relaxing the lane validation, cannot silently turn a stranded-funds
+    ///      or wrong-receiver bug into a live one. They are cheap. Do not
+    ///      delete them without re-checking those two call-site invariants.
     function sendMessage(
         address _receiver,
+        uint64 _bridgeChainId,
         uint256 _gasLimit,
-        uint256 _destinationChainId,
         bytes calldata _message
-    ) public payable override onlyCrossChainController returns (bytes32) {
+    )
+        public
+        payable
+        override
+        onlyDelegatecallFromController
+        returns (bytes32 messageId, address feeToken, uint256 fee)
+    {
         if (_receiver == address(0)) revert Errors.RECEIVER_ADDRESS_ZERO();
+        // Defence in depth: the controller already rejects an unset lane, but
+        // selector 0 must never reach the Router.
+        if (_bridgeChainId == 0) revert Errors.UNKNOWN_CHAIN_ID(0);
 
-        // Transform standard chain id into chainlink's chain selector.
-        uint64 destChainSelector = SafeCast.toUint64(
-            toNativeChainId(_destinationChainId)
-        );
-
-        address currentFeeToken = feeToken;
+        feeToken = FEE_TOKEN;
 
         Client.EVM2AnyMessage memory ccipMessage = _buildMessage(
             _receiver,
             _gasLimit,
             _message,
-            currentFeeToken
+            feeToken
         );
 
         // CCIP does not refund overpayment, so quote and pay exactly.
-        uint256 fees = CCIP_ROUTER.getFee(destChainSelector, ccipMessage);
+        fee = CCIP_ROUTER.getFee(_bridgeChainId, ccipMessage);
 
-        bytes32 messageId;
-
-        if (currentFeeToken == address(0)) {
+        // `address(this)` is the CONTROLLER here: it is the fee payer.
+        if (feeToken == address(0)) {
             uint256 balance = address(this).balance;
-            if (balance < fees) {
+            if (balance < fee) {
                 revert Errors.INSUFFICIENT_FEE_BALANCE(
                     address(0),
-                    fees,
+                    fee,
                     balance
                 );
             }
 
-            messageId = CCIP_ROUTER.ccipSend{value: fees}(
-                destChainSelector,
+            messageId = CCIP_ROUTER.ccipSend{value: fee}(
+                _bridgeChainId,
                 ccipMessage
             );
         } else {
-            // Native value would be stranded here; the controller custodies it.
+            // Native value would be stranded in the controller's balance while
+            // an ERC20 fee is due; surface the mistake instead.
             if (msg.value != 0) revert Errors.UNEXPECTED_NATIVE_VALUE();
 
-            uint256 balance = IERC20(currentFeeToken).balanceOf(address(this));
-            if (balance < fees) {
-                revert Errors.INSUFFICIENT_FEE_BALANCE(
-                    currentFeeToken,
-                    fees,
-                    balance
-                );
+            uint256 balance = IERC20(feeToken).balanceOf(address(this));
+            if (balance < fee) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(feeToken, fee, balance);
             }
 
-            // The Router pulls the fee via `transferFrom`.
-            IERC20(currentFeeToken).forceApprove(address(CCIP_ROUTER), fees);
+            // The Router pulls the fee via `transferFrom` from the CONTROLLER,
+            // which is the account granting the allowance under `delegatecall`.
+            IERC20(feeToken).forceApprove(address(CCIP_ROUTER), fee);
 
-            messageId = CCIP_ROUTER.ccipSend(destChainSelector, ccipMessage);
+            messageId = CCIP_ROUTER.ccipSend(_bridgeChainId, ccipMessage);
 
-            // Leave no standing allowance.
-            IERC20(currentFeeToken).forceApprove(address(CCIP_ROUTER), 0);
+            // Leave no standing allowance on the controller.
+            IERC20(feeToken).forceApprove(address(CCIP_ROUTER), 0);
         }
-
-        _returnRemainder(currentFeeToken);
-
-        return messageId;
     }
 
     // -------------------------------------------------------------------------
-    // Receiving
+    // Receiving -- normal call, this contract's own storage
     // -------------------------------------------------------------------------
 
     /// @inheritdoc IAny2EVMMessageReceiver
+    /// @dev `message.sender` is the remote CONTROLLER (it `delegatecall`ed its
+    ///      adapter's send code, so it is the account that called the remote
+    ///      Router), which is what `_trustedRemotes` stores.
     function ccipReceive(
         Client.Any2EVMMessage calldata message
     ) external onlyRouter {
@@ -253,9 +287,10 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
     // -------------------------------------------------------------------------
 
     /// @inheritdoc IBaseAdapter
-    /// @dev CCIP addresses lanes by chain SELECTOR, not by EVM chain id, so
-    ///      this is a real lookup. Unknown ids revert rather than returning `0`
-    ///      (which would target a nonexistent lane).
+    /// @dev CCIP addresses lanes by chain SELECTOR, not by EVM chain id. Not
+    ///      consulted when sending (the controller supplies the selector);
+    ///      exposed for operations and for the consistency assertion.
+    ///      Unknown ids revert rather than returning `0`.
     function toNativeChainId(
         uint256 _chainId
     ) public view virtual override returns (uint256) {
@@ -298,31 +333,6 @@ contract CCIPAdapter is IERC165, IAny2EVMMessageReceiver, BaseAdapter {
                 extraArgs: extraArgs,
                 feeToken: _feeToken
             });
-    }
-
-    /// @dev Returns anything left over after paying the bridge to the
-    ///      controller, so the adapter never accumulates custody.
-    function _returnRemainder(address _feeToken) internal {
-        if (_feeToken == address(0)) {
-            uint256 remainder = address(this).balance;
-            if (remainder != 0) {
-                (bool ok, ) = CROSS_CHAIN_CONTROLLER.call{value: remainder}("");
-                if (!ok) {
-                    revert Errors.NATIVE_TRANSFER_FAILED(
-                        CROSS_CHAIN_CONTROLLER,
-                        remainder
-                    );
-                }
-            }
-        } else {
-            uint256 remainder = IERC20(_feeToken).balanceOf(address(this));
-            if (remainder != 0) {
-                IERC20(_feeToken).safeTransfer(
-                    CROSS_CHAIN_CONTROLLER,
-                    remainder
-                );
-            }
-        }
     }
 
     function _setChainSelectors(

--- a/src/common/crosschain/adapters/IBaseAdapter.sol
+++ b/src/common/crosschain/adapters/IBaseAdapter.sol
@@ -3,9 +3,35 @@ pragma solidity ^0.8.0;
 
 /// @title IBaseAdapter
 /// @notice Bridge-agnostic interface implemented by every cross-chain adapter.
-/// @dev Adapters are invoked by the `CrossChainController` with a regular
-///      `call` (never `delegatecall`), therefore adapter storage is the
-///      adapter's own and the `msg.sender` seen by the bridge is the ADAPTER.
+/// @dev  ADAPTERS ARE `delegatecall`ED FOR SENDING AND `call`ED FOR RECEIVING.
+///
+///       Send path (`sendMessage`, and by extension `quoteFee`):
+///       - executed with `delegatecall` from the `CrossChainController`, so
+///         `address(this)` is the CONTROLLER and any storage access would land
+///         in the controller's slots. Implementations therefore MUST NOT read
+///         or write ANY storage on the send path: every send-time parameter is
+///         either an `immutable` (which lives in the adapter's bytecode and so
+///         resolves correctly under `delegatecall`) or an explicit argument
+///         supplied by the controller, including the bridge-native destination
+///         chain id.
+///       - because the controller executes the adapter's code, the address the
+///         bridge sees as the message sender is the CONTROLLER, not the
+///         adapter. See the trusted-remote note below.
+///
+///       Receive path (`ccipReceive` & friends):
+///       - a NORMAL call from the bridge router into the adapter, so the
+///         adapter's own storage applies and mutable, permissioned
+///         configuration (trusted remotes, chain-id maps) is legitimate there.
+///
+///       TRUSTED REMOTES HOLD THE REMOTE **CONTROLLER**, NOT THE REMOTE
+///       ADAPTER. Two different kinds of address appear in configuration:
+///       - `CrossChainController.chainToAdapter[chainId].remoteAdapter` is the
+///         bridge-level RECEIVER on the far side, i.e. the remote ADAPTER;
+///       - `trustedRemote(chainId)` on the receiving adapter is the address
+///         allowed to have ORIGINATED the message, i.e. the remote CONTROLLER.
+///       Confusing the two is the single easiest way to misconfigure this
+///       system. Use `BaseAdapter.assertTrustedRemotesMatchControllers` at
+///       deployment time.
 interface IBaseAdapter {
     /// @notice The address of cross chain controller that adapter stores
     ///         to send/receive messages to/from.
@@ -15,6 +41,9 @@ interface IBaseAdapter {
     /// @param _chainId The standard chain Id.
     /// @return The transformed chain id into adapter's custom id.
     /// @dev MUST revert for unmapped chain ids instead of returning `0`.
+    ///      NOT used on the send path (the controller supplies the
+    ///      bridge-native id as an argument); kept for operations and for the
+    ///      `assertChainSelectorsMatchController` consistency check.
     function toNativeChainId(uint256 _chainId) external view returns (uint256);
 
     /// @notice Transforms adapter's own custom chain Id into standard chain id.
@@ -26,35 +55,45 @@ interface IBaseAdapter {
     ) external view returns (uint256);
 
     /// @notice Quotes the bridge fee for a given message.
+    /// @dev MUST be context independent: it is invoked as a normal `view` call
+    ///      by the controller but must return the same answer as the
+    ///      `delegatecall`ed send path would use, which is only true if it
+    ///      reads no storage.
     /// @param _receiver The address of the adapter on a remote chain.
+    /// @param _bridgeChainId The bridge-native destination chain id.
     /// @param _gasLimit The gas limit for cross-chain execution.
-    /// @param _destinationChainId The remote chain's standard id.
     /// @param _message Encoded message.
     /// @return feeToken The token the fee is denominated in. `address(0)`
     ///         means the chain's native currency.
     /// @return fee The amount of `feeToken` required to send the message.
     function quoteFee(
         address _receiver,
+        uint64 _bridgeChainId,
         uint256 _gasLimit,
-        uint256 _destinationChainId,
         bytes calldata _message
     ) external view returns (address feeToken, uint256 fee);
 
-    /// @notice Sends a message over the bridge. Callable only by the
-    ///         `CROSS_CHAIN_CONTROLLER`.
-    /// @dev The controller pays the fee per send: native fees arrive as
-    ///      `msg.value`, ERC20 fees are transferred to the adapter immediately
-    ///      before the call. The adapter MUST NOT rely on a standing balance
-    ///      and MUST return any remainder to the controller.
+    /// @notice Sends a message over the bridge.
+    /// @dev MUST be reached only by `delegatecall` from the
+    ///      `CROSS_CHAIN_CONTROLLER`; implementations MUST enforce this by
+    ///      checking `address(this) == CROSS_CHAIN_CONTROLLER`. The fee is paid
+    ///      directly out of the CONTROLLER's balance, because under
+    ///      `delegatecall` the controller is the account executing the bridge
+    ///      call. No fee hand-over, and no change to return.
     /// @param _receiver The address of the adapter on a remote chain.
+    /// @param _bridgeChainId The bridge-native destination chain id.
     /// @param _gasLimit The gas limit for cross-chain execution.
-    /// @param _destinationChainId The remote chain's standard id.
     /// @param _message Encoded message.
-    /// @return The bridge's message identifier.
+    /// @return messageId The bridge's message identifier.
+    /// @return feeToken The token the fee was paid in (`address(0)` native).
+    /// @return fee The amount actually paid, for event reporting.
     function sendMessage(
         address _receiver,
+        uint64 _bridgeChainId,
         uint256 _gasLimit,
-        uint256 _destinationChainId,
         bytes calldata _message
-    ) external payable returns (bytes32);
+    )
+        external
+        payable
+        returns (bytes32 messageId, address feeToken, uint256 fee);
 }

--- a/src/common/crosschain/adapters/IBaseAdapter.sol
+++ b/src/common/crosschain/adapters/IBaseAdapter.sol
@@ -2,36 +2,6 @@
 pragma solidity ^0.8.0;
 
 /// @title IBaseAdapter
-/// @notice Bridge-agnostic interface implemented by every cross-chain adapter.
-/// @dev  ADAPTERS ARE `delegatecall`ED FOR SENDING AND `call`ED FOR RECEIVING.
-///
-///       Send path (`sendMessage`, and by extension `quoteFee`):
-///       - executed with `delegatecall` from the `CrossChainController`, so
-///         `address(this)` is the CONTROLLER and any storage access would land
-///         in the controller's slots. Implementations therefore MUST NOT read
-///         or write ANY storage on the send path: every send-time parameter is
-///         either an `immutable` (which lives in the adapter's bytecode and so
-///         resolves correctly under `delegatecall`) or an explicit argument
-///         supplied by the controller, including the bridge-native destination
-///         chain id.
-///       - because the controller executes the adapter's code, the address the
-///         bridge sees as the message sender is the CONTROLLER, not the
-///         adapter. See the trusted-remote note below.
-///
-///       Receive path (`ccipReceive` & friends):
-///       - a NORMAL call from the bridge router into the adapter, so the
-///         adapter's own storage applies and mutable, permissioned
-///         configuration (trusted remotes, chain-id maps) is legitimate there.
-///
-///       TRUSTED REMOTES HOLD THE REMOTE **CONTROLLER**, NOT THE REMOTE
-///       ADAPTER. Two different kinds of address appear in configuration:
-///       - `CrossChainController.chainToAdapter[chainId].remoteAdapter` is the
-///         bridge-level RECEIVER on the far side, i.e. the remote ADAPTER;
-///       - `trustedRemote(chainId)` on the receiving adapter is the address
-///         allowed to have ORIGINATED the message, i.e. the remote CONTROLLER.
-///       Confusing the two is the single easiest way to misconfigure this
-///       system. Use `BaseAdapter.assertTrustedRemotesMatchControllers` at
-///       deployment time.
 interface IBaseAdapter {
     /// @notice The address of cross chain controller that adapter stores
     ///         to send/receive messages to/from.
@@ -41,9 +11,6 @@ interface IBaseAdapter {
     /// @param _chainId The standard chain Id.
     /// @return The transformed chain id into adapter's custom id.
     /// @dev MUST revert for unmapped chain ids instead of returning `0`.
-    ///      NOT used on the send path (the controller supplies the
-    ///      bridge-native id as an argument); kept for operations and for the
-    ///      `assertChainSelectorsMatchController` consistency check.
     function toNativeChainId(uint256 _chainId) external view returns (uint256);
 
     /// @notice Transforms adapter's own custom chain Id into standard chain id.
@@ -55,12 +22,9 @@ interface IBaseAdapter {
     ) external view returns (uint256);
 
     /// @notice Quotes the bridge fee for a given message.
-    /// @dev MUST be context independent: it is invoked as a normal `view` call
-    ///      by the controller but must return the same answer as the
-    ///      `delegatecall`ed send path would use, which is only true if it
-    ///      reads no storage.
     /// @param _receiver The address of the adapter on a remote chain.
-    /// @param _bridgeChainId The bridge-native destination chain id.
+    /// @param _destinationChainId The standard destination chain id; the adapter
+    ///        converts it to its own native chain id internally.
     /// @param _gasLimit The gas limit for cross-chain execution.
     /// @param _message Encoded message.
     /// @return feeToken The token the fee is denominated in. `address(0)`
@@ -68,7 +32,7 @@ interface IBaseAdapter {
     /// @return fee The amount of `feeToken` required to send the message.
     function quoteFee(
         address _receiver,
-        uint64 _bridgeChainId,
+        uint256 _destinationChainId,
         uint256 _gasLimit,
         bytes calldata _message
     ) external view returns (address feeToken, uint256 fee);
@@ -81,19 +45,16 @@ interface IBaseAdapter {
     ///      `delegatecall` the controller is the account executing the bridge
     ///      call. No fee hand-over, and no change to return.
     /// @param _receiver The address of the adapter on a remote chain.
-    /// @param _bridgeChainId The bridge-native destination chain id.
+    /// @param _destinationChainId The standard destination chain id; the adapter
+    ///        converts it to its own native chain id internally.
     /// @param _gasLimit The gas limit for cross-chain execution.
     /// @param _message Encoded message.
     /// @return messageId The bridge's message identifier.
-    /// @return feeToken The token the fee was paid in (`address(0)` native).
     /// @return fee The amount actually paid, for event reporting.
     function sendMessage(
         address _receiver,
-        uint64 _bridgeChainId,
+        uint256 _destinationChainId,
         uint256 _gasLimit,
         bytes calldata _message
-    )
-        external
-        payable
-        returns (bytes32 messageId, address feeToken, uint256 fee);
+    ) external payable returns (bytes32 messageId, uint256 fee);
 }

--- a/src/common/crosschain/adapters/IBaseAdapter.sol
+++ b/src/common/crosschain/adapters/IBaseAdapter.sol
@@ -1,29 +1,60 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+/// @title IBaseAdapter
+/// @notice Bridge-agnostic interface implemented by every cross-chain adapter.
+/// @dev Adapters are invoked by the `CrossChainController` with a regular
+///      `call` (never `delegatecall`), therefore adapter storage is the
+///      adapter's own and the `msg.sender` seen by the bridge is the ADAPTER.
 interface IBaseAdapter {
     /// @notice The address of cross chain controller that adapter stores
     ///         to send/receive messages to/from.
-    function CROSS_CHAIN_CONTROLLER() external returns (address);
+    function CROSS_CHAIN_CONTROLLER() external view returns (address);
 
     /// @notice Transforms standard chain id into adapter's own custom chain Ids.
     /// @param _chainId The standard chain Id.
     /// @return The transformed chain id into adapter's custom id.
-    function toNativeChainId(uint256 _chainId) external returns (uint256);
+    /// @dev MUST revert for unmapped chain ids instead of returning `0`.
+    function toNativeChainId(uint256 _chainId) external view returns (uint256);
 
     /// @notice Transforms adapter's own custom chain Id into standard chain id.
     /// @param _chainId The custom chain id of adapter.
     /// @return The transformed chain id into standard chain id.
-    function fromNativeChainId(uint256 _chainId) external returns (uint256);
+    /// @dev MUST revert for unmapped chain ids instead of returning `0`.
+    function fromNativeChainId(
+        uint256 _chainId
+    ) external view returns (uint256);
 
-    /// @param _receiver The address of the adapter on a remote chain
+    /// @notice Quotes the bridge fee for a given message.
+    /// @param _receiver The address of the adapter on a remote chain.
     /// @param _gasLimit The gas limit for cross-chain execution.
     /// @param _destinationChainId The remote chain's standard id.
     /// @param _message Encoded message.
+    /// @return feeToken The token the fee is denominated in. `address(0)`
+    ///         means the chain's native currency.
+    /// @return fee The amount of `feeToken` required to send the message.
+    function quoteFee(
+        address _receiver,
+        uint256 _gasLimit,
+        uint256 _destinationChainId,
+        bytes calldata _message
+    ) external view returns (address feeToken, uint256 fee);
+
+    /// @notice Sends a message over the bridge. Callable only by the
+    ///         `CROSS_CHAIN_CONTROLLER`.
+    /// @dev The controller pays the fee per send: native fees arrive as
+    ///      `msg.value`, ERC20 fees are transferred to the adapter immediately
+    ///      before the call. The adapter MUST NOT rely on a standing balance
+    ///      and MUST return any remainder to the controller.
+    /// @param _receiver The address of the adapter on a remote chain.
+    /// @param _gasLimit The gas limit for cross-chain execution.
+    /// @param _destinationChainId The remote chain's standard id.
+    /// @param _message Encoded message.
+    /// @return The bridge's message identifier.
     function sendMessage(
         address _receiver,
         uint256 _gasLimit,
         uint256 _destinationChainId,
         bytes calldata _message
-    ) external returns (uint256);
+    ) external payable returns (bytes32);
 }

--- a/src/common/crosschain/lib/ChainIds.sol
+++ b/src/common/crosschain/lib/ChainIds.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.8;
+
+/// @title ChainIds
+/// @notice Standard (EVM) chain ids used by the cross-chain adapters.
+/// @custom:security-contact sirt@aragon.org
+library ChainIds {
+    uint256 internal constant ETHEREUM = 1;
+    uint256 internal constant BNB = 56;
+    uint256 internal constant POLYGON = 137;
+    uint256 internal constant MONAD = 143;
+    uint256 internal constant SONIC = 146;
+    uint256 internal constant BASE = 8453;
+    uint256 internal constant PLASMA = 9745;
+    uint256 internal constant CELO = 42220;
+    uint256 internal constant ARBITRUM_ONE = 42161;
+    uint256 internal constant AVALANCHE = 43114;
+}

--- a/src/common/crosschain/lib/Errors.sol
+++ b/src/common/crosschain/lib/Errors.sol
@@ -13,11 +13,15 @@ library Errors {
     ///         "unset" marker of the `chainToAdapter` and chain-selector maps.
     error INVALID_CHAIN_ID();
 
-    /// @notice Thrown when only one of `localAdapter`/`remoteAdapter` is set.
-    ///         A lane is either fully configured or fully cleared.
+    /// @notice Thrown when a lane is only partially configured. A lane is
+    ///         either fully set (`localAdapter`, `remoteAdapter` and
+    ///         `bridgeChainId` all non-zero) or fully cleared.
     error INCOMPLETE_ADAPTER_CONFIG(uint256 chainId);
 
-    /// @notice Thrown when forwarding to a chain that has no adapter pair set.
+    /// @notice Thrown when forwarding to a chain whose lane is unset. Covers a
+    ///         missing local adapter, a missing remote adapter, and a missing
+    ///         bridge-native chain id (which would otherwise send to
+    ///         selector `0`).
     error ADAPTER_NOT_CONFIGURED(uint256 chainId);
 
     /// @notice Thrown when the configured local adapter has no deployed code.
@@ -41,6 +45,24 @@ library Errors {
     ///         than the `CrossChainController` that owns the adapter.
     error CALLER_NOT_CROSS_CHAIN_CONTROLLER(address caller);
 
+    /// @notice Thrown when the send path is executed outside a `delegatecall`
+    ///         from the owning `CrossChainController`, i.e. when
+    ///         `address(this) != CROSS_CHAIN_CONTROLLER`. Calling an adapter's
+    ///         `sendMessage` directly would use the adapter's own (empty)
+    ///         balance and make the bridge see the adapter as the sender, which
+    ///         the far side does not trust.
+    error SEND_PATH_NOT_DELEGATECALLED(address context);
+
+    /// @notice Thrown when a RECEIVE-path function — which legitimately reads
+    ///         the adapter's own storage — is reached in a foreign execution
+    ///         context, i.e. `address(this) != _selfAddress`.
+    /// @dev Mirror of `SEND_PATH_NOT_DELEGATECALLED`. The whole Option-1
+    ///      design rests on send and receive running in DIFFERENT contexts;
+    ///      this hard-blocks any future path that lets send-path context reach
+    ///      storage-reading receive code, which is precisely the class of bug
+    ///      the `delegatecall` mechanism could otherwise reintroduce.
+    error DELEGATE_CALL_FORBIDDEN(address context, address self);
+
     /// @notice Thrown when the internal self-call entry point is called
     ///         externally.
     error CALLER_NOT_SELF(address caller);
@@ -54,13 +76,21 @@ library Errors {
     error RECEIVER_ADDRESS_ZERO();
 
     /// @notice Thrown by the deployment-time consistency helper when the
-    ///         adapter's trusted remote does not match the controller's
-    ///         configured `remoteAdapter` for the same chain.
+    ///         adapter's trusted remote does not match the expected remote
+    ///         CONTROLLER address for that chain.
     error TRUSTED_REMOTE_MISMATCH(
         uint256 chainId,
         address trustedRemote,
-        address configuredRemoteAdapter
+        address expectedRemoteController
     );
+
+    /// @notice Thrown by the deployment-time consistency helper when the
+    ///         adapter's trusted remote equals the controller's configured
+    ///         `remoteAdapter` for the same chain. Under `delegatecall` the
+    ///         bridge sees the remote CONTROLLER as the sender, so trusting the
+    ///         remote ADAPTER is the canonical misconfiguration: every inbound
+    ///         message would be rejected.
+    error TRUSTED_REMOTE_IS_REMOTE_ADAPTER(uint256 chainId, address remote);
 
     // ---------------------------------------------------------------------
     // Chain id mapping
@@ -71,6 +101,16 @@ library Errors {
 
     /// @notice Thrown when a bridge-native chain id has no standard counterpart.
     error UNKNOWN_NATIVE_CHAIN_ID(uint256 nativeChainId);
+
+    /// @notice Thrown when the controller's send-side `bridgeChainId` for a
+    ///         chain disagrees with the adapter's receive-side chain-id map.
+    ///         The two live in different contracts by design (send config must
+    ///         be storage-free) and must be kept in sync.
+    error CHAIN_ID_DESYNC(
+        uint256 chainId,
+        uint64 controllerBridgeChainId,
+        uint64 adapterBridgeChainId
+    );
 
     // ---------------------------------------------------------------------
     // Fees
@@ -86,6 +126,10 @@ library Errors {
     );
 
     error NOT_ENOUGH_TO_PAY_BRIDGE();
+
+    /// @notice Thrown when the `delegatecall` into the local adapter's send
+    ///         path failed without returning a reason to bubble.
+    error MESSAGE_SEND_FAILED();
 
     /// @notice Thrown when native value is sent while an ERC20 fee token is
     ///         configured (the value would be stranded).

--- a/src/common/crosschain/lib/Errors.sol
+++ b/src/common/crosschain/lib/Errors.sol
@@ -3,11 +3,104 @@
 pragma solidity ^0.8.8;
 
 library Errors {
-    error NOT_ENOUGH_TO_PAY_BRIDGE();
-    error RECEIVER_ADDRESS_ZERO();
-    error CALLER_NOT_CCIP_ROUTER();
+    // ---------------------------------------------------------------------
+    // Generic / configuration
+    // ---------------------------------------------------------------------
+
     error INVALID_LENGTH_MISMATCH();
+
+    /// @notice Thrown when a chain id of `0` is used. `0` is reserved as the
+    ///         "unset" marker of the `chainToAdapter` and chain-selector maps.
+    error INVALID_CHAIN_ID();
+
+    /// @notice Thrown when only one of `localAdapter`/`remoteAdapter` is set.
+    ///         A lane is either fully configured or fully cleared.
+    error INCOMPLETE_ADAPTER_CONFIG(uint256 chainId);
+
+    /// @notice Thrown when forwarding to a chain that has no adapter pair set.
+    error ADAPTER_NOT_CONFIGURED(uint256 chainId);
+
+    /// @notice Thrown when the configured local adapter has no deployed code.
+    ///         Guards against the EVM reporting success for calls to codeless
+    ///         addresses.
+    error ADAPTER_HAS_NO_CODE(address adapter);
+
+    error ZERO_ADDRESS();
+
+    // ---------------------------------------------------------------------
+    // Authorization
+    // ---------------------------------------------------------------------
+
+    error CALLER_NOT_CCIP_ROUTER();
+
+    /// @notice Thrown when `receiveMessage` is called by anything other than a
+    ///         local adapter registered through `updateConfig`.
+    error CALLER_NOT_LOCAL_ADAPTER(address caller);
+
+    /// @notice Thrown when an adapter entry point is called by anything other
+    ///         than the `CrossChainController` that owns the adapter.
+    error CALLER_NOT_CROSS_CHAIN_CONTROLLER(address caller);
+
+    /// @notice Thrown when the internal self-call entry point is called
+    ///         externally.
+    error CALLER_NOT_SELF(address caller);
+
+    // ---------------------------------------------------------------------
+    // Trusted remotes
+    // ---------------------------------------------------------------------
+
     error TRUSTED_REMOTE_NOT_SET();
     error REMOTE_NOT_TRUSTED();
-    error SEND_MESSAGE_TO_ADAPTER_FAILED(bytes reason);
+    error RECEIVER_ADDRESS_ZERO();
+
+    /// @notice Thrown by the deployment-time consistency helper when the
+    ///         adapter's trusted remote does not match the controller's
+    ///         configured `remoteAdapter` for the same chain.
+    error TRUSTED_REMOTE_MISMATCH(
+        uint256 chainId,
+        address trustedRemote,
+        address configuredRemoteAdapter
+    );
+
+    // ---------------------------------------------------------------------
+    // Chain id mapping
+    // ---------------------------------------------------------------------
+
+    /// @notice Thrown when a standard chain id has no bridge-native counterpart.
+    error UNKNOWN_CHAIN_ID(uint256 chainId);
+
+    /// @notice Thrown when a bridge-native chain id has no standard counterpart.
+    error UNKNOWN_NATIVE_CHAIN_ID(uint256 nativeChainId);
+
+    // ---------------------------------------------------------------------
+    // Fees
+    // ---------------------------------------------------------------------
+
+    /// @notice Thrown when the pre-funded fee balance is below the quoted fee.
+    /// @dev Distinct on purpose: ops alerts on exactly this to know when the
+    ///      fee-paying contract must be topped up.
+    error INSUFFICIENT_FEE_BALANCE(
+        address feeToken,
+        uint256 required,
+        uint256 available
+    );
+
+    error NOT_ENOUGH_TO_PAY_BRIDGE();
+
+    /// @notice Thrown when native value is sent while an ERC20 fee token is
+    ///         configured (the value would be stranded).
+    error UNEXPECTED_NATIVE_VALUE();
+
+    error NATIVE_TRANSFER_FAILED(address to, uint256 amount);
+
+    // ---------------------------------------------------------------------
+    // Defensive receive / retry
+    // ---------------------------------------------------------------------
+
+    /// @notice Thrown when retrying a call id that has no stored failed message.
+    error NO_FAILED_MESSAGE(bytes32 callId);
+
+    /// @notice Thrown when an inbound message reuses a call id that is already
+    ///         stored as failed and pending retry.
+    error MESSAGE_ALREADY_PENDING(bytes32 callId);
 }

--- a/test/common/crosschain/CCIPAdapter.t.sol
+++ b/test/common/crosschain/CCIPAdapter.t.sol
@@ -11,86 +11,60 @@ import {
 } from "@chainlink/contracts-ccip/contracts/interfaces/IAny2EVMMessageReceiver.sol";
 import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
 
-import {CCIPAdapter} from "../../../src/common/crosschain/adapters/CCIP/CCIPAdapter.sol";
-import {IBaseAdapter} from "../../../src/common/crosschain/adapters/IBaseAdapter.sol";
-import {CrossChainController} from "../../../src/common/crosschain/CrossChainController.sol";
+import {
+    CCIPAdapter
+} from "../../../src/common/crosschain/adapters/CCIP/CCIPAdapter.sol";
+import {
+    BaseAdapter
+} from "../../../src/common/crosschain/adapters/BaseAdapter.sol";
+import {
+    IBaseAdapter
+} from "../../../src/common/crosschain/adapters/IBaseAdapter.sol";
+import {
+    CrossChainController
+} from "../../../src/common/crosschain/CrossChainController.sol";
 import {Errors} from "../../../src/common/crosschain/lib/Errors.sol";
+import {ChainIds} from "../../../src/common/crosschain/lib/ChainIds.sol";
 import {DaoUnauthorized} from "../../../src/common/permission/auth/auth.sol";
 import {Action} from "../../../src/common/executors/IExecutor.sol";
 import {IDAO} from "../../../src/common/dao/IDAO.sol";
 
 import {DAOMock} from "../../mocks/commons/dao/DAOMock.sol";
 import {ERC20Mock} from "../../mocks/commons/token/ERC20Mock.sol";
-import {CCIPRouterMock} from "../../mocks/commons/crosschain/CCIPRouterMock.sol";
-import {DelegateCallerMock} from "../../mocks/commons/crosschain/DelegateCallerMock.sol";
+import {
+    CCIPRouterMock
+} from "../../mocks/commons/crosschain/CCIPRouterMock.sol";
+import {
+    DelegateCallerMock
+} from "../../mocks/commons/crosschain/DelegateCallerMock.sol";
 
-/// @notice Regression suite for `CCIPAdapter` (`src/common/crosschain/adapters/CCIP/CCIPAdapter.sol`)
-///         written against "Option 1": SEND is now a `delegatecall` from
-///         `CrossChainController.forwardMessage` into the local adapter, while
-///         RECEIVE stays a normal call from the CCIP Router into the adapter.
-///
-/// TWO DIFFERENT KINDS OF "REMOTE" ADDRESS APPEAR THROUGHOUT THIS FILE. Naming
-/// is deliberately verbose to keep them apart:
-///   - `remoteController` -- the remote chain's `CrossChainController`. Because
-///     the local send is a `delegatecall`, the account CCIP sees calling
-///     `ccipSend` on the source chain is the source CONTROLLER, so THIS is what
-///     `_trustedRemotes[chainId]` must hold on the receiving adapter.
-///   - `remoteAdapter` -- the remote chain's `CCIPAdapter`, i.e. the bridge-level
-///     RECEIVER. This is what `CrossChainController.chainToAdapter[chainId].remoteAdapter`
-///     stores locally, as the destination `ccipSend` targets.
-///   Confusing the two -- trusting the remote ADAPTER instead of the remote
-///   CONTROLLER -- is a silent, total loss of inbound liveness, and is
-///   explicitly exercised below (`assertTrustedRemotesMatchControllers`,
-///   `TRUSTED_REMOTE_IS_REMOTE_ADAPTER`, and the plain `ccipReceive` misconfig
-///   test).
-///
-/// Setup mirrors production wiring: a `DAOMock` owns a real
-/// `CrossChainController`, and every `CCIPAdapter` adopts that controller's DAO
-/// in its constructor (`BaseAdapter` -> `DaoAuthorizable`).
-///
-/// Coverage:
-///  a) `_forwardMessage` is not externally callable.
-///  b) `ccipReceive` caller / trusted-remote checks and the success path.
-///  c) chain-id <-> CCIP-selector mapping, incl. re-pointing and clearing.
-///  d) `sendMessage` can ONLY be reached via `delegatecall` from the
-///     controller -- never directly, not even by the controller itself via a
-///     plain `call`.
-///  e) fee handling: the CONTROLLER pays and never hands custody to the
-///     adapter, for both native and ERC20 fees.
-///  f) config setters (receive-side only) are permissioned and emit events.
-///  g) `assertTrustedRemotesMatchControllers` / `assertChainSelectorsMatchController`
-///     deployment-time consistency helpers.
-///  h) ERC-165 `supportsInterface`.
-///  i) an end-to-end send through `CrossChainController.forwardMessage`.
-///  j) constructor validation.
-///  k) NEW, and the actual point of this redesign: immutables surviving
-///     `delegatecall`, no storage collision with the controller, the fee
-///     payer being the controller and not the adapter, and the operational
-///     consequences of the send/receive config living in two places
-///     (desync, and the fee-token-is-immutable trade-off).
 contract CCIPAdapterTest is Test {
     // -------------------------------------------------------------------------
     // Real CCIP chain selectors / standard chain ids used throughout.
     // -------------------------------------------------------------------------
+
     uint64 internal constant SEL_ETH_MAINNET = 5009297550715157269;
     uint64 internal constant SEL_BASE = 15971525489660198786;
     uint64 internal constant SEL_ARBITRUM_ONE = 4949039107694359620;
+    // A real CCIP selector the adapter does NOT map (Sepolia is intentionally
+    // absent from the production map), used to exercise the unmapped path.
     uint64 internal constant SEL_SEPOLIA = 16015286601757825753;
-    uint64 internal constant SEL_BASE_SEPOLIA = 10344971235874465080;
 
-    uint256 internal constant CHAIN_ETH_MAINNET = 1;
-    uint256 internal constant CHAIN_BASE = 8453;
-    uint256 internal constant CHAIN_ARBITRUM_ONE = 42161;
-    uint256 internal constant CHAIN_SEPOLIA = 11155111;
+    // Standard chain ids come from `ChainIds` (src/common/crosschain/lib).
+    uint256 internal constant CHAIN_ETH_MAINNET = ChainIds.ETHEREUM;
+    uint256 internal constant CHAIN_BASE = ChainIds.BASE;
+    uint256 internal constant CHAIN_ARBITRUM_ONE = ChainIds.ARBITRUM_ONE;
 
     // -------------------------------------------------------------------------
     // Events re-declared locally so `vm.expectEmit` can match by signature
     // (solc 0.8.17 cannot `emit Contract.Event(...)` for externally-defined
-    // events). `FeeTokenSet` is GONE: there is no setter any more.
+    // events).
     // -------------------------------------------------------------------------
-    event ChainSelectorSet(uint256 indexed chainId, uint64 chainSelector);
-    event TrustedRemoteSet(uint256 indexed chainId, address trustedRemote);
-    event MessageReceived(uint256 indexed originChainId, bytes32 indexed messageId, bytes32 indexed callId);
+    event MessageReceived(
+        uint256 indexed originChainId,
+        bytes32 indexed messageId,
+        bytes32 indexed callId
+    );
 
     DAOMock internal daoMock;
     CrossChainController internal controller;
@@ -131,38 +105,25 @@ contract CCIPAdapterTest is Test {
         router = new CCIPRouterMock();
         feeTokenErc20 = new ERC20Mock("Fee Token", "FEE");
 
-        uint256[] memory chainIds = new uint256[](1);
-        chainIds[0] = CHAIN_ETH_MAINNET;
-        address[] memory trustedRemoteControllers = new address[](1);
-        trustedRemoteControllers[0] = remoteController;
-
-        uint256[] memory selChainIds = new uint256[](3);
-        selChainIds[0] = CHAIN_ETH_MAINNET;
-        selChainIds[1] = CHAIN_BASE;
-        selChainIds[2] = CHAIN_ARBITRUM_ONE;
-        uint64[] memory selectors = new uint64[](3);
-        selectors[0] = SEL_ETH_MAINNET;
-        selectors[1] = SEL_BASE;
-        selectors[2] = SEL_ARBITRUM_ONE;
+        BaseAdapter.TrustedRemoteConfig[]
+            memory trustedRemotes = new BaseAdapter.TrustedRemoteConfig[](1);
+        trustedRemotes[0] = BaseAdapter.TrustedRemoteConfig({
+            standardChainId: CHAIN_ETH_MAINNET,
+            trustedRemote: remoteController
+        });
 
         adapter = new CCIPAdapter(
             address(controller),
             address(router),
             address(0), // native fee token
-            chainIds,
-            trustedRemoteControllers,
-            selChainIds,
-            selectors
+            trustedRemotes
         );
 
         erc20Adapter = new CCIPAdapter(
             address(controller),
             address(router),
             address(feeTokenErc20),
-            new uint256[](0),
-            new address[](0),
-            new uint256[](0),
-            new uint64[](0)
+            new BaseAdapter.TrustedRemoteConfig[](0)
         );
 
         delegateCallerMock = new DelegateCallerMock(IDAO(address(daoMock)));
@@ -170,10 +131,7 @@ contract CCIPAdapterTest is Test {
             address(delegateCallerMock),
             address(router),
             address(feeTokenErc20),
-            new uint256[](0),
-            new address[](0),
-            new uint256[](0),
-            new uint64[](0)
+            new BaseAdapter.TrustedRemoteConfig[](0)
         );
     }
 
@@ -193,17 +151,16 @@ contract CCIPAdapterTest is Test {
     function _registerLane(
         uint256 chainId,
         address localAdapter,
-        address remoteAdapterAddr,
-        uint64 bridgeChainId
+        address remoteAdapterAddr
     ) internal {
         _grantAllPermissions();
         uint256[] memory ids = new uint256[](1);
         ids[0] = chainId;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        CrossChainController.ChainConfig[]
+            memory configs = new CrossChainController.ChainConfig[](1);
         configs[0] = CrossChainController.ChainConfig({
             localAdapter: localAdapter,
-            remoteAdapter: remoteAdapterAddr,
-            bridgeChainId: bridgeChainId
+            remoteAdapter: remoteAdapterAddr
         });
         controller.updateConfig(ids, configs);
     }
@@ -213,7 +170,8 @@ contract CCIPAdapterTest is Test {
         _grantAllPermissions();
         uint256[] memory ids = new uint256[](1);
         ids[0] = chainId;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        CrossChainController.ChainConfig[]
+            memory configs = new CrossChainController.ChainConfig[](1);
         controller.updateConfig(ids, configs);
     }
 
@@ -237,28 +195,15 @@ contract CCIPAdapterTest is Test {
     }
 
     // =========================================================================
-    // a) `_forwardMessage` must not be externally callable.
-    // =========================================================================
-
-    /// @dev `_forwardMessage` is `internal` on `BaseAdapter`, reachable only
-    ///      after `ccipReceive`'s `onlyRouter` and trusted-remote checks. A raw
-    ///      call with the old signature must simply fail: the adapter has no
-    ///      fallback, so there is no selector for it to hit.
-    function test_forwardMessage_isNotExternallyCallable() public {
-        (bool success, bytes memory returndata) = address(adapter).call(
-            abi.encodeWithSignature("_forwardMessage(bytes32,bytes,uint256)", bytes32(0), bytes(""), CHAIN_ETH_MAINNET)
-        );
-
-        assertFalse(success, "_forwardMessage must not be externally callable");
-        assertEq(returndata.length, 0, "no fallback exists to handle the unmatched selector");
-    }
-
-    // =========================================================================
     // b) `ccipReceive`
     // =========================================================================
 
     function test_ccipReceive_revertsIfCallerNotRouter() public {
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteController, "");
+        Client.Any2EVMMessage memory message = _buildInbound(
+            SEL_ETH_MAINNET,
+            remoteController,
+            ""
+        );
 
         vm.expectRevert(Errors.CALLER_NOT_CCIP_ROUTER.selector);
         vm.prank(alice);
@@ -266,29 +211,40 @@ contract CCIPAdapterTest is Test {
     }
 
     function test_ccipReceive_revertsIfDecodedSenderIsZero() public {
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, address(0), "");
+        Client.Any2EVMMessage memory message = _buildInbound(
+            SEL_ETH_MAINNET,
+            address(0),
+            ""
+        );
 
         vm.expectRevert(Errors.REMOTE_NOT_TRUSTED.selector);
         vm.prank(address(router));
         adapter.ccipReceive(message);
     }
 
-    function test_ccipReceive_revertsIfSenderIsAnArbitraryUntrustedAddress() public {
+    function test_ccipReceive_revertsIfSenderIsAnArbitraryUntrustedAddress()
+        public
+    {
         address untrusted = makeAddr("untrusted");
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, untrusted, "");
+        Client.Any2EVMMessage memory message = _buildInbound(
+            SEL_ETH_MAINNET,
+            untrusted,
+            ""
+        );
 
         vm.expectRevert(Errors.REMOTE_NOT_TRUSTED.selector);
         vm.prank(address(router));
         adapter.ccipReceive(message);
     }
 
-    /// @dev THE canonical misconfiguration this redesign invites: pointing
-    ///      `ccipReceive` at the remote ADAPTER instead of the remote
-    ///      CONTROLLER. `remoteAdapter` is a real, meaningful address in this
-    ///      suite's config (it's what `chainToAdapter[].remoteAdapter` holds),
-    ///      but it must NEVER be a valid `_trustedRemotes` entry.
-    function test_ccipReceive_revertsIfSenderIsRemoteAdapterInsteadOfRemoteController() public {
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteAdapter, "");
+    function test_ccipReceive_revertsIfSenderIsRemoteAdapterInsteadOfRemoteController()
+        public
+    {
+        Client.Any2EVMMessage memory message = _buildInbound(
+            SEL_ETH_MAINNET,
+            remoteAdapter,
+            ""
+        );
 
         vm.expectRevert(Errors.REMOTE_NOT_TRUSTED.selector);
         vm.prank(address(router));
@@ -296,16 +252,25 @@ contract CCIPAdapterTest is Test {
     }
 
     /// @dev The success path: sender IS the remote CONTROLLER.
-    function test_ccipReceive_succeedsWhenSenderIsRemoteControllerAndForwardsToController() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+    function test_ccipReceive_succeedsWhenSenderIsRemoteControllerAndForwardsToController()
+        public
+    {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
 
         bytes memory payload = _emptyActionsPayload();
         bytes32 messageId = keccak256("msg-1");
 
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteController, payload);
+        Client.Any2EVMMessage memory message = _buildInbound(
+            SEL_ETH_MAINNET,
+            remoteController,
+            payload
+        );
         message.messageId = messageId;
 
-        bytes32 expectedCallId = controller.deriveCallId(CHAIN_ETH_MAINNET, messageId);
+        bytes32 expectedCallId = controller.deriveCallId(
+            CHAIN_ETH_MAINNET,
+            messageId
+        );
 
         vm.expectEmit(true, true, true, true, address(controller));
         emit MessageReceived(CHAIN_ETH_MAINNET, messageId, expectedCallId);
@@ -319,73 +284,82 @@ contract CCIPAdapterTest is Test {
     // =========================================================================
 
     function test_toNativeChainId_returnsConfiguredSelector() public view {
-        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_ETH_MAINNET));
+        assertEq(
+            adapter.toNativeChainId(CHAIN_ETH_MAINNET),
+            uint256(SEL_ETH_MAINNET)
+        );
     }
 
     function test_toNativeChainId_revertsForUnmappedChain() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, uint256(999)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.UNKNOWN_CHAIN_ID.selector,
+                uint256(999)
+            )
+        );
         adapter.toNativeChainId(999);
     }
 
-    function test_fromNativeChainId_isExactInverseOfToNativeChainId() public view {
-        assertEq(adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET)), CHAIN_ETH_MAINNET);
+    function test_fromNativeChainId_isExactInverseOfToNativeChainId()
+        public
+        view
+    {
+        assertEq(
+            adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET)),
+            CHAIN_ETH_MAINNET
+        );
         assertEq(adapter.fromNativeChainId(uint256(SEL_BASE)), CHAIN_BASE);
-        assertEq(adapter.fromNativeChainId(uint256(SEL_ARBITRUM_ONE)), CHAIN_ARBITRUM_ONE);
+        assertEq(
+            adapter.fromNativeChainId(uint256(SEL_ARBITRUM_ONE)),
+            CHAIN_ARBITRUM_ONE
+        );
     }
 
     function test_fromNativeChainId_revertsForUnmappedSelector() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_SEPOLIA)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.UNKNOWN_NATIVE_CHAIN_ID.selector,
+                uint256(SEL_SEPOLIA)
+            )
+        );
         adapter.fromNativeChainId(uint256(SEL_SEPOLIA));
     }
 
-    function test_chainIdMapping_roundTripsOverSeveralConfiguredChains() public view {
-        uint256[3] memory chains = [CHAIN_ETH_MAINNET, CHAIN_BASE, CHAIN_ARBITRUM_ONE];
+    function test_chainIdMapping_roundTripsOverSeveralConfiguredChains()
+        public
+        view
+    {
+        uint256[3] memory chains = [
+            CHAIN_ETH_MAINNET,
+            CHAIN_BASE,
+            CHAIN_ARBITRUM_ONE
+        ];
         for (uint256 i = 0; i < chains.length; i++) {
-            assertEq(adapter.fromNativeChainId(adapter.toNativeChainId(chains[i])), chains[i]);
+            assertEq(
+                adapter.fromNativeChainId(adapter.toNativeChainId(chains[i])),
+                chains[i]
+            );
         }
     }
 
     /// @dev A message arriving from a selector never mapped to a standard
     ///      chain id must revert, not be silently treated as chain `0`.
     function test_ccipReceive_revertsForUnmappedSourceSelector() public {
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_SEPOLIA, remoteController, "");
+        uint64 unmappedSelector = 1234567890; // not in the adapter's map
+        Client.Any2EVMMessage memory message = _buildInbound(
+            unmappedSelector,
+            remoteController,
+            ""
+        );
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_SEPOLIA)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.UNKNOWN_NATIVE_CHAIN_ID.selector,
+                uint256(unmappedSelector)
+            )
+        );
         vm.prank(address(router));
         adapter.ccipReceive(message);
-    }
-
-    function test_setChainSelectors_repointingChainClearsOldReverseMapping() public {
-        _grantAllPermissions();
-
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
-        uint64[] memory sels = new uint64[](1);
-        sels[0] = SEL_BASE_SEPOLIA;
-        adapter.setChainSelectors(ids, sels);
-
-        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_BASE_SEPOLIA));
-        assertEq(adapter.fromNativeChainId(uint256(SEL_BASE_SEPOLIA)), CHAIN_ETH_MAINNET);
-
-        // The old selector's reverse entry must be cleared, not left dangling.
-        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_ETH_MAINNET)));
-        adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET));
-    }
-
-    function test_setChainSelectors_zeroSelectorClearsLaneBothDirections() public {
-        _grantAllPermissions();
-
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
-        uint64[] memory sels = new uint64[](1);
-        sels[0] = 0;
-        adapter.setChainSelectors(ids, sels);
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, CHAIN_ETH_MAINNET));
-        adapter.toNativeChainId(CHAIN_ETH_MAINNET);
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_ETH_MAINNET)));
-        adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET));
     }
 
     // =========================================================================
@@ -402,14 +376,26 @@ contract CCIPAdapterTest is Test {
     ///      side's `_trustedRemotes` does not trust (it trusts the
     ///      controller). Both failure modes are silent/expensive rather than
     ///      loud, so this must revert instead of degrading gracefully.
-    function test_sendMessage_revertsIfCalledDirectly_evenWhenCallerIsTheController() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.SEND_PATH_NOT_DELEGATECALLED.selector, address(adapter)));
+    function test_sendMessage_revertsIfCalledDirectly_evenWhenCallerIsTheController()
+        public
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SEND_PATH_NOT_DELEGATECALLED.selector,
+                address(adapter)
+            )
+        );
         vm.prank(address(controller));
         adapter.sendMessage(remoteAdapter, SEL_ETH_MAINNET, 200_000, "");
     }
 
     function test_sendMessage_revertsIfCalledDirectlyByAnybody() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.SEND_PATH_NOT_DELEGATECALLED.selector, address(adapter)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SEND_PATH_NOT_DELEGATECALLED.selector,
+                address(adapter)
+            )
+        );
         vm.prank(alice);
         adapter.sendMessage(remoteAdapter, SEL_ETH_MAINNET, 200_000, "");
     }
@@ -424,7 +410,10 @@ contract CCIPAdapterTest is Test {
     ///      CROSS_CHAIN_CONTROLLER` context directly, so the check itself is
     ///      still proven to work correctly in isolation.
     function test_sendMessage_isolated_revertsIfReceiverIsZero() public {
-        bytes memory data = abi.encodeCall(IBaseAdapter.sendMessage, (address(0), SEL_ETH_MAINNET, 200_000, bytes("")));
+        bytes memory data = abi.encodeCall(
+            IBaseAdapter.sendMessage,
+            (address(0), SEL_ETH_MAINNET, 200_000, bytes(""))
+        );
 
         vm.expectRevert(Errors.RECEIVER_ADDRESS_ZERO.selector);
         delegateCallerMock.delegateCall(address(isolationAdapter), data);
@@ -440,65 +429,104 @@ contract CCIPAdapterTest is Test {
     ///      the approval is actually made -- and, since the send is a
     ///      `delegatecall`, made on the CONTROLLER's allowance, which is what
     ///      the router pulls from.
-    function test_sendMessage_erc20Fee_approvesRouterAndRouterPullsExactFee() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
+    function test_sendMessage_erc20Fee_approvesRouterAndRouterPullsExactFee()
+        public
+    {
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter);
         uint256 feeAmount = 3 ether;
         router.setFee(feeAmount);
         feeTokenErc20.setBalance(address(controller), feeAmount);
 
-        bytes32 messageId = controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "hello");
+        bytes32 messageId = controller.forwardMessage(
+            CHAIN_ETH_MAINNET,
+            200_000,
+            "hello"
+        );
 
         assertEq(router.ccipSendCallCount(), 1);
-        assertEq(feeTokenErc20.balanceOf(address(router)), feeAmount, "router must have pulled the fee");
+        assertEq(
+            feeTokenErc20.balanceOf(address(router)),
+            feeAmount,
+            "router must have pulled the fee"
+        );
         assertEq(messageId, router.nextMessageId());
     }
 
-    function test_sendMessage_erc20Fee_leavesZeroStandingAllowanceOnControllerAfterSend() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
+    function test_sendMessage_erc20Fee_leavesZeroStandingAllowanceOnControllerAfterSend()
+        public
+    {
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter);
         uint256 feeAmount = 3 ether;
         router.setFee(feeAmount);
         feeTokenErc20.setBalance(address(controller), feeAmount);
 
         controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
 
-        assertEq(feeTokenErc20.allowance(address(controller), address(router)), 0);
+        assertEq(
+            feeTokenErc20.allowance(address(controller), address(router)),
+            0
+        );
     }
 
-    function test_sendMessage_erc20Fee_revertsIfControllerBalanceInsufficient() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
+    function test_sendMessage_erc20Fee_revertsIfControllerBalanceInsufficient()
+        public
+    {
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter);
         uint256 feeAmount = 1 ether;
         uint256 available = 0.4 ether;
         router.setFee(feeAmount);
         feeTokenErc20.setBalance(address(controller), available);
 
         vm.expectRevert(
-            abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(feeTokenErc20), feeAmount, available)
+            abi.encodeWithSelector(
+                Errors.INSUFFICIENT_FEE_BALANCE.selector,
+                address(feeTokenErc20),
+                feeAmount,
+                available
+            )
         );
         controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
     }
 
-    function test_sendMessage_nativeFee_paysExactFeeFromControllerBalance() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+    function test_sendMessage_nativeFee_paysExactFeeFromControllerBalance()
+        public
+    {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
         uint256 feeAmount = 0.05 ether;
         router.setFee(feeAmount);
         vm.deal(address(controller), feeAmount);
 
         controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
 
-        assertEq(router.lastMsgValue(), feeAmount, "router must receive exactly the quoted fee");
+        assertEq(
+            router.lastMsgValue(),
+            feeAmount,
+            "router must receive exactly the quoted fee"
+        );
         assertEq(address(controller).balance, 0);
-        assertEq(address(adapter).balance, 0, "adapter must never hold native funds");
+        assertEq(
+            address(adapter).balance,
+            0,
+            "adapter must never hold native funds"
+        );
     }
 
-    function test_sendMessage_nativeFee_revertsIfControllerBalanceInsufficient() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+    function test_sendMessage_nativeFee_revertsIfControllerBalanceInsufficient()
+        public
+    {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
         uint256 feeAmount = 1 ether;
         uint256 available = 0.5 ether;
         router.setFee(feeAmount);
         vm.deal(address(controller), available);
 
         vm.expectRevert(
-            abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(0), feeAmount, available)
+            abi.encodeWithSelector(
+                Errors.INSUFFICIENT_FEE_BALANCE.selector,
+                address(0),
+                feeAmount,
+                available
+            )
         );
         controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
     }
@@ -509,14 +537,19 @@ contract CCIPAdapterTest is Test {
     ///      because `forwardMessage` is not `payable`: `msg.value` inside the
     ///      delegatecalled `sendMessage` is always whatever `forwardMessage`'s
     ///      own call frame had, which can only be `0`. Exercised in isolation.
-    function test_sendMessage_isolated_revertsIfNativeValueSentWhileErc20FeeTokenConfigured() public {
+    function test_sendMessage_isolated_revertsIfNativeValueSentWhileErc20FeeTokenConfigured()
+        public
+    {
         bytes memory data = abi.encodeCall(
             IBaseAdapter.sendMessage,
-            (remoteAdapter, SEL_ETH_MAINNET, 200_000, bytes(""))
+            (remoteAdapter, CHAIN_ETH_MAINNET, 200_000, bytes(""))
         );
 
         vm.expectRevert(Errors.UNEXPECTED_NATIVE_VALUE.selector);
-        delegateCallerMock.delegateCall{value: 1 ether}(address(isolationAdapter), data);
+        delegateCallerMock.delegateCall{value: 1 ether}(
+            address(isolationAdapter),
+            data
+        );
     }
 
     function test_quoteFee_revertsIfReceiverIsZero() public {
@@ -525,14 +558,21 @@ contract CCIPAdapterTest is Test {
     }
 
     function test_quoteFee_revertsIfBridgeChainIdIsZero() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, uint256(0)));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, uint256(0))
+        );
         adapter.quoteFee(remoteAdapter, 0, 200_000, "");
     }
 
     function test_quoteFee_returnsRouterQuoteAndConfiguredFeeToken() public {
         router.setFee(7 ether);
 
-        (address feeToken, uint256 fee) = erc20Adapter.quoteFee(remoteAdapter, SEL_ETH_MAINNET, 200_000, "");
+        (address feeToken, uint256 fee) = erc20Adapter.quoteFee(
+            remoteAdapter,
+            CHAIN_ETH_MAINNET,
+            200_000,
+            ""
+        );
 
         assertEq(feeToken, address(feeTokenErc20));
         assertEq(fee, 7 ether);
@@ -543,223 +583,8 @@ contract CCIPAdapterTest is Test {
     //    NOTE: `setFeeToken` is GONE -- see the fee-token-immutability section.
     // =========================================================================
 
-    function test_setChainSelectors_revertsIfUnauthorized() public {
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_SEPOLIA;
-        uint64[] memory sels = new uint64[](1);
-        sels[0] = SEL_SEPOLIA;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DaoUnauthorized.selector,
-                address(daoMock),
-                address(adapter),
-                alice,
-                adapter.UPDATE_ADAPTER_CONFIG_PERMISSION_ID()
-            )
-        );
-        vm.prank(alice);
-        adapter.setChainSelectors(ids, sels);
-    }
-
-    function test_setChainSelectors_emitsEventAndUpdatesStorage() public {
-        _grantAllPermissions();
-
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_SEPOLIA;
-        uint64[] memory sels = new uint64[](1);
-        sels[0] = SEL_SEPOLIA;
-
-        vm.expectEmit(true, true, true, true, address(adapter));
-        emit ChainSelectorSet(CHAIN_SEPOLIA, SEL_SEPOLIA);
-        adapter.setChainSelectors(ids, sels);
-
-        assertEq(adapter.toNativeChainId(CHAIN_SEPOLIA), uint256(SEL_SEPOLIA));
-    }
-
-    function test_setTrustedRemotes_revertsIfUnauthorized() public {
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
-        address[] memory remotes = new address[](1);
-        remotes[0] = makeAddr("newRemoteController");
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DaoUnauthorized.selector,
-                address(daoMock),
-                address(adapter),
-                alice,
-                adapter.UPDATE_ADAPTER_CONFIG_PERMISSION_ID()
-            )
-        );
-        vm.prank(alice);
-        adapter.setTrustedRemotes(ids, remotes);
-    }
-
-    function test_setTrustedRemotes_emitsEventAndUpdatesStorage() public {
-        _grantAllPermissions();
-
-        address newRemoteController = makeAddr("newRemoteController");
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
-        address[] memory remotes = new address[](1);
-        remotes[0] = newRemoteController;
-
-        vm.expectEmit(true, true, true, true, address(adapter));
-        emit TrustedRemoteSet(CHAIN_ETH_MAINNET, newRemoteController);
-        adapter.setTrustedRemotes(ids, remotes);
-
-        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), newRemoteController);
-    }
-
     function test_trustedRemote_returnsZeroForUnsetChain() public view {
         assertEq(adapter.trustedRemote(CHAIN_BASE), address(0));
-    }
-
-    // =========================================================================
-    // g.1) `assertTrustedRemotesMatchControllers`
-    // =========================================================================
-
-    function test_assertTrustedRemotesMatchControllers_passesWhenTrustedRemoteMatchesExpectedController() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
-
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
-        address[] memory expected = new address[](1);
-        expected[0] = remoteController;
-
-        adapter.assertTrustedRemotesMatchControllers(ids, expected); // must not revert
-    }
-
-    function test_assertTrustedRemotesMatchControllers_revertsWhenExpectedControllerIsWrong() public {
-        address wrongExpected = makeAddr("wrongExpectedController");
-
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
-        address[] memory expected = new address[](1);
-        expected[0] = wrongExpected;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.TRUSTED_REMOTE_MISMATCH.selector,
-                CHAIN_ETH_MAINNET,
-                remoteController,
-                wrongExpected
-            )
-        );
-        adapter.assertTrustedRemotesMatchControllers(ids, expected);
-    }
-
-    function test_assertTrustedRemotesMatchControllers_revertsWhenTrustedRemoteIsUnset() public {
-        // CHAIN_BASE has a selector mapping but no trusted remote configured.
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_BASE;
-        address[] memory expected = new address[](1);
-        expected[0] = makeAddr("anyExpectedController");
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.TRUSTED_REMOTE_MISMATCH.selector,
-                CHAIN_BASE,
-                address(0),
-                expected[0]
-            )
-        );
-        adapter.assertTrustedRemotesMatchControllers(ids, expected);
-    }
-
-    function test_assertTrustedRemotesMatchControllers_revertsOnLengthMismatch() public {
-        uint256[] memory ids = new uint256[](2);
-        ids[0] = CHAIN_ETH_MAINNET;
-        ids[1] = CHAIN_BASE;
-        address[] memory expected = new address[](1);
-        expected[0] = remoteController;
-
-        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
-        adapter.assertTrustedRemotesMatchControllers(ids, expected);
-    }
-
-    /// @dev THE canonical misconfiguration, mechanically detected: the adapter
-    ///      was set up trusting the remote ADAPTER (copy-pasted from
-    ///      `chainToAdapter[].remoteAdapter`) instead of the remote
-    ///      CONTROLLER. `expected` is deliberately set equal to the (wrong)
-    ///      trusted value so the plain mismatch check does not fire first --
-    ///      isolating the `TRUSTED_REMOTE_IS_REMOTE_ADAPTER` branch.
-    function test_assertTrustedRemotesMatchControllers_revertsWhenTrustedRemoteIsRemoteAdapter() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
-
-        _grantAllPermissions();
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
-        address[] memory misconfiguredTrustedRemotes = new address[](1);
-        misconfiguredTrustedRemotes[0] = remoteAdapter; // WRONG: should be remoteController.
-        adapter.setTrustedRemotes(ids, misconfiguredTrustedRemotes);
-
-        address[] memory expected = new address[](1);
-        expected[0] = remoteAdapter; // matches the (wrong) trusted value.
-
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.TRUSTED_REMOTE_IS_REMOTE_ADAPTER.selector, CHAIN_ETH_MAINNET, remoteAdapter)
-        );
-        adapter.assertTrustedRemotesMatchControllers(ids, expected);
-    }
-
-    // =========================================================================
-    // g.2) `assertChainSelectorsMatchController`
-    // =========================================================================
-
-    function test_assertChainSelectorsMatchController_passesWhenInSync() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
-
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
-        adapter.assertChainSelectorsMatchController(ids); // must not revert
-    }
-
-    function test_assertChainSelectorsMatchController_revertsOnDesync() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
-
-        // Desync the RECEIVE-side map away from what the controller's
-        // SEND-side config still says, e.g. via an incomplete `setChainSelectors`
-        // rollout for a new CCIP lane version.
-        _grantAllPermissions();
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
-        uint64[] memory sels = new uint64[](1);
-        sels[0] = SEL_BASE_SEPOLIA;
-        adapter.setChainSelectors(ids, sels);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.CHAIN_ID_DESYNC.selector,
-                CHAIN_ETH_MAINNET,
-                SEL_ETH_MAINNET,
-                SEL_BASE_SEPOLIA
-            )
-        );
-        adapter.assertChainSelectorsMatchController(ids);
-    }
-
-    function test_assertChainSelectorsMatchController_revertsWhenControllerHasNoLane() public {
-        // CHAIN_BASE has an adapter-side selector (from `setUp`) but no
-        // controller lane was ever registered for it.
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_BASE;
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_BASE));
-        adapter.assertChainSelectorsMatchController(ids);
-    }
-
-    function test_assertChainSelectorsMatchController_revertsWhenAdapterHasNoEntry() public {
-        // Controller lane registered for CHAIN_SEPOLIA, but the adapter's own
-        // selector map was never told about it.
-        _registerLane(CHAIN_SEPOLIA, address(adapter), remoteAdapter, SEL_SEPOLIA);
-
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_SEPOLIA;
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, CHAIN_SEPOLIA));
-        adapter.assertChainSelectorsMatchController(ids);
     }
 
     /// @dev Demonstrates what a desync actually DOES, not just that it is
@@ -768,36 +593,24 @@ contract CCIPAdapterTest is Test {
     ///      `SEL_ETH_MAINNET` for `CHAIN_ETH_MAINNET`, pointing the controller's
     ///      lane at a different selector sends there instead -- the adapter's
     ///      receive-side storage is not read at all on send.
-    function test_desyncedChainSelectors_sendGoesToControllersSelector_ignoringAdapterMap() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_BASE_SEPOLIA);
-
-        uint256 feeAmount = 0.01 ether;
-        router.setFee(feeAmount);
-        vm.deal(address(controller), feeAmount);
-
-        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
-
-        assertEq(
-            router.lastDestChainSelector(),
-            SEL_BASE_SEPOLIA,
-            "send must use the controller's bridgeChainId, not the adapter's own selector map"
-        );
-        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_ETH_MAINNET), "adapter's own map is untouched");
-    }
-
     // =========================================================================
     // h) ERC-165
     // =========================================================================
 
     function test_supportsInterface_IAny2EVMMessageReceiver() public view {
-        assertTrue(adapter.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId));
+        assertTrue(
+            adapter.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId)
+        );
     }
 
     function test_supportsInterface_IERC165() public view {
         assertTrue(adapter.supportsInterface(type(IERC165).interfaceId));
     }
 
-    function test_supportsInterface_returnsFalseForUnknownInterface() public view {
+    function test_supportsInterface_returnsFalseForUnknownInterface()
+        public
+        view
+    {
         assertFalse(adapter.supportsInterface(0xdeadbeef));
     }
 
@@ -805,8 +618,10 @@ contract CCIPAdapterTest is Test {
     // i) End-to-end: controller.forwardMessage -> [delegatecall] adapter -> router
     // =========================================================================
 
-    function test_forwardMessage_endToEnd_routesThroughAdapterToRouter() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+    function test_forwardMessage_endToEnd_routesThroughAdapterToRouter()
+        public
+    {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
 
         uint256 feeAmount = 0.02 ether;
         router.setFee(feeAmount);
@@ -818,22 +633,45 @@ contract CCIPAdapterTest is Test {
         bytes memory payload = _emptyActionsPayload();
         uint256 gasLimit = 300_000;
 
-        bytes32 messageId = controller.forwardMessage(CHAIN_ETH_MAINNET, gasLimit, payload);
+        bytes32 messageId = controller.forwardMessage(
+            CHAIN_ETH_MAINNET,
+            gasLimit,
+            payload
+        );
 
-        assertEq(messageId, expectedMessageId, "controller must surface the router's messageId");
+        assertEq(
+            messageId,
+            expectedMessageId,
+            "controller must surface the router's messageId"
+        );
 
         address decodedReceiver = abi.decode(router.lastReceiver(), (address));
-        assertEq(decodedReceiver, remoteAdapter, "router must target the remote adapter");
+        assertEq(
+            decodedReceiver,
+            remoteAdapter,
+            "router must target the remote adapter"
+        );
         assertEq(router.lastData(), payload);
         assertEq(router.lastFeeToken(), address(0));
         assertEq(router.lastDestChainSelector(), SEL_ETH_MAINNET);
         assertEq(router.lastMsgValue(), feeAmount);
-        assertEq(router.lastCaller(), address(controller), "CCIP must see the controller as the sender under delegatecall");
+        assertEq(
+            router.lastCaller(),
+            address(controller),
+            "CCIP must see the controller as the sender under delegatecall"
+        );
 
         bytes memory expectedExtraArgs = Client._argsToBytes(
-            Client.GenericExtraArgsV2({gasLimit: gasLimit, allowOutOfOrderExecution: true})
+            Client.GenericExtraArgsV2({
+                gasLimit: gasLimit,
+                allowOutOfOrderExecution: true
+            })
         );
-        assertEq(router.lastExtraArgs(), expectedExtraArgs, "extraArgs must encode the requested gas limit");
+        assertEq(
+            router.lastExtraArgs(),
+            expectedExtraArgs,
+            "extraArgs must encode the requested gas limit"
+        );
     }
 
     // =========================================================================
@@ -841,54 +679,24 @@ contract CCIPAdapterTest is Test {
     // =========================================================================
 
     function test_constructor_revertsIfRouterIsZeroAddress() public {
-        uint256[] memory empty;
-        address[] memory emptyAddr;
-
         vm.expectRevert(Errors.ZERO_ADDRESS.selector);
-        new CCIPAdapter(address(controller), address(0), address(0), empty, emptyAddr, empty, new uint64[](0));
-    }
-
-    function test_constructor_revertsOnTrustedRemoteLengthMismatch() public {
-        uint256[] memory chainIds = new uint256[](2);
-        chainIds[0] = CHAIN_ETH_MAINNET;
-        chainIds[1] = CHAIN_BASE;
-        address[] memory remotes = new address[](1);
-        remotes[0] = remoteController;
-
-        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
         new CCIPAdapter(
             address(controller),
-            address(router),
             address(0),
-            chainIds,
-            remotes,
-            new uint256[](0),
-            new uint64[](0)
+            address(0),
+            new BaseAdapter.TrustedRemoteConfig[](0)
         );
     }
 
-    function test_constructor_revertsOnSelectorLengthMismatch() public {
-        uint256[] memory selChainIds = new uint256[](2);
-        selChainIds[0] = CHAIN_ETH_MAINNET;
-        selChainIds[1] = CHAIN_BASE;
-        uint64[] memory sels = new uint64[](1);
-        sels[0] = SEL_ETH_MAINNET;
-
-        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
-        new CCIPAdapter(
-            address(controller),
-            address(router),
-            address(0),
-            new uint256[](0),
-            new address[](0),
-            selChainIds,
-            sels
-        );
-    }
-
-    function test_constructor_wiresUpConfiguredTrustedRemoteControllerAndSelector() public view {
+    function test_constructor_wiresUpConfiguredTrustedRemoteControllerAndSelector()
+        public
+        view
+    {
         assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), remoteController);
-        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_ETH_MAINNET));
+        assertEq(
+            adapter.toNativeChainId(CHAIN_ETH_MAINNET),
+            uint256(SEL_ETH_MAINNET)
+        );
     }
 
     // =========================================================================
@@ -904,8 +712,10 @@ contract CCIPAdapterTest is Test {
     ///      silent, wrong-currency bridge send. `FEE_TOKEN` being `immutable`
     ///      means it is baked into the adapter's bytecode and resolves
     ///      identically no matter whose storage is in scope.
-    function test_immutables_feeTokenAndRouterSurviveDelegatecall_notMisreadAsControllerStorage() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
+    function test_immutables_feeTokenAndRouterSurviveDelegatecall_notMisreadAsControllerStorage()
+        public
+    {
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter);
 
         uint256 feeAmount = 2 ether;
         router.setFee(feeAmount);
@@ -913,8 +723,16 @@ contract CCIPAdapterTest is Test {
 
         controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
 
-        assertEq(router.lastFeeToken(), address(feeTokenErc20), "immutable FEE_TOKEN must survive delegatecall");
-        assertEq(router.lastCaller(), address(controller), "CCIP_ROUTER must see the controller as caller");
+        assertEq(
+            router.lastFeeToken(),
+            address(feeTokenErc20),
+            "immutable FEE_TOKEN must survive delegatecall"
+        );
+        assertEq(
+            router.lastCaller(),
+            address(controller),
+            "CCIP_ROUTER must see the controller as caller"
+        );
     }
 
     /// @dev Two adapters, two ERC20 fee tokens, two routers: a send through
@@ -923,21 +741,20 @@ contract CCIPAdapterTest is Test {
     ///      controller's storage, this would either hit the wrong router or
     ///      silently agree by coincidence -- using two independent routers
     ///      rules the coincidence out.
-    function test_immutables_twoAdaptersRouteExclusivelyToTheirOwnRouterAndFeeToken() public {
+    function test_immutables_twoAdaptersRouteExclusivelyToTheirOwnRouterAndFeeToken()
+        public
+    {
         CCIPRouterMock routerB = new CCIPRouterMock();
         ERC20Mock feeTokenB = new ERC20Mock("Fee Token B", "FEEB");
         CCIPAdapter adapterB = new CCIPAdapter(
             address(controller),
             address(routerB),
             address(feeTokenB),
-            new uint256[](0),
-            new address[](0),
-            new uint256[](0),
-            new uint64[](0)
+            new BaseAdapter.TrustedRemoteConfig[](0)
         );
 
-        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET); // -> router (lane A)
-        _registerLane(CHAIN_BASE, address(adapterB), remoteAdapter, SEL_BASE); // -> routerB (lane B)
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter); // -> router (lane A)
+        _registerLane(CHAIN_BASE, address(adapterB), remoteAdapter); // -> routerB (lane B)
 
         router.setFee(1 ether);
         routerB.setFee(2 ether);
@@ -948,7 +765,11 @@ contract CCIPAdapterTest is Test {
 
         assertEq(router.ccipSendCallCount(), 1);
         assertEq(router.lastFeeToken(), address(feeTokenErc20));
-        assertEq(routerB.ccipSendCallCount(), 0, "lane A's send must not touch router B at all");
+        assertEq(
+            routerB.ccipSendCallCount(),
+            0,
+            "lane A's send must not touch router B at all"
+        );
     }
 
     // =========================================================================
@@ -967,31 +788,55 @@ contract CCIPAdapterTest is Test {
     ///      controller never issues a plain `call` into the adapter -- worth
     ///      asserting so a future refactor that broke this would be caught.
     function test_forwardMessage_doesNotCollideWithControllerStorage() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
 
         uint256 feeAmount = 0.02 ether;
         router.setFee(feeAmount);
         vm.deal(address(controller), feeAmount);
 
-        bytes32 chainConfigSlotA = keccak256(abi.encode(CHAIN_ETH_MAINNET, uint256(0)));
+        bytes32 chainConfigSlotA = keccak256(
+            abi.encode(CHAIN_ETH_MAINNET, uint256(0))
+        );
         bytes32 chainConfigSlotB = bytes32(uint256(chainConfigSlotA) + 1);
-        bytes32 laneCountSlot = keccak256(abi.encode(address(adapter), uint256(1)));
+        bytes32 laneCountSlot = keccak256(
+            abi.encode(address(adapter), uint256(1))
+        );
 
         bytes32 slot0Before = vm.load(address(controller), bytes32(uint256(0)));
         bytes32 slot1Before = vm.load(address(controller), bytes32(uint256(1)));
         bytes32 slot2Before = vm.load(address(controller), bytes32(uint256(2)));
-        bytes32 chainConfigABefore = vm.load(address(controller), chainConfigSlotA);
-        bytes32 chainConfigBBefore = vm.load(address(controller), chainConfigSlotB);
+        bytes32 chainConfigABefore = vm.load(
+            address(controller),
+            chainConfigSlotA
+        );
+        bytes32 chainConfigBBefore = vm.load(
+            address(controller),
+            chainConfigSlotB
+        );
         bytes32 laneCountBefore = vm.load(address(controller), laneCountSlot);
 
         address trustedRemoteBefore = adapter.trustedRemote(CHAIN_ETH_MAINNET);
-        uint256 nativeChainIdBefore = adapter.toNativeChainId(CHAIN_ETH_MAINNET);
+        uint256 nativeChainIdBefore = adapter.toNativeChainId(
+            CHAIN_ETH_MAINNET
+        );
 
         controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
 
-        assertEq(vm.load(address(controller), bytes32(uint256(0))), slot0Before, "slot 0 mutated by send");
-        assertEq(vm.load(address(controller), bytes32(uint256(1))), slot1Before, "slot 1 mutated by send");
-        assertEq(vm.load(address(controller), bytes32(uint256(2))), slot2Before, "slot 2 mutated by send");
+        assertEq(
+            vm.load(address(controller), bytes32(uint256(0))),
+            slot0Before,
+            "slot 0 mutated by send"
+        );
+        assertEq(
+            vm.load(address(controller), bytes32(uint256(1))),
+            slot1Before,
+            "slot 1 mutated by send"
+        );
+        assertEq(
+            vm.load(address(controller), bytes32(uint256(2))),
+            slot2Before,
+            "slot 2 mutated by send"
+        );
         assertEq(
             vm.load(address(controller), chainConfigSlotA),
             chainConfigABefore,
@@ -1008,7 +853,11 @@ contract CCIPAdapterTest is Test {
             "_localAdapterLaneCount[adapter] slot mutated by send"
         );
 
-        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), trustedRemoteBefore, "adapter's own storage touched by send");
+        assertEq(
+            adapter.trustedRemote(CHAIN_ETH_MAINNET),
+            trustedRemoteBefore,
+            "adapter's own storage touched by send"
+        );
         assertEq(
             adapter.toNativeChainId(CHAIN_ETH_MAINNET),
             nativeChainIdBefore,
@@ -1021,28 +870,40 @@ contract CCIPAdapterTest is Test {
     // =========================================================================
 
     /// @dev Proves that reaching the RECEIVE path under `delegatecall` reverts.
-    ///      `delegateCallerMock` has NO storage of its own for `_trustedRemotes`
-    ///      / `_selectorToChainId`, so those checks would revert first unless
-    ///      fake entries are planted at the exact slots
-    ///      `forge inspect .../CCIPAdapter.sol:CCIPAdapter storageLayout`
-    ///      reports (slot 0 `_trustedRemotes`, slot 2 `_selectorToChainId`) --
-    ///      done here via `vm.store` so execution genuinely reaches
-    ///      `_forwardMessage` and trips `DELEGATE_CALL_FORBIDDEN` specifically,
-    ///      rather than failing earlier for an unrelated reason.
-    function test_ccipReceive_delegatecalledIntoAdapter_revertsWithDelegateCallForbidden() public {
-        uint256 fakeOriginChainId = 777;
-        address fakeTrustedSender = makeAddr("fakeTrustedSenderForDelegatecallProbe");
+    ///      The native<->standard map is hardcoded pure logic, so no storage is
+    ///      needed for it -- `SEL_ETH_MAINNET` resolves to `ChainIds.ETHEREUM`
+    ///      on its own. The ONLY storage read on the way to `_forwardMessage` is
+    ///      `_trustedRemotes[originChainId]` (slot 0), which under `delegatecall`
+    ///      resolves against `delegateCallerMock`'s own (otherwise empty)
+    ///      storage. We plant a matching trusted-remote entry there via
+    ///      `vm.store` so the trusted-remote check passes and execution genuinely
+    ///      reaches `_forwardMessage`, tripping `DELEGATE_CALL_FORBIDDEN`
+    ///      specifically rather than `REMOTE_NOT_TRUSTED` first.
+    function test_ccipReceive_delegatecalledIntoAdapter_revertsWithDelegateCallForbidden()
+        public
+    {
+        // `fromNativeChainId(SEL_ETH_MAINNET)` is pure and returns this.
+        uint256 originChainId = ChainIds.ETHEREUM;
+        address fakeTrustedSender = makeAddr(
+            "fakeTrustedSenderForDelegatecallProbe"
+        );
 
-        // `_selectorToChainId[SEL_ETH_MAINNET] = fakeOriginChainId` at slot 2,
+        // `_trustedRemotes[originChainId] = fakeTrustedSender` at slot 0,
         // computed against `delegateCallerMock`'s own (otherwise empty) storage.
-        bytes32 selectorToChainIdSlot = keccak256(abi.encode(uint256(SEL_ETH_MAINNET), uint256(2)));
-        vm.store(address(delegateCallerMock), selectorToChainIdSlot, bytes32(fakeOriginChainId));
+        bytes32 trustedRemoteSlot = keccak256(
+            abi.encode(originChainId, uint256(0))
+        );
+        vm.store(
+            address(delegateCallerMock),
+            trustedRemoteSlot,
+            bytes32(uint256(uint160(fakeTrustedSender)))
+        );
 
-        // `_trustedRemotes[fakeOriginChainId] = fakeTrustedSender` at slot 0.
-        bytes32 trustedRemoteSlot = keccak256(abi.encode(fakeOriginChainId, uint256(0)));
-        vm.store(address(delegateCallerMock), trustedRemoteSlot, bytes32(uint256(uint160(fakeTrustedSender))));
-
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, fakeTrustedSender, "");
+        Client.Any2EVMMessage memory message = _buildInbound(
+            SEL_ETH_MAINNET,
+            fakeTrustedSender,
+            ""
+        );
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1052,7 +913,10 @@ contract CCIPAdapterTest is Test {
             )
         );
         vm.prank(address(router)); // `onlyRouter` checks msg.sender, preserved across delegatecall.
-        delegateCallerMock.delegateCall(address(adapter), abi.encodeCall(CCIPAdapter.ccipReceive, (message)));
+        delegateCallerMock.delegateCall(
+            address(adapter),
+            abi.encodeCall(CCIPAdapter.ccipReceive, (message))
+        );
     }
 
     // =========================================================================
@@ -1065,21 +929,25 @@ contract CCIPAdapterTest is Test {
     ///      the new `FEE_TOKEN` and repointing the lane via
     ///      `CrossChainController.updateConfig`, which correctly de-registers
     ///      the old local adapter (refcounted) and registers the new one.
-    function test_feeTokenRotation_requiresDeployingANewAdapterAndRepointingTheLane() public {
+    function test_feeTokenRotation_requiresDeployingANewAdapterAndRepointingTheLane()
+        public
+    {
         ERC20Mock newFeeToken = new ERC20Mock("New Fee Token", "NEWFEE");
         CCIPAdapter newAdapter = new CCIPAdapter(
             address(controller),
             address(router),
             address(newFeeToken),
-            new uint256[](0),
-            new address[](0),
-            new uint256[](0),
-            new uint64[](0)
+            new BaseAdapter.TrustedRemoteConfig[](0)
         );
 
         // Old lane, old fee token: works today.
-        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
-        assertTrue(controller.isRegisteredLocalAdapter(address(erc20Adapter)));
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter);
+        assertTrue(
+            controller.isRegisteredLocalAdapter(
+                address(erc20Adapter),
+                CHAIN_ETH_MAINNET
+            )
+        );
 
         router.setFee(1 ether);
         feeTokenErc20.setBalance(address(controller), 1 ether);
@@ -1087,17 +955,29 @@ contract CCIPAdapterTest is Test {
         assertEq(router.lastFeeToken(), address(feeTokenErc20));
 
         // Rotate: repoint the SAME chain id at the new adapter/fee token.
-        _registerLane(CHAIN_ETH_MAINNET, address(newAdapter), remoteAdapter, SEL_ETH_MAINNET);
+        _registerLane(CHAIN_ETH_MAINNET, address(newAdapter), remoteAdapter);
 
         assertFalse(
-            controller.isRegisteredLocalAdapter(address(erc20Adapter)),
+            controller.isRegisteredLocalAdapter(
+                address(erc20Adapter),
+                CHAIN_ETH_MAINNET
+            ),
             "old adapter must lose the right to call receiveMessage once its last lane is repointed"
         );
-        assertTrue(controller.isRegisteredLocalAdapter(address(newAdapter)));
+        assertTrue(
+            controller.isRegisteredLocalAdapter(
+                address(newAdapter),
+                CHAIN_ETH_MAINNET
+            )
+        );
 
         router.setFee(1 ether);
         newFeeToken.setBalance(address(controller), 1 ether);
         controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
-        assertEq(router.lastFeeToken(), address(newFeeToken), "send must now use the new adapter's fee token");
+        assertEq(
+            router.lastFeeToken(),
+            address(newFeeToken),
+            "send must now use the new adapter's fee token"
+        );
     }
 }

--- a/test/common/crosschain/CCIPAdapter.t.sol
+++ b/test/common/crosschain/CCIPAdapter.t.sol
@@ -1,0 +1,695 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {
+    IAny2EVMMessageReceiver
+} from "@chainlink/contracts-ccip/contracts/interfaces/IAny2EVMMessageReceiver.sol";
+import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
+
+import {CCIPAdapter} from "../../../src/common/crosschain/adapters/CCIP/CCIPAdapter.sol";
+import {CrossChainController} from "../../../src/common/crosschain/CrossChainController.sol";
+import {Errors} from "../../../src/common/crosschain/lib/Errors.sol";
+import {DaoUnauthorized} from "../../../src/common/permission/auth/auth.sol";
+import {Action} from "../../../src/common/executors/IExecutor.sol";
+
+import {DAOMock} from "../../mocks/commons/dao/DAOMock.sol";
+import {ERC20Mock} from "../../mocks/commons/token/ERC20Mock.sol";
+import {CCIPRouterMock} from "../../mocks/commons/crosschain/CCIPRouterMock.sol";
+
+/// @notice Regression suite for `CCIPAdapter` (`src/common/crosschain/adapters/CCIP/CCIPAdapter.sol`)
+///         written against the just-hardened cross-chain adapter code.
+///
+/// Setup mirrors production wiring: a `DAOMock` owns a real `CrossChainController`,
+/// and the `CCIPAdapter` adopts that controller's DAO in its constructor
+/// (`BaseAdapter` -> `DaoAuthorizable`). The controller invokes the adapter with a
+/// plain `call`, so CCIP sees the ADAPTER as the message sender on the remote
+/// chain — `_trustedRemotes[chainId]` therefore holds the REMOTE ADAPTER address,
+/// which is exactly what `CrossChainController.chainToAdapter[chainId].remoteAdapter`
+/// stores for the local->remote lane.
+///
+/// Coverage locks in the security-review regressions:
+///  a) `_forwardMessage` is not externally callable (was `public` pre-hardening).
+///  b) `ccipReceive` caller / trusted-remote checks and the success path.
+///  c) chain-id <-> CCIP-selector mapping now reverts instead of silently
+///     mapping to chain `0`.
+///  d) `sendMessage` caller / receiver guards.
+///  e) fee handling: ERC20 fee approval (the missing-`forceApprove` bug),
+///     leftover-return, and native/ERC20 edge cases.
+///  f) config setters are permissioned and emit events.
+///  g) `assertTrustedRemotesMatchController` deployment sanity check.
+///  h) ERC-165 `supportsInterface`.
+///  i) an end-to-end send through `CrossChainController.forwardMessage`.
+contract CCIPAdapterTest is Test {
+    // -------------------------------------------------------------------------
+    // Real CCIP chain selectors / standard chain ids used throughout.
+    // -------------------------------------------------------------------------
+    uint64 internal constant SEL_ETH_MAINNET = 5009297550715157269;
+    uint64 internal constant SEL_BASE = 15971525489660198786;
+    uint64 internal constant SEL_ARBITRUM_ONE = 4949039107694359620;
+    uint64 internal constant SEL_SEPOLIA = 16015286601757825753;
+    uint64 internal constant SEL_BASE_SEPOLIA = 10344971235874465080;
+
+    uint256 internal constant CHAIN_ETH_MAINNET = 1;
+    uint256 internal constant CHAIN_BASE = 8453;
+    uint256 internal constant CHAIN_ARBITRUM_ONE = 42161;
+    uint256 internal constant CHAIN_SEPOLIA = 11155111;
+
+    // -------------------------------------------------------------------------
+    // Events re-declared locally so `vm.expectEmit` can match by signature.
+    // -------------------------------------------------------------------------
+    event FeeTokenSet(address feeToken);
+    event ChainSelectorSet(uint256 indexed chainId, uint64 chainSelector);
+    event TrustedRemoteSet(uint256 indexed chainId, address trustedRemote);
+    event MessageReceived(uint256 indexed originChainId, bytes32 indexed messageId, bytes32 indexed callId);
+
+    DAOMock internal daoMock;
+    CrossChainController internal controller;
+    CCIPRouterMock internal router;
+    ERC20Mock internal feeTokenErc20;
+    CCIPAdapter internal adapter;
+
+    address internal alice;
+    /// @dev The remote-chain ADAPTER address trusted for `CHAIN_ETH_MAINNET`.
+    address internal remoteAdapter;
+
+    function setUp() public {
+        alice = makeAddr("alice");
+        remoteAdapter = makeAddr("remoteAdapter");
+
+        daoMock = new DAOMock();
+        controller = new CrossChainController(address(daoMock));
+        router = new CCIPRouterMock();
+        feeTokenErc20 = new ERC20Mock("Fee Token", "FEE");
+
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ETH_MAINNET;
+        address[] memory trustedRemotes = new address[](1);
+        trustedRemotes[0] = remoteAdapter;
+
+        uint256[] memory selChainIds = new uint256[](3);
+        selChainIds[0] = CHAIN_ETH_MAINNET;
+        selChainIds[1] = CHAIN_BASE;
+        selChainIds[2] = CHAIN_ARBITRUM_ONE;
+        uint64[] memory selectors = new uint64[](3);
+        selectors[0] = SEL_ETH_MAINNET;
+        selectors[1] = SEL_BASE;
+        selectors[2] = SEL_ARBITRUM_ONE;
+
+        adapter = new CCIPAdapter(
+            address(controller),
+            address(router),
+            address(0), // native fee token by default
+            chainIds,
+            trustedRemotes,
+            selChainIds,
+            selectors
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /// @dev `DAOMock.hasPermission` is a single flag that authorizes EVERY
+    ///      permission once toggled; only flip it inside tests that need it.
+    function _grantAllPermissions() internal {
+        daoMock.setHasPermissionReturnValueMock(true);
+    }
+
+    function _setFeeToken(address token) internal {
+        _grantAllPermissions();
+        adapter.setFeeToken(token);
+    }
+
+    /// @dev Registers `localAdapter`/`remote` as the controller's adapter pair
+    ///      for `chainId`, granting the adapter the right to call
+    ///      `receiveMessage` and enabling `forwardMessage`/`quoteFee` for it.
+    function _registerLane(uint256 chainId, address localAdapter, address remote) internal {
+        _grantAllPermissions();
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = chainId;
+        CrossChainController.AdapterByChain[] memory pairs = new CrossChainController.AdapterByChain[](1);
+        pairs[0] = CrossChainController.AdapterByChain({localAdapter: localAdapter, remoteAdapter: remote});
+        controller.updateConfig(ids, pairs);
+    }
+
+    function _buildInbound(
+        uint64 selector,
+        address sender,
+        bytes memory data
+    ) internal pure returns (Client.Any2EVMMessage memory) {
+        return
+            Client.Any2EVMMessage({
+                messageId: keccak256("default-inbound-message"),
+                sourceChainSelector: selector,
+                sender: abi.encode(sender),
+                data: data,
+                destTokenAmounts: new Client.EVMTokenAmount[](0)
+            });
+    }
+
+    // =========================================================================
+    // a) `_forwardMessage` must not be externally callable.
+    // =========================================================================
+
+    /// @dev The pre-hardening code had `_forwardMessage` `public`, letting
+    ///      anyone inject an arbitrary payload/origin chain straight into the
+    ///      controller's `receiveMessage`, bypassing both the `onlyRouter`
+    ///      check and the trusted-remote check in `ccipReceive`. It is now
+    ///      `internal` on `BaseAdapter`; `adapter._forwardMessage(...)` does
+    ///      not even compile from outside the contract, and there is no
+    ///      selector for it in the adapter's ABI. This test proves the
+    ///      low-level fallback path is closed too: a raw call with the old
+    ///      function's signature does not reach any code (the adapter has no
+    ///      fallback function), so it must simply fail.
+    function test_forwardMessage_isNotExternallyCallable() public {
+        (bool success, bytes memory returndata) = address(adapter).call(
+            abi.encodeWithSignature(
+                "_forwardMessage(bytes32,bytes,uint256)",
+                bytes32(0),
+                bytes(""),
+                CHAIN_ETH_MAINNET
+            )
+        );
+
+        assertFalse(success, "_forwardMessage must not be externally callable");
+        assertEq(returndata.length, 0, "no fallback exists to handle the unmatched selector");
+    }
+
+    // =========================================================================
+    // b) `ccipReceive`
+    // =========================================================================
+
+    function test_ccipReceive_revertsIfCallerNotRouter() public {
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteAdapter, "");
+
+        vm.expectRevert(Errors.CALLER_NOT_CCIP_ROUTER.selector);
+        vm.prank(alice);
+        adapter.ccipReceive(message);
+    }
+
+    function test_ccipReceive_revertsIfDecodedSenderIsZero() public {
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, address(0), "");
+
+        vm.expectRevert(Errors.REMOTE_NOT_TRUSTED.selector);
+        vm.prank(address(router));
+        adapter.ccipReceive(message);
+    }
+
+    function test_ccipReceive_revertsIfSenderNotConfiguredTrustedRemote() public {
+        address untrusted = makeAddr("untrusted");
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, untrusted, "");
+
+        vm.expectRevert(Errors.REMOTE_NOT_TRUSTED.selector);
+        vm.prank(address(router));
+        adapter.ccipReceive(message);
+    }
+
+    function test_ccipReceive_succeedsForTrustedRemoteAndForwardsToController() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
+
+        Action[] memory actions = new Action[](0);
+        bytes memory payload = abi.encode(actions);
+        bytes32 messageId = keccak256("msg-1");
+
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteAdapter, payload);
+        message.messageId = messageId;
+
+        bytes32 expectedCallId = controller.deriveCallId(CHAIN_ETH_MAINNET, messageId);
+
+        vm.expectEmit(true, true, true, true, address(controller));
+        emit MessageReceived(CHAIN_ETH_MAINNET, messageId, expectedCallId);
+
+        vm.prank(address(router));
+        adapter.ccipReceive(message);
+    }
+
+    // =========================================================================
+    // c) chain-id <-> selector mapping
+    // =========================================================================
+
+    function test_toNativeChainId_returnsConfiguredSelector() public view {
+        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_ETH_MAINNET));
+    }
+
+    function test_toNativeChainId_revertsForUnmappedChain() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, uint256(999)));
+        adapter.toNativeChainId(999);
+    }
+
+    function test_fromNativeChainId_isExactInverseOfToNativeChainId() public view {
+        assertEq(adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET)), CHAIN_ETH_MAINNET);
+        assertEq(adapter.fromNativeChainId(uint256(SEL_BASE)), CHAIN_BASE);
+        assertEq(adapter.fromNativeChainId(uint256(SEL_ARBITRUM_ONE)), CHAIN_ARBITRUM_ONE);
+    }
+
+    function test_fromNativeChainId_revertsForUnmappedSelector() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_SEPOLIA)));
+        adapter.fromNativeChainId(uint256(SEL_SEPOLIA));
+    }
+
+    function test_chainIdMapping_roundTripsOverSeveralConfiguredChains() public view {
+        uint256[3] memory chains = [CHAIN_ETH_MAINNET, CHAIN_BASE, CHAIN_ARBITRUM_ONE];
+        for (uint256 i = 0; i < chains.length; i++) {
+            assertEq(adapter.fromNativeChainId(adapter.toNativeChainId(chains[i])), chains[i]);
+        }
+    }
+
+    /// @dev A message arriving from a selector that was never mapped to a
+    ///      standard chain id must revert, not be silently treated as
+    ///      originating from chain `0`.
+    function test_ccipReceive_revertsForUnmappedSourceSelector() public {
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_SEPOLIA, remoteAdapter, "");
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_SEPOLIA)));
+        vm.prank(address(router));
+        adapter.ccipReceive(message);
+    }
+
+    function test_setChainSelectors_repointingChainClearsOldReverseMapping() public {
+        _grantAllPermissions();
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = SEL_BASE_SEPOLIA;
+        adapter.setChainSelectors(ids, sels);
+
+        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_BASE_SEPOLIA));
+        assertEq(adapter.fromNativeChainId(uint256(SEL_BASE_SEPOLIA)), CHAIN_ETH_MAINNET);
+
+        // The old selector's reverse entry must be cleared, not left dangling
+        // (which would let a message with the stale selector be misattributed).
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_ETH_MAINNET)));
+        adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET));
+    }
+
+    function test_setChainSelectors_zeroSelectorClearsLaneBothDirections() public {
+        _grantAllPermissions();
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = 0;
+        adapter.setChainSelectors(ids, sels);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, CHAIN_ETH_MAINNET));
+        adapter.toNativeChainId(CHAIN_ETH_MAINNET);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_ETH_MAINNET)));
+        adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET));
+    }
+
+    // =========================================================================
+    // d) `sendMessage` caller / receiver guards
+    // =========================================================================
+
+    function test_sendMessage_revertsIfCallerNotController() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_CROSS_CHAIN_CONTROLLER.selector, alice));
+        vm.prank(alice);
+        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_sendMessage_revertsIfReceiverIsZero() public {
+        vm.expectRevert(Errors.RECEIVER_ADDRESS_ZERO.selector);
+        vm.prank(address(controller));
+        adapter.sendMessage(address(0), 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    // =========================================================================
+    // e) Fees
+    // =========================================================================
+
+    /// @dev Regression test for the missing `forceApprove`: the old adapter
+    ///      never approved the router, so `CCIPRouterMock.ccipSend`'s
+    ///      `transferFrom` pull would revert on zero allowance. This test only
+    ///      passes if the adapter actually approves the router first.
+    function test_sendMessage_erc20Fee_approvesRouterAndRouterPullsExactFee() public {
+        _setFeeToken(address(feeTokenErc20));
+        uint256 feeAmount = 3 ether;
+        router.setFee(feeAmount);
+        feeTokenErc20.setBalance(address(adapter), feeAmount);
+
+        vm.prank(address(controller));
+        bytes32 messageId = adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "hello");
+
+        assertEq(router.ccipSendCallCount(), 1);
+        assertEq(feeTokenErc20.balanceOf(address(router)), feeAmount, "router must have pulled the fee");
+        assertEq(messageId, router.nextMessageId());
+    }
+
+    function test_sendMessage_erc20Fee_leavesZeroStandingAllowanceAfterSend() public {
+        _setFeeToken(address(feeTokenErc20));
+        uint256 feeAmount = 3 ether;
+        router.setFee(feeAmount);
+        feeTokenErc20.setBalance(address(adapter), feeAmount);
+
+        vm.prank(address(controller));
+        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+
+        assertEq(feeTokenErc20.allowance(address(adapter), address(router)), 0);
+    }
+
+    function test_sendMessage_erc20Fee_returnsLeftoverBalanceToController() public {
+        _setFeeToken(address(feeTokenErc20));
+        uint256 feeAmount = 3 ether;
+        uint256 extra = 1 ether;
+        router.setFee(feeAmount);
+        feeTokenErc20.setBalance(address(adapter), feeAmount + extra);
+
+        vm.prank(address(controller));
+        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+
+        assertEq(feeTokenErc20.balanceOf(address(adapter)), 0, "adapter must not retain custody");
+        assertEq(feeTokenErc20.balanceOf(address(controller)), extra, "leftover must return to controller");
+    }
+
+    function test_sendMessage_erc20Fee_revertsIfInsufficientBalance() public {
+        _setFeeToken(address(feeTokenErc20));
+        uint256 feeAmount = 1 ether;
+        uint256 available = 0.4 ether;
+        router.setFee(feeAmount);
+        feeTokenErc20.setBalance(address(adapter), available);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.INSUFFICIENT_FEE_BALANCE.selector,
+                address(feeTokenErc20),
+                feeAmount,
+                available
+            )
+        );
+        vm.prank(address(controller));
+        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_sendMessage_revertsIfNativeValueSentWhileErc20FeeTokenConfigured() public {
+        _setFeeToken(address(feeTokenErc20));
+        vm.deal(address(controller), 1 ether);
+
+        vm.expectRevert(Errors.UNEXPECTED_NATIVE_VALUE.selector);
+        vm.prank(address(controller));
+        adapter.sendMessage{value: 1 ether}(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_sendMessage_nativeFee_paysExactFeeAndReturnsLeftoverToController() public {
+        // Adapter defaults to native (address(0)) fee token from setUp.
+        uint256 feeAmount = 0.05 ether;
+        uint256 extra = 0.01 ether;
+        router.setFee(feeAmount);
+
+        // Simulate a stray pre-existing native balance on the adapter, on top
+        // of the exact fee the controller hands over as `msg.value`.
+        vm.deal(address(adapter), extra);
+        vm.deal(address(controller), feeAmount);
+
+        vm.prank(address(controller));
+        adapter.sendMessage{value: feeAmount}(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+
+        assertEq(router.lastMsgValue(), feeAmount, "router must receive exactly the quoted fee");
+        assertEq(address(adapter).balance, 0, "adapter must not retain custody");
+        assertEq(address(controller).balance, extra, "leftover must return to controller");
+    }
+
+    function test_sendMessage_nativeFee_revertsIfInsufficientBalance() public {
+        uint256 feeAmount = 1 ether;
+        uint256 available = 0.5 ether;
+        router.setFee(feeAmount);
+        vm.deal(address(controller), available);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(0), feeAmount, available)
+        );
+        vm.prank(address(controller));
+        adapter.sendMessage{value: available}(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_quoteFee_revertsIfReceiverIsZero() public {
+        vm.expectRevert(Errors.RECEIVER_ADDRESS_ZERO.selector);
+        adapter.quoteFee(address(0), 200_000, CHAIN_ETH_MAINNET, "");
+    }
+
+    function test_quoteFee_returnsRouterQuoteAndConfiguredFeeToken() public {
+        _setFeeToken(address(feeTokenErc20));
+        router.setFee(7 ether);
+
+        (address feeToken, uint256 fee) = adapter.quoteFee(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+
+        assertEq(feeToken, address(feeTokenErc20));
+        assertEq(fee, 7 ether);
+    }
+
+    // =========================================================================
+    // f) Config setters: permissioned + emit events
+    // =========================================================================
+
+    function test_setFeeToken_revertsIfUnauthorized() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(adapter),
+                alice,
+                adapter.UPDATE_ADAPTER_CONFIG_PERMISSION_ID()
+            )
+        );
+        vm.prank(alice);
+        adapter.setFeeToken(address(feeTokenErc20));
+    }
+
+    function test_setFeeToken_emitsEventAndUpdatesStorage() public {
+        _grantAllPermissions();
+
+        vm.expectEmit(true, true, true, true, address(adapter));
+        emit FeeTokenSet(address(feeTokenErc20));
+        adapter.setFeeToken(address(feeTokenErc20));
+
+        assertEq(adapter.feeToken(), address(feeTokenErc20));
+    }
+
+    function test_setChainSelectors_revertsIfUnauthorized() public {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_SEPOLIA;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = SEL_SEPOLIA;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(adapter),
+                alice,
+                adapter.UPDATE_ADAPTER_CONFIG_PERMISSION_ID()
+            )
+        );
+        vm.prank(alice);
+        adapter.setChainSelectors(ids, sels);
+    }
+
+    function test_setChainSelectors_emitsEventAndUpdatesStorage() public {
+        _grantAllPermissions();
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_SEPOLIA;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = SEL_SEPOLIA;
+
+        vm.expectEmit(true, true, true, true, address(adapter));
+        emit ChainSelectorSet(CHAIN_SEPOLIA, SEL_SEPOLIA);
+        adapter.setChainSelectors(ids, sels);
+
+        assertEq(adapter.toNativeChainId(CHAIN_SEPOLIA), uint256(SEL_SEPOLIA));
+    }
+
+    function test_setTrustedRemotes_revertsIfUnauthorized() public {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        address[] memory remotes = new address[](1);
+        remotes[0] = makeAddr("newRemote");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(adapter),
+                alice,
+                adapter.UPDATE_ADAPTER_CONFIG_PERMISSION_ID()
+            )
+        );
+        vm.prank(alice);
+        adapter.setTrustedRemotes(ids, remotes);
+    }
+
+    function test_setTrustedRemotes_emitsEventAndUpdatesStorage() public {
+        _grantAllPermissions();
+
+        address newRemote = makeAddr("newRemote");
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        address[] memory remotes = new address[](1);
+        remotes[0] = newRemote;
+
+        vm.expectEmit(true, true, true, true, address(adapter));
+        emit TrustedRemoteSet(CHAIN_ETH_MAINNET, newRemote);
+        adapter.setTrustedRemotes(ids, remotes);
+
+        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), newRemote);
+    }
+
+    function test_trustedRemote_returnsZeroForUnsetChain() public view {
+        assertEq(adapter.trustedRemote(CHAIN_BASE), address(0));
+    }
+
+    // =========================================================================
+    // g) `assertTrustedRemotesMatchController`
+    // =========================================================================
+
+    function test_assertTrustedRemotesMatchController_passesWhenBothSidesAgree() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        adapter.assertTrustedRemotesMatchController(ids); // must not revert
+    }
+
+    function test_assertTrustedRemotesMatchController_revertsWhenMismatched() public {
+        address controllerConfiguredRemote = makeAddr("controllerConfiguredRemote");
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), controllerConfiguredRemote);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.TRUSTED_REMOTE_MISMATCH.selector,
+                CHAIN_ETH_MAINNET,
+                remoteAdapter,
+                controllerConfiguredRemote
+            )
+        );
+        adapter.assertTrustedRemotesMatchController(ids);
+    }
+
+    function test_assertTrustedRemotesMatchController_revertsWhenControllerLaneUnconfigured() public {
+        // No `updateConfig` call: the controller's `remoteAdapter` for this
+        // chain stays `address(0)` while the adapter already trusts `remoteAdapter`.
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.TRUSTED_REMOTE_MISMATCH.selector, CHAIN_ETH_MAINNET, remoteAdapter, address(0))
+        );
+        adapter.assertTrustedRemotesMatchController(ids);
+    }
+
+    // =========================================================================
+    // h) ERC-165
+    // =========================================================================
+
+    function test_supportsInterface_IAny2EVMMessageReceiver() public view {
+        assertTrue(adapter.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId));
+    }
+
+    function test_supportsInterface_IERC165() public view {
+        assertTrue(adapter.supportsInterface(type(IERC165).interfaceId));
+    }
+
+    function test_supportsInterface_returnsFalseForUnknownInterface() public view {
+        assertFalse(adapter.supportsInterface(0xdeadbeef));
+    }
+
+    // =========================================================================
+    // i) End-to-end-ish: controller.forwardMessage -> adapter.sendMessage -> router
+    // =========================================================================
+
+    function test_forwardMessage_endToEnd_routesThroughAdapterToRouter() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
+
+        uint256 feeAmount = 0.02 ether;
+        router.setFee(feeAmount);
+        vm.deal(address(controller), feeAmount);
+
+        bytes32 expectedMessageId = keccak256("expected-message-id");
+        router.setNextMessageId(expectedMessageId);
+
+        Action[] memory actions = new Action[](0);
+        bytes memory payload = abi.encode(actions);
+        uint256 gasLimit = 300_000;
+
+        bytes32 messageId = controller.forwardMessage(CHAIN_ETH_MAINNET, gasLimit, payload);
+
+        assertEq(messageId, expectedMessageId, "controller must surface the router's messageId");
+
+        address decodedReceiver = abi.decode(router.lastReceiver(), (address));
+        assertEq(decodedReceiver, remoteAdapter, "router must target the remote adapter");
+        assertEq(router.lastData(), payload);
+        assertEq(router.lastFeeToken(), address(0));
+        assertEq(router.lastDestChainSelector(), SEL_ETH_MAINNET);
+        assertEq(router.lastMsgValue(), feeAmount);
+
+        bytes memory expectedExtraArgs = Client._argsToBytes(
+            Client.GenericExtraArgsV2({gasLimit: gasLimit, allowOutOfOrderExecution: true})
+        );
+        assertEq(router.lastExtraArgs(), expectedExtraArgs, "extraArgs must encode the requested gas limit");
+    }
+
+    // =========================================================================
+    // Constructor validation (bonus coverage)
+    // =========================================================================
+
+    function test_constructor_revertsIfRouterIsZeroAddress() public {
+        uint256[] memory empty;
+        address[] memory emptyAddr;
+
+        vm.expectRevert(Errors.ZERO_ADDRESS.selector);
+        new CCIPAdapter(address(controller), address(0), address(0), empty, emptyAddr, empty, new uint64[](0));
+    }
+
+    function test_constructor_revertsOnTrustedRemoteLengthMismatch() public {
+        uint256[] memory chainIds = new uint256[](2);
+        chainIds[0] = CHAIN_ETH_MAINNET;
+        chainIds[1] = CHAIN_BASE;
+        address[] memory remotes = new address[](1);
+        remotes[0] = remoteAdapter;
+
+        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
+        new CCIPAdapter(
+            address(controller),
+            address(router),
+            address(0),
+            chainIds,
+            remotes,
+            new uint256[](0),
+            new uint64[](0)
+        );
+    }
+
+    function test_constructor_revertsOnSelectorLengthMismatch() public {
+        uint256[] memory selChainIds = new uint256[](2);
+        selChainIds[0] = CHAIN_ETH_MAINNET;
+        selChainIds[1] = CHAIN_BASE;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = SEL_ETH_MAINNET;
+
+        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
+        new CCIPAdapter(
+            address(controller),
+            address(router),
+            address(0),
+            new uint256[](0),
+            new address[](0),
+            selChainIds,
+            sels
+        );
+    }
+
+    function test_constructor_wiresUpConfiguredTrustedRemoteAndSelector() public view {
+        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), remoteAdapter);
+        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_ETH_MAINNET));
+    }
+}

--- a/test/common/crosschain/CCIPAdapter.t.sol
+++ b/test/common/crosschain/CCIPAdapter.t.sol
@@ -12,38 +12,62 @@ import {
 import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
 
 import {CCIPAdapter} from "../../../src/common/crosschain/adapters/CCIP/CCIPAdapter.sol";
+import {IBaseAdapter} from "../../../src/common/crosschain/adapters/IBaseAdapter.sol";
 import {CrossChainController} from "../../../src/common/crosschain/CrossChainController.sol";
 import {Errors} from "../../../src/common/crosschain/lib/Errors.sol";
 import {DaoUnauthorized} from "../../../src/common/permission/auth/auth.sol";
 import {Action} from "../../../src/common/executors/IExecutor.sol";
+import {IDAO} from "../../../src/common/dao/IDAO.sol";
 
 import {DAOMock} from "../../mocks/commons/dao/DAOMock.sol";
 import {ERC20Mock} from "../../mocks/commons/token/ERC20Mock.sol";
 import {CCIPRouterMock} from "../../mocks/commons/crosschain/CCIPRouterMock.sol";
+import {DelegateCallerMock} from "../../mocks/commons/crosschain/DelegateCallerMock.sol";
 
 /// @notice Regression suite for `CCIPAdapter` (`src/common/crosschain/adapters/CCIP/CCIPAdapter.sol`)
-///         written against the just-hardened cross-chain adapter code.
+///         written against "Option 1": SEND is now a `delegatecall` from
+///         `CrossChainController.forwardMessage` into the local adapter, while
+///         RECEIVE stays a normal call from the CCIP Router into the adapter.
 ///
-/// Setup mirrors production wiring: a `DAOMock` owns a real `CrossChainController`,
-/// and the `CCIPAdapter` adopts that controller's DAO in its constructor
-/// (`BaseAdapter` -> `DaoAuthorizable`). The controller invokes the adapter with a
-/// plain `call`, so CCIP sees the ADAPTER as the message sender on the remote
-/// chain — `_trustedRemotes[chainId]` therefore holds the REMOTE ADAPTER address,
-/// which is exactly what `CrossChainController.chainToAdapter[chainId].remoteAdapter`
-/// stores for the local->remote lane.
+/// TWO DIFFERENT KINDS OF "REMOTE" ADDRESS APPEAR THROUGHOUT THIS FILE. Naming
+/// is deliberately verbose to keep them apart:
+///   - `remoteController` -- the remote chain's `CrossChainController`. Because
+///     the local send is a `delegatecall`, the account CCIP sees calling
+///     `ccipSend` on the source chain is the source CONTROLLER, so THIS is what
+///     `_trustedRemotes[chainId]` must hold on the receiving adapter.
+///   - `remoteAdapter` -- the remote chain's `CCIPAdapter`, i.e. the bridge-level
+///     RECEIVER. This is what `CrossChainController.chainToAdapter[chainId].remoteAdapter`
+///     stores locally, as the destination `ccipSend` targets.
+///   Confusing the two -- trusting the remote ADAPTER instead of the remote
+///   CONTROLLER -- is a silent, total loss of inbound liveness, and is
+///   explicitly exercised below (`assertTrustedRemotesMatchControllers`,
+///   `TRUSTED_REMOTE_IS_REMOTE_ADAPTER`, and the plain `ccipReceive` misconfig
+///   test).
 ///
-/// Coverage locks in the security-review regressions:
-///  a) `_forwardMessage` is not externally callable (was `public` pre-hardening).
+/// Setup mirrors production wiring: a `DAOMock` owns a real
+/// `CrossChainController`, and every `CCIPAdapter` adopts that controller's DAO
+/// in its constructor (`BaseAdapter` -> `DaoAuthorizable`).
+///
+/// Coverage:
+///  a) `_forwardMessage` is not externally callable.
 ///  b) `ccipReceive` caller / trusted-remote checks and the success path.
-///  c) chain-id <-> CCIP-selector mapping now reverts instead of silently
-///     mapping to chain `0`.
-///  d) `sendMessage` caller / receiver guards.
-///  e) fee handling: ERC20 fee approval (the missing-`forceApprove` bug),
-///     leftover-return, and native/ERC20 edge cases.
-///  f) config setters are permissioned and emit events.
-///  g) `assertTrustedRemotesMatchController` deployment sanity check.
+///  c) chain-id <-> CCIP-selector mapping, incl. re-pointing and clearing.
+///  d) `sendMessage` can ONLY be reached via `delegatecall` from the
+///     controller -- never directly, not even by the controller itself via a
+///     plain `call`.
+///  e) fee handling: the CONTROLLER pays and never hands custody to the
+///     adapter, for both native and ERC20 fees.
+///  f) config setters (receive-side only) are permissioned and emit events.
+///  g) `assertTrustedRemotesMatchControllers` / `assertChainSelectorsMatchController`
+///     deployment-time consistency helpers.
 ///  h) ERC-165 `supportsInterface`.
 ///  i) an end-to-end send through `CrossChainController.forwardMessage`.
+///  j) constructor validation.
+///  k) NEW, and the actual point of this redesign: immutables surviving
+///     `delegatecall`, no storage collision with the controller, the fee
+///     payer being the controller and not the adapter, and the operational
+///     consequences of the send/receive config living in two places
+///     (desync, and the fee-token-is-immutable trade-off).
 contract CCIPAdapterTest is Test {
     // -------------------------------------------------------------------------
     // Real CCIP chain selectors / standard chain ids used throughout.
@@ -60,9 +84,10 @@ contract CCIPAdapterTest is Test {
     uint256 internal constant CHAIN_SEPOLIA = 11155111;
 
     // -------------------------------------------------------------------------
-    // Events re-declared locally so `vm.expectEmit` can match by signature.
+    // Events re-declared locally so `vm.expectEmit` can match by signature
+    // (solc 0.8.17 cannot `emit Contract.Event(...)` for externally-defined
+    // events). `FeeTokenSet` is GONE: there is no setter any more.
     // -------------------------------------------------------------------------
-    event FeeTokenSet(address feeToken);
     event ChainSelectorSet(uint256 indexed chainId, uint64 chainSelector);
     event TrustedRemoteSet(uint256 indexed chainId, address trustedRemote);
     event MessageReceived(uint256 indexed originChainId, bytes32 indexed messageId, bytes32 indexed callId);
@@ -71,14 +96,34 @@ contract CCIPAdapterTest is Test {
     CrossChainController internal controller;
     CCIPRouterMock internal router;
     ERC20Mock internal feeTokenErc20;
+
+    /// @dev Default adapter from `setUp`: native (`address(0)`) fee token.
     CCIPAdapter internal adapter;
+    /// @dev A second adapter sharing `router`, but with `FEE_TOKEN = feeTokenErc20`.
+    ///      `FEE_TOKEN` is immutable, so an ERC20-fee lane needs its own adapter
+    ///      instance -- there is no setter to flip `adapter` itself over.
+    CCIPAdapter internal erc20Adapter;
+
+    /// @dev Drives the two guard-isolation tests that the real controller
+    ///      cannot reach (see `DelegateCallerMock`'s own docs).
+    DelegateCallerMock internal delegateCallerMock;
+    /// @dev An adapter whose `CROSS_CHAIN_CONTROLLER` is `delegateCallerMock`,
+    ///      used only by those isolation tests.
+    CCIPAdapter internal isolationAdapter;
 
     address internal alice;
-    /// @dev The remote-chain ADAPTER address trusted for `CHAIN_ETH_MAINNET`.
+    /// @dev The remote chain's CONTROLLER -- the address CCIP reports as the
+    ///      message sender on receive, because the source-chain send is a
+    ///      `delegatecall`. This is what `_trustedRemotes[chainId]` holds.
+    address internal remoteController;
+    /// @dev The remote chain's ADAPTER -- the bridge-level receiver, i.e. what
+    ///      `CrossChainController.chainToAdapter[chainId].remoteAdapter` holds.
+    ///      NEVER a valid value for `_trustedRemotes`.
     address internal remoteAdapter;
 
     function setUp() public {
         alice = makeAddr("alice");
+        remoteController = makeAddr("remoteController");
         remoteAdapter = makeAddr("remoteAdapter");
 
         daoMock = new DAOMock();
@@ -88,8 +133,8 @@ contract CCIPAdapterTest is Test {
 
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = CHAIN_ETH_MAINNET;
-        address[] memory trustedRemotes = new address[](1);
-        trustedRemotes[0] = remoteAdapter;
+        address[] memory trustedRemoteControllers = new address[](1);
+        trustedRemoteControllers[0] = remoteController;
 
         uint256[] memory selChainIds = new uint256[](3);
         selChainIds[0] = CHAIN_ETH_MAINNET;
@@ -103,11 +148,32 @@ contract CCIPAdapterTest is Test {
         adapter = new CCIPAdapter(
             address(controller),
             address(router),
-            address(0), // native fee token by default
+            address(0), // native fee token
             chainIds,
-            trustedRemotes,
+            trustedRemoteControllers,
             selChainIds,
             selectors
+        );
+
+        erc20Adapter = new CCIPAdapter(
+            address(controller),
+            address(router),
+            address(feeTokenErc20),
+            new uint256[](0),
+            new address[](0),
+            new uint256[](0),
+            new uint64[](0)
+        );
+
+        delegateCallerMock = new DelegateCallerMock(IDAO(address(daoMock)));
+        isolationAdapter = new CCIPAdapter(
+            address(delegateCallerMock),
+            address(router),
+            address(feeTokenErc20),
+            new uint256[](0),
+            new address[](0),
+            new uint256[](0),
+            new uint64[](0)
         );
     }
 
@@ -121,21 +187,34 @@ contract CCIPAdapterTest is Test {
         daoMock.setHasPermissionReturnValueMock(true);
     }
 
-    function _setFeeToken(address token) internal {
-        _grantAllPermissions();
-        adapter.setFeeToken(token);
-    }
-
-    /// @dev Registers `localAdapter`/`remote` as the controller's adapter pair
-    ///      for `chainId`, granting the adapter the right to call
-    ///      `receiveMessage` and enabling `forwardMessage`/`quoteFee` for it.
-    function _registerLane(uint256 chainId, address localAdapter, address remote) internal {
+    /// @dev Registers `localAdapter`/`remoteAdapterAddr` as the controller's
+    ///      lane for `chainId`, with `bridgeChainId` as the CCIP selector to
+    ///      send to. Grants `UPDATE_CONFIG_PERMISSION` in the process.
+    function _registerLane(
+        uint256 chainId,
+        address localAdapter,
+        address remoteAdapterAddr,
+        uint64 bridgeChainId
+    ) internal {
         _grantAllPermissions();
         uint256[] memory ids = new uint256[](1);
         ids[0] = chainId;
-        CrossChainController.AdapterByChain[] memory pairs = new CrossChainController.AdapterByChain[](1);
-        pairs[0] = CrossChainController.AdapterByChain({localAdapter: localAdapter, remoteAdapter: remote});
-        controller.updateConfig(ids, pairs);
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = CrossChainController.ChainConfig({
+            localAdapter: localAdapter,
+            remoteAdapter: remoteAdapterAddr,
+            bridgeChainId: bridgeChainId
+        });
+        controller.updateConfig(ids, configs);
+    }
+
+    /// @dev Clears a previously-registered lane (all-zero config).
+    function _clearLane(uint256 chainId) internal {
+        _grantAllPermissions();
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = chainId;
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        controller.updateConfig(ids, configs);
     }
 
     function _buildInbound(
@@ -153,28 +232,21 @@ contract CCIPAdapterTest is Test {
             });
     }
 
+    function _emptyActionsPayload() internal pure returns (bytes memory) {
+        return abi.encode(new Action[](0));
+    }
+
     // =========================================================================
     // a) `_forwardMessage` must not be externally callable.
     // =========================================================================
 
-    /// @dev The pre-hardening code had `_forwardMessage` `public`, letting
-    ///      anyone inject an arbitrary payload/origin chain straight into the
-    ///      controller's `receiveMessage`, bypassing both the `onlyRouter`
-    ///      check and the trusted-remote check in `ccipReceive`. It is now
-    ///      `internal` on `BaseAdapter`; `adapter._forwardMessage(...)` does
-    ///      not even compile from outside the contract, and there is no
-    ///      selector for it in the adapter's ABI. This test proves the
-    ///      low-level fallback path is closed too: a raw call with the old
-    ///      function's signature does not reach any code (the adapter has no
-    ///      fallback function), so it must simply fail.
+    /// @dev `_forwardMessage` is `internal` on `BaseAdapter`, reachable only
+    ///      after `ccipReceive`'s `onlyRouter` and trusted-remote checks. A raw
+    ///      call with the old signature must simply fail: the adapter has no
+    ///      fallback, so there is no selector for it to hit.
     function test_forwardMessage_isNotExternallyCallable() public {
         (bool success, bytes memory returndata) = address(adapter).call(
-            abi.encodeWithSignature(
-                "_forwardMessage(bytes32,bytes,uint256)",
-                bytes32(0),
-                bytes(""),
-                CHAIN_ETH_MAINNET
-            )
+            abi.encodeWithSignature("_forwardMessage(bytes32,bytes,uint256)", bytes32(0), bytes(""), CHAIN_ETH_MAINNET)
         );
 
         assertFalse(success, "_forwardMessage must not be externally callable");
@@ -186,7 +258,7 @@ contract CCIPAdapterTest is Test {
     // =========================================================================
 
     function test_ccipReceive_revertsIfCallerNotRouter() public {
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteAdapter, "");
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteController, "");
 
         vm.expectRevert(Errors.CALLER_NOT_CCIP_ROUTER.selector);
         vm.prank(alice);
@@ -201,7 +273,7 @@ contract CCIPAdapterTest is Test {
         adapter.ccipReceive(message);
     }
 
-    function test_ccipReceive_revertsIfSenderNotConfiguredTrustedRemote() public {
+    function test_ccipReceive_revertsIfSenderIsAnArbitraryUntrustedAddress() public {
         address untrusted = makeAddr("untrusted");
         Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, untrusted, "");
 
@@ -210,14 +282,27 @@ contract CCIPAdapterTest is Test {
         adapter.ccipReceive(message);
     }
 
-    function test_ccipReceive_succeedsForTrustedRemoteAndForwardsToController() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
+    /// @dev THE canonical misconfiguration this redesign invites: pointing
+    ///      `ccipReceive` at the remote ADAPTER instead of the remote
+    ///      CONTROLLER. `remoteAdapter` is a real, meaningful address in this
+    ///      suite's config (it's what `chainToAdapter[].remoteAdapter` holds),
+    ///      but it must NEVER be a valid `_trustedRemotes` entry.
+    function test_ccipReceive_revertsIfSenderIsRemoteAdapterInsteadOfRemoteController() public {
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteAdapter, "");
 
-        Action[] memory actions = new Action[](0);
-        bytes memory payload = abi.encode(actions);
+        vm.expectRevert(Errors.REMOTE_NOT_TRUSTED.selector);
+        vm.prank(address(router));
+        adapter.ccipReceive(message);
+    }
+
+    /// @dev The success path: sender IS the remote CONTROLLER.
+    function test_ccipReceive_succeedsWhenSenderIsRemoteControllerAndForwardsToController() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+
+        bytes memory payload = _emptyActionsPayload();
         bytes32 messageId = keccak256("msg-1");
 
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteAdapter, payload);
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, remoteController, payload);
         message.messageId = messageId;
 
         bytes32 expectedCallId = controller.deriveCallId(CHAIN_ETH_MAINNET, messageId);
@@ -260,11 +345,10 @@ contract CCIPAdapterTest is Test {
         }
     }
 
-    /// @dev A message arriving from a selector that was never mapped to a
-    ///      standard chain id must revert, not be silently treated as
-    ///      originating from chain `0`.
+    /// @dev A message arriving from a selector never mapped to a standard
+    ///      chain id must revert, not be silently treated as chain `0`.
     function test_ccipReceive_revertsForUnmappedSourceSelector() public {
-        Client.Any2EVMMessage memory message = _buildInbound(SEL_SEPOLIA, remoteAdapter, "");
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_SEPOLIA, remoteController, "");
 
         vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_SEPOLIA)));
         vm.prank(address(router));
@@ -283,8 +367,7 @@ contract CCIPAdapterTest is Test {
         assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_BASE_SEPOLIA));
         assertEq(adapter.fromNativeChainId(uint256(SEL_BASE_SEPOLIA)), CHAIN_ETH_MAINNET);
 
-        // The old selector's reverse entry must be cleared, not left dangling
-        // (which would let a message with the stale selector be misattributed).
+        // The old selector's reverse entry must be cleared, not left dangling.
         vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_NATIVE_CHAIN_ID.selector, uint256(SEL_ETH_MAINNET)));
         adapter.fromNativeChainId(uint256(SEL_ETH_MAINNET));
     }
@@ -306,117 +389,109 @@ contract CCIPAdapterTest is Test {
     }
 
     // =========================================================================
-    // d) `sendMessage` caller / receiver guards
+    // d) `sendMessage` can ONLY be reached via `delegatecall` from the controller
     // =========================================================================
 
-    function test_sendMessage_revertsIfCallerNotController() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_CROSS_CHAIN_CONTROLLER.selector, alice));
-        vm.prank(alice);
-        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
-    }
-
-    function test_sendMessage_revertsIfReceiverIsZero() public {
-        vm.expectRevert(Errors.RECEIVER_ADDRESS_ZERO.selector);
+    /// @dev THE core guard of the redesign. `onlyDelegatecallFromController`
+    ///      checks `address(this) == CROSS_CHAIN_CONTROLLER`, NOT `msg.sender`
+    ///      -- so `vm.prank(address(controller))` does nothing here; a direct
+    ///      call to the adapter always has `address(this) == address(adapter)`.
+    ///      This matters because a direct call would (a) spend the ADAPTER's
+    ///      own (normally empty) balance instead of the controller's, and
+    ///      (b) make CCIP attribute the message to the adapter, which the far
+    ///      side's `_trustedRemotes` does not trust (it trusts the
+    ///      controller). Both failure modes are silent/expensive rather than
+    ///      loud, so this must revert instead of degrading gracefully.
+    function test_sendMessage_revertsIfCalledDirectly_evenWhenCallerIsTheController() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.SEND_PATH_NOT_DELEGATECALLED.selector, address(adapter)));
         vm.prank(address(controller));
-        adapter.sendMessage(address(0), 200_000, CHAIN_ETH_MAINNET, "");
+        adapter.sendMessage(remoteAdapter, SEL_ETH_MAINNET, 200_000, "");
+    }
+
+    function test_sendMessage_revertsIfCalledDirectlyByAnybody() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.SEND_PATH_NOT_DELEGATECALLED.selector, address(adapter)));
+        vm.prank(alice);
+        adapter.sendMessage(remoteAdapter, SEL_ETH_MAINNET, 200_000, "");
+    }
+
+    /// @dev `RECEIVER_ADDRESS_ZERO` sits BEHIND `onlyDelegatecallFromController`.
+    ///      The only production caller of `sendMessage`,
+    ///      `CrossChainController.forwardMessage`, already refuses to
+    ///      delegatecall with a zero receiver (`_validatedConfig` requires
+    ///      `remoteAdapter != address(0)`), so this specific branch is dead
+    ///      code from that entry point today. `isolationAdapter` +
+    ///      `delegateCallerMock` reproduce the `address(this) ==
+    ///      CROSS_CHAIN_CONTROLLER` context directly, so the check itself is
+    ///      still proven to work correctly in isolation.
+    function test_sendMessage_isolated_revertsIfReceiverIsZero() public {
+        bytes memory data = abi.encodeCall(IBaseAdapter.sendMessage, (address(0), SEL_ETH_MAINNET, 200_000, bytes("")));
+
+        vm.expectRevert(Errors.RECEIVER_ADDRESS_ZERO.selector);
+        delegateCallerMock.delegateCall(address(isolationAdapter), data);
     }
 
     // =========================================================================
-    // e) Fees
+    // e) Fees -- the controller pays, the adapter never holds funds
     // =========================================================================
 
-    /// @dev Regression test for the missing `forceApprove`: the old adapter
-    ///      never approved the router, so `CCIPRouterMock.ccipSend`'s
-    ///      `transferFrom` pull would revert on zero allowance. This test only
-    ///      passes if the adapter actually approves the router first.
+    /// @dev Regression test for the missing `forceApprove`: a naive adapter
+    ///      that never approves the router would make `CCIPRouterMock`'s
+    ///      `transferFrom` pull revert on zero allowance. This only passes if
+    ///      the approval is actually made -- and, since the send is a
+    ///      `delegatecall`, made on the CONTROLLER's allowance, which is what
+    ///      the router pulls from.
     function test_sendMessage_erc20Fee_approvesRouterAndRouterPullsExactFee() public {
-        _setFeeToken(address(feeTokenErc20));
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
         uint256 feeAmount = 3 ether;
         router.setFee(feeAmount);
-        feeTokenErc20.setBalance(address(adapter), feeAmount);
+        feeTokenErc20.setBalance(address(controller), feeAmount);
 
-        vm.prank(address(controller));
-        bytes32 messageId = adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "hello");
+        bytes32 messageId = controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "hello");
 
         assertEq(router.ccipSendCallCount(), 1);
         assertEq(feeTokenErc20.balanceOf(address(router)), feeAmount, "router must have pulled the fee");
         assertEq(messageId, router.nextMessageId());
     }
 
-    function test_sendMessage_erc20Fee_leavesZeroStandingAllowanceAfterSend() public {
-        _setFeeToken(address(feeTokenErc20));
+    function test_sendMessage_erc20Fee_leavesZeroStandingAllowanceOnControllerAfterSend() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
         uint256 feeAmount = 3 ether;
         router.setFee(feeAmount);
-        feeTokenErc20.setBalance(address(adapter), feeAmount);
+        feeTokenErc20.setBalance(address(controller), feeAmount);
 
-        vm.prank(address(controller));
-        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
 
-        assertEq(feeTokenErc20.allowance(address(adapter), address(router)), 0);
+        assertEq(feeTokenErc20.allowance(address(controller), address(router)), 0);
     }
 
-    function test_sendMessage_erc20Fee_returnsLeftoverBalanceToController() public {
-        _setFeeToken(address(feeTokenErc20));
-        uint256 feeAmount = 3 ether;
-        uint256 extra = 1 ether;
-        router.setFee(feeAmount);
-        feeTokenErc20.setBalance(address(adapter), feeAmount + extra);
-
-        vm.prank(address(controller));
-        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
-
-        assertEq(feeTokenErc20.balanceOf(address(adapter)), 0, "adapter must not retain custody");
-        assertEq(feeTokenErc20.balanceOf(address(controller)), extra, "leftover must return to controller");
-    }
-
-    function test_sendMessage_erc20Fee_revertsIfInsufficientBalance() public {
-        _setFeeToken(address(feeTokenErc20));
+    function test_sendMessage_erc20Fee_revertsIfControllerBalanceInsufficient() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
         uint256 feeAmount = 1 ether;
         uint256 available = 0.4 ether;
         router.setFee(feeAmount);
-        feeTokenErc20.setBalance(address(adapter), available);
+        feeTokenErc20.setBalance(address(controller), available);
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.INSUFFICIENT_FEE_BALANCE.selector,
-                address(feeTokenErc20),
-                feeAmount,
-                available
-            )
+            abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(feeTokenErc20), feeAmount, available)
         );
-        vm.prank(address(controller));
-        adapter.sendMessage(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
     }
 
-    function test_sendMessage_revertsIfNativeValueSentWhileErc20FeeTokenConfigured() public {
-        _setFeeToken(address(feeTokenErc20));
-        vm.deal(address(controller), 1 ether);
-
-        vm.expectRevert(Errors.UNEXPECTED_NATIVE_VALUE.selector);
-        vm.prank(address(controller));
-        adapter.sendMessage{value: 1 ether}(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
-    }
-
-    function test_sendMessage_nativeFee_paysExactFeeAndReturnsLeftoverToController() public {
-        // Adapter defaults to native (address(0)) fee token from setUp.
+    function test_sendMessage_nativeFee_paysExactFeeFromControllerBalance() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
         uint256 feeAmount = 0.05 ether;
-        uint256 extra = 0.01 ether;
         router.setFee(feeAmount);
-
-        // Simulate a stray pre-existing native balance on the adapter, on top
-        // of the exact fee the controller hands over as `msg.value`.
-        vm.deal(address(adapter), extra);
         vm.deal(address(controller), feeAmount);
 
-        vm.prank(address(controller));
-        adapter.sendMessage{value: feeAmount}(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
 
         assertEq(router.lastMsgValue(), feeAmount, "router must receive exactly the quoted fee");
-        assertEq(address(adapter).balance, 0, "adapter must not retain custody");
-        assertEq(address(controller).balance, extra, "leftover must return to controller");
+        assertEq(address(controller).balance, 0);
+        assertEq(address(adapter).balance, 0, "adapter must never hold native funds");
     }
 
-    function test_sendMessage_nativeFee_revertsIfInsufficientBalance() public {
+    function test_sendMessage_nativeFee_revertsIfControllerBalanceInsufficient() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
         uint256 feeAmount = 1 ether;
         uint256 available = 0.5 ether;
         router.setFee(feeAmount);
@@ -425,52 +500,48 @@ contract CCIPAdapterTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(0), feeAmount, available)
         );
-        vm.prank(address(controller));
-        adapter.sendMessage{value: available}(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
+    }
+
+    /// @dev `UNEXPECTED_NATIVE_VALUE` guards against native value being
+    ///      stranded while an ERC20 fee is due. Like `RECEIVER_ADDRESS_ZERO`
+    ///      above, it is unreachable through the real controller today,
+    ///      because `forwardMessage` is not `payable`: `msg.value` inside the
+    ///      delegatecalled `sendMessage` is always whatever `forwardMessage`'s
+    ///      own call frame had, which can only be `0`. Exercised in isolation.
+    function test_sendMessage_isolated_revertsIfNativeValueSentWhileErc20FeeTokenConfigured() public {
+        bytes memory data = abi.encodeCall(
+            IBaseAdapter.sendMessage,
+            (remoteAdapter, SEL_ETH_MAINNET, 200_000, bytes(""))
+        );
+
+        vm.expectRevert(Errors.UNEXPECTED_NATIVE_VALUE.selector);
+        delegateCallerMock.delegateCall{value: 1 ether}(address(isolationAdapter), data);
     }
 
     function test_quoteFee_revertsIfReceiverIsZero() public {
         vm.expectRevert(Errors.RECEIVER_ADDRESS_ZERO.selector);
-        adapter.quoteFee(address(0), 200_000, CHAIN_ETH_MAINNET, "");
+        adapter.quoteFee(address(0), SEL_ETH_MAINNET, 200_000, "");
+    }
+
+    function test_quoteFee_revertsIfBridgeChainIdIsZero() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, uint256(0)));
+        adapter.quoteFee(remoteAdapter, 0, 200_000, "");
     }
 
     function test_quoteFee_returnsRouterQuoteAndConfiguredFeeToken() public {
-        _setFeeToken(address(feeTokenErc20));
         router.setFee(7 ether);
 
-        (address feeToken, uint256 fee) = adapter.quoteFee(remoteAdapter, 200_000, CHAIN_ETH_MAINNET, "");
+        (address feeToken, uint256 fee) = erc20Adapter.quoteFee(remoteAdapter, SEL_ETH_MAINNET, 200_000, "");
 
         assertEq(feeToken, address(feeTokenErc20));
         assertEq(fee, 7 ether);
     }
 
     // =========================================================================
-    // f) Config setters: permissioned + emit events
+    // f) Config setters (receive-side only): permissioned + emit events.
+    //    NOTE: `setFeeToken` is GONE -- see the fee-token-immutability section.
     // =========================================================================
-
-    function test_setFeeToken_revertsIfUnauthorized() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DaoUnauthorized.selector,
-                address(daoMock),
-                address(adapter),
-                alice,
-                adapter.UPDATE_ADAPTER_CONFIG_PERMISSION_ID()
-            )
-        );
-        vm.prank(alice);
-        adapter.setFeeToken(address(feeTokenErc20));
-    }
-
-    function test_setFeeToken_emitsEventAndUpdatesStorage() public {
-        _grantAllPermissions();
-
-        vm.expectEmit(true, true, true, true, address(adapter));
-        emit FeeTokenSet(address(feeTokenErc20));
-        adapter.setFeeToken(address(feeTokenErc20));
-
-        assertEq(adapter.feeToken(), address(feeTokenErc20));
-    }
 
     function test_setChainSelectors_revertsIfUnauthorized() public {
         uint256[] memory ids = new uint256[](1);
@@ -510,7 +581,7 @@ contract CCIPAdapterTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = CHAIN_ETH_MAINNET;
         address[] memory remotes = new address[](1);
-        remotes[0] = makeAddr("newRemote");
+        remotes[0] = makeAddr("newRemoteController");
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -528,17 +599,17 @@ contract CCIPAdapterTest is Test {
     function test_setTrustedRemotes_emitsEventAndUpdatesStorage() public {
         _grantAllPermissions();
 
-        address newRemote = makeAddr("newRemote");
+        address newRemoteController = makeAddr("newRemoteController");
         uint256[] memory ids = new uint256[](1);
         ids[0] = CHAIN_ETH_MAINNET;
         address[] memory remotes = new address[](1);
-        remotes[0] = newRemote;
+        remotes[0] = newRemoteController;
 
         vm.expectEmit(true, true, true, true, address(adapter));
-        emit TrustedRemoteSet(CHAIN_ETH_MAINNET, newRemote);
+        emit TrustedRemoteSet(CHAIN_ETH_MAINNET, newRemoteController);
         adapter.setTrustedRemotes(ids, remotes);
 
-        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), newRemote);
+        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), newRemoteController);
     }
 
     function test_trustedRemote_returnsZeroForUnsetChain() public view {
@@ -546,45 +617,172 @@ contract CCIPAdapterTest is Test {
     }
 
     // =========================================================================
-    // g) `assertTrustedRemotesMatchController`
+    // g.1) `assertTrustedRemotesMatchControllers`
     // =========================================================================
 
-    function test_assertTrustedRemotesMatchController_passesWhenBothSidesAgree() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
+    function test_assertTrustedRemotesMatchControllers_passesWhenTrustedRemoteMatchesExpectedController() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
 
         uint256[] memory ids = new uint256[](1);
         ids[0] = CHAIN_ETH_MAINNET;
-        adapter.assertTrustedRemotesMatchController(ids); // must not revert
+        address[] memory expected = new address[](1);
+        expected[0] = remoteController;
+
+        adapter.assertTrustedRemotesMatchControllers(ids, expected); // must not revert
     }
 
-    function test_assertTrustedRemotesMatchController_revertsWhenMismatched() public {
-        address controllerConfiguredRemote = makeAddr("controllerConfiguredRemote");
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), controllerConfiguredRemote);
+    function test_assertTrustedRemotesMatchControllers_revertsWhenExpectedControllerIsWrong() public {
+        address wrongExpected = makeAddr("wrongExpectedController");
 
         uint256[] memory ids = new uint256[](1);
         ids[0] = CHAIN_ETH_MAINNET;
+        address[] memory expected = new address[](1);
+        expected[0] = wrongExpected;
 
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.TRUSTED_REMOTE_MISMATCH.selector,
                 CHAIN_ETH_MAINNET,
-                remoteAdapter,
-                controllerConfiguredRemote
+                remoteController,
+                wrongExpected
             )
         );
-        adapter.assertTrustedRemotesMatchController(ids);
+        adapter.assertTrustedRemotesMatchControllers(ids, expected);
     }
 
-    function test_assertTrustedRemotesMatchController_revertsWhenControllerLaneUnconfigured() public {
-        // No `updateConfig` call: the controller's `remoteAdapter` for this
-        // chain stays `address(0)` while the adapter already trusts `remoteAdapter`.
+    function test_assertTrustedRemotesMatchControllers_revertsWhenTrustedRemoteIsUnset() public {
+        // CHAIN_BASE has a selector mapping but no trusted remote configured.
         uint256[] memory ids = new uint256[](1);
-        ids[0] = CHAIN_ETH_MAINNET;
+        ids[0] = CHAIN_BASE;
+        address[] memory expected = new address[](1);
+        expected[0] = makeAddr("anyExpectedController");
 
         vm.expectRevert(
-            abi.encodeWithSelector(Errors.TRUSTED_REMOTE_MISMATCH.selector, CHAIN_ETH_MAINNET, remoteAdapter, address(0))
+            abi.encodeWithSelector(
+                Errors.TRUSTED_REMOTE_MISMATCH.selector,
+                CHAIN_BASE,
+                address(0),
+                expected[0]
+            )
         );
-        adapter.assertTrustedRemotesMatchController(ids);
+        adapter.assertTrustedRemotesMatchControllers(ids, expected);
+    }
+
+    function test_assertTrustedRemotesMatchControllers_revertsOnLengthMismatch() public {
+        uint256[] memory ids = new uint256[](2);
+        ids[0] = CHAIN_ETH_MAINNET;
+        ids[1] = CHAIN_BASE;
+        address[] memory expected = new address[](1);
+        expected[0] = remoteController;
+
+        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
+        adapter.assertTrustedRemotesMatchControllers(ids, expected);
+    }
+
+    /// @dev THE canonical misconfiguration, mechanically detected: the adapter
+    ///      was set up trusting the remote ADAPTER (copy-pasted from
+    ///      `chainToAdapter[].remoteAdapter`) instead of the remote
+    ///      CONTROLLER. `expected` is deliberately set equal to the (wrong)
+    ///      trusted value so the plain mismatch check does not fire first --
+    ///      isolating the `TRUSTED_REMOTE_IS_REMOTE_ADAPTER` branch.
+    function test_assertTrustedRemotesMatchControllers_revertsWhenTrustedRemoteIsRemoteAdapter() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+
+        _grantAllPermissions();
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        address[] memory misconfiguredTrustedRemotes = new address[](1);
+        misconfiguredTrustedRemotes[0] = remoteAdapter; // WRONG: should be remoteController.
+        adapter.setTrustedRemotes(ids, misconfiguredTrustedRemotes);
+
+        address[] memory expected = new address[](1);
+        expected[0] = remoteAdapter; // matches the (wrong) trusted value.
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.TRUSTED_REMOTE_IS_REMOTE_ADAPTER.selector, CHAIN_ETH_MAINNET, remoteAdapter)
+        );
+        adapter.assertTrustedRemotesMatchControllers(ids, expected);
+    }
+
+    // =========================================================================
+    // g.2) `assertChainSelectorsMatchController`
+    // =========================================================================
+
+    function test_assertChainSelectorsMatchController_passesWhenInSync() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        adapter.assertChainSelectorsMatchController(ids); // must not revert
+    }
+
+    function test_assertChainSelectorsMatchController_revertsOnDesync() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+
+        // Desync the RECEIVE-side map away from what the controller's
+        // SEND-side config still says, e.g. via an incomplete `setChainSelectors`
+        // rollout for a new CCIP lane version.
+        _grantAllPermissions();
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_ETH_MAINNET;
+        uint64[] memory sels = new uint64[](1);
+        sels[0] = SEL_BASE_SEPOLIA;
+        adapter.setChainSelectors(ids, sels);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.CHAIN_ID_DESYNC.selector,
+                CHAIN_ETH_MAINNET,
+                SEL_ETH_MAINNET,
+                SEL_BASE_SEPOLIA
+            )
+        );
+        adapter.assertChainSelectorsMatchController(ids);
+    }
+
+    function test_assertChainSelectorsMatchController_revertsWhenControllerHasNoLane() public {
+        // CHAIN_BASE has an adapter-side selector (from `setUp`) but no
+        // controller lane was ever registered for it.
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_BASE;
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_BASE));
+        adapter.assertChainSelectorsMatchController(ids);
+    }
+
+    function test_assertChainSelectorsMatchController_revertsWhenAdapterHasNoEntry() public {
+        // Controller lane registered for CHAIN_SEPOLIA, but the adapter's own
+        // selector map was never told about it.
+        _registerLane(CHAIN_SEPOLIA, address(adapter), remoteAdapter, SEL_SEPOLIA);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = CHAIN_SEPOLIA;
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.UNKNOWN_CHAIN_ID.selector, CHAIN_SEPOLIA));
+        adapter.assertChainSelectorsMatchController(ids);
+    }
+
+    /// @dev Demonstrates what a desync actually DOES, not just that it is
+    ///      detected: the SEND path only ever consults the controller's
+    ///      `bridgeChainId`. Even though the adapter's own map still says
+    ///      `SEL_ETH_MAINNET` for `CHAIN_ETH_MAINNET`, pointing the controller's
+    ///      lane at a different selector sends there instead -- the adapter's
+    ///      receive-side storage is not read at all on send.
+    function test_desyncedChainSelectors_sendGoesToControllersSelector_ignoringAdapterMap() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_BASE_SEPOLIA);
+
+        uint256 feeAmount = 0.01 ether;
+        router.setFee(feeAmount);
+        vm.deal(address(controller), feeAmount);
+
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
+
+        assertEq(
+            router.lastDestChainSelector(),
+            SEL_BASE_SEPOLIA,
+            "send must use the controller's bridgeChainId, not the adapter's own selector map"
+        );
+        assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_ETH_MAINNET), "adapter's own map is untouched");
     }
 
     // =========================================================================
@@ -604,11 +802,11 @@ contract CCIPAdapterTest is Test {
     }
 
     // =========================================================================
-    // i) End-to-end-ish: controller.forwardMessage -> adapter.sendMessage -> router
+    // i) End-to-end: controller.forwardMessage -> [delegatecall] adapter -> router
     // =========================================================================
 
     function test_forwardMessage_endToEnd_routesThroughAdapterToRouter() public {
-        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter);
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
 
         uint256 feeAmount = 0.02 ether;
         router.setFee(feeAmount);
@@ -617,8 +815,7 @@ contract CCIPAdapterTest is Test {
         bytes32 expectedMessageId = keccak256("expected-message-id");
         router.setNextMessageId(expectedMessageId);
 
-        Action[] memory actions = new Action[](0);
-        bytes memory payload = abi.encode(actions);
+        bytes memory payload = _emptyActionsPayload();
         uint256 gasLimit = 300_000;
 
         bytes32 messageId = controller.forwardMessage(CHAIN_ETH_MAINNET, gasLimit, payload);
@@ -631,6 +828,7 @@ contract CCIPAdapterTest is Test {
         assertEq(router.lastFeeToken(), address(0));
         assertEq(router.lastDestChainSelector(), SEL_ETH_MAINNET);
         assertEq(router.lastMsgValue(), feeAmount);
+        assertEq(router.lastCaller(), address(controller), "CCIP must see the controller as the sender under delegatecall");
 
         bytes memory expectedExtraArgs = Client._argsToBytes(
             Client.GenericExtraArgsV2({gasLimit: gasLimit, allowOutOfOrderExecution: true})
@@ -639,7 +837,7 @@ contract CCIPAdapterTest is Test {
     }
 
     // =========================================================================
-    // Constructor validation (bonus coverage)
+    // j) Constructor validation
     // =========================================================================
 
     function test_constructor_revertsIfRouterIsZeroAddress() public {
@@ -655,7 +853,7 @@ contract CCIPAdapterTest is Test {
         chainIds[0] = CHAIN_ETH_MAINNET;
         chainIds[1] = CHAIN_BASE;
         address[] memory remotes = new address[](1);
-        remotes[0] = remoteAdapter;
+        remotes[0] = remoteController;
 
         vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
         new CCIPAdapter(
@@ -688,8 +886,218 @@ contract CCIPAdapterTest is Test {
         );
     }
 
-    function test_constructor_wiresUpConfiguredTrustedRemoteAndSelector() public view {
-        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), remoteAdapter);
+    function test_constructor_wiresUpConfiguredTrustedRemoteControllerAndSelector() public view {
+        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), remoteController);
         assertEq(adapter.toNativeChainId(CHAIN_ETH_MAINNET), uint256(SEL_ETH_MAINNET));
+    }
+
+    // =========================================================================
+    // k.1) Immutables resolve correctly under `delegatecall` -- the
+    //      load-bearing assumption of the whole redesign.
+    // =========================================================================
+
+    /// @dev Under a naive design where the fee token was a regular storage
+    ///      variable, this same `delegatecall` would read the CONTROLLER's
+    ///      slot (whatever happens to live there) instead of the adapter's
+    ///      configured fee token, and would very likely observe `address(0)`
+    ///      (native) even though an ERC20 fee token was configured -- a
+    ///      silent, wrong-currency bridge send. `FEE_TOKEN` being `immutable`
+    ///      means it is baked into the adapter's bytecode and resolves
+    ///      identically no matter whose storage is in scope.
+    function test_immutables_feeTokenAndRouterSurviveDelegatecall_notMisreadAsControllerStorage() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
+
+        uint256 feeAmount = 2 ether;
+        router.setFee(feeAmount);
+        feeTokenErc20.setBalance(address(controller), feeAmount);
+
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
+
+        assertEq(router.lastFeeToken(), address(feeTokenErc20), "immutable FEE_TOKEN must survive delegatecall");
+        assertEq(router.lastCaller(), address(controller), "CCIP_ROUTER must see the controller as caller");
+    }
+
+    /// @dev Two adapters, two ERC20 fee tokens, two routers: a send through
+    ///      lane A must resolve adapter A's OWN immutables and hit ONLY
+    ///      router A. If the immutables were ever misread against the
+    ///      controller's storage, this would either hit the wrong router or
+    ///      silently agree by coincidence -- using two independent routers
+    ///      rules the coincidence out.
+    function test_immutables_twoAdaptersRouteExclusivelyToTheirOwnRouterAndFeeToken() public {
+        CCIPRouterMock routerB = new CCIPRouterMock();
+        ERC20Mock feeTokenB = new ERC20Mock("Fee Token B", "FEEB");
+        CCIPAdapter adapterB = new CCIPAdapter(
+            address(controller),
+            address(routerB),
+            address(feeTokenB),
+            new uint256[](0),
+            new address[](0),
+            new uint256[](0),
+            new uint64[](0)
+        );
+
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET); // -> router (lane A)
+        _registerLane(CHAIN_BASE, address(adapterB), remoteAdapter, SEL_BASE); // -> routerB (lane B)
+
+        router.setFee(1 ether);
+        routerB.setFee(2 ether);
+        feeTokenErc20.setBalance(address(controller), 1 ether);
+        feeTokenB.setBalance(address(controller), 2 ether);
+
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
+
+        assertEq(router.ccipSendCallCount(), 1);
+        assertEq(router.lastFeeToken(), address(feeTokenErc20));
+        assertEq(routerB.ccipSendCallCount(), 0, "lane A's send must not touch router B at all");
+    }
+
+    // =========================================================================
+    // k.2) No storage collision with the controller.
+    // =========================================================================
+
+    /// @dev Snapshots the controller's storage byte-for-byte around a
+    ///      successful `forwardMessage`, using the REAL `CCIPAdapter` (not a
+    ///      mock). Slots verified with:
+    ///        `forge inspect .../CrossChainController.sol:CrossChainController storageLayout`
+    ///      -> slot 0 `chainToAdapter`, slot 1 `_localAdapterLaneCount`, slot 2
+    ///      `_failedMessages`, plus the derived element slots for the specific
+    ///      chain id / adapter this send touches. Also checks the adapter's
+    ///      OWN storage (a completely different address) is untouched, which
+    ///      is trivially guaranteed by `delegatecall` semantics as long as the
+    ///      controller never issues a plain `call` into the adapter -- worth
+    ///      asserting so a future refactor that broke this would be caught.
+    function test_forwardMessage_doesNotCollideWithControllerStorage() public {
+        _registerLane(CHAIN_ETH_MAINNET, address(adapter), remoteAdapter, SEL_ETH_MAINNET);
+
+        uint256 feeAmount = 0.02 ether;
+        router.setFee(feeAmount);
+        vm.deal(address(controller), feeAmount);
+
+        bytes32 chainConfigSlotA = keccak256(abi.encode(CHAIN_ETH_MAINNET, uint256(0)));
+        bytes32 chainConfigSlotB = bytes32(uint256(chainConfigSlotA) + 1);
+        bytes32 laneCountSlot = keccak256(abi.encode(address(adapter), uint256(1)));
+
+        bytes32 slot0Before = vm.load(address(controller), bytes32(uint256(0)));
+        bytes32 slot1Before = vm.load(address(controller), bytes32(uint256(1)));
+        bytes32 slot2Before = vm.load(address(controller), bytes32(uint256(2)));
+        bytes32 chainConfigABefore = vm.load(address(controller), chainConfigSlotA);
+        bytes32 chainConfigBBefore = vm.load(address(controller), chainConfigSlotB);
+        bytes32 laneCountBefore = vm.load(address(controller), laneCountSlot);
+
+        address trustedRemoteBefore = adapter.trustedRemote(CHAIN_ETH_MAINNET);
+        uint256 nativeChainIdBefore = adapter.toNativeChainId(CHAIN_ETH_MAINNET);
+
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
+
+        assertEq(vm.load(address(controller), bytes32(uint256(0))), slot0Before, "slot 0 mutated by send");
+        assertEq(vm.load(address(controller), bytes32(uint256(1))), slot1Before, "slot 1 mutated by send");
+        assertEq(vm.load(address(controller), bytes32(uint256(2))), slot2Before, "slot 2 mutated by send");
+        assertEq(
+            vm.load(address(controller), chainConfigSlotA),
+            chainConfigABefore,
+            "chainToAdapter[chainId] slot A mutated by send"
+        );
+        assertEq(
+            vm.load(address(controller), chainConfigSlotB),
+            chainConfigBBefore,
+            "chainToAdapter[chainId] slot B mutated by send"
+        );
+        assertEq(
+            vm.load(address(controller), laneCountSlot),
+            laneCountBefore,
+            "_localAdapterLaneCount[adapter] slot mutated by send"
+        );
+
+        assertEq(adapter.trustedRemote(CHAIN_ETH_MAINNET), trustedRemoteBefore, "adapter's own storage touched by send");
+        assertEq(
+            adapter.toNativeChainId(CHAIN_ETH_MAINNET),
+            nativeChainIdBefore,
+            "adapter's own selector-map storage touched by send"
+        );
+    }
+
+    // =========================================================================
+    // k.3) The DELEGATE_CALL_FORBIDDEN receive-path guard.
+    // =========================================================================
+
+    /// @dev Proves that reaching the RECEIVE path under `delegatecall` reverts.
+    ///      `delegateCallerMock` has NO storage of its own for `_trustedRemotes`
+    ///      / `_selectorToChainId`, so those checks would revert first unless
+    ///      fake entries are planted at the exact slots
+    ///      `forge inspect .../CCIPAdapter.sol:CCIPAdapter storageLayout`
+    ///      reports (slot 0 `_trustedRemotes`, slot 2 `_selectorToChainId`) --
+    ///      done here via `vm.store` so execution genuinely reaches
+    ///      `_forwardMessage` and trips `DELEGATE_CALL_FORBIDDEN` specifically,
+    ///      rather than failing earlier for an unrelated reason.
+    function test_ccipReceive_delegatecalledIntoAdapter_revertsWithDelegateCallForbidden() public {
+        uint256 fakeOriginChainId = 777;
+        address fakeTrustedSender = makeAddr("fakeTrustedSenderForDelegatecallProbe");
+
+        // `_selectorToChainId[SEL_ETH_MAINNET] = fakeOriginChainId` at slot 2,
+        // computed against `delegateCallerMock`'s own (otherwise empty) storage.
+        bytes32 selectorToChainIdSlot = keccak256(abi.encode(uint256(SEL_ETH_MAINNET), uint256(2)));
+        vm.store(address(delegateCallerMock), selectorToChainIdSlot, bytes32(fakeOriginChainId));
+
+        // `_trustedRemotes[fakeOriginChainId] = fakeTrustedSender` at slot 0.
+        bytes32 trustedRemoteSlot = keccak256(abi.encode(fakeOriginChainId, uint256(0)));
+        vm.store(address(delegateCallerMock), trustedRemoteSlot, bytes32(uint256(uint160(fakeTrustedSender))));
+
+        Client.Any2EVMMessage memory message = _buildInbound(SEL_ETH_MAINNET, fakeTrustedSender, "");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.DELEGATE_CALL_FORBIDDEN.selector,
+                address(delegateCallerMock), // address(this) during the delegatecalled execution
+                address(adapter) // the adapter's immutable `_selfAddress`
+            )
+        );
+        vm.prank(address(router)); // `onlyRouter` checks msg.sender, preserved across delegatecall.
+        delegateCallerMock.delegateCall(address(adapter), abi.encodeCall(CCIPAdapter.ccipReceive, (message)));
+    }
+
+    // =========================================================================
+    // k.4) Fee-token immutability trade-off: no `setFeeToken`.
+    // =========================================================================
+
+    /// @dev There is no setter to rotate `FEE_TOKEN` -- it is `immutable` by
+    ///      necessity (see `CCIPAdapter`'s contract-level docs). Rotating the
+    ///      fee token for a lane means deploying a SECOND `CCIPAdapter` with
+    ///      the new `FEE_TOKEN` and repointing the lane via
+    ///      `CrossChainController.updateConfig`, which correctly de-registers
+    ///      the old local adapter (refcounted) and registers the new one.
+    function test_feeTokenRotation_requiresDeployingANewAdapterAndRepointingTheLane() public {
+        ERC20Mock newFeeToken = new ERC20Mock("New Fee Token", "NEWFEE");
+        CCIPAdapter newAdapter = new CCIPAdapter(
+            address(controller),
+            address(router),
+            address(newFeeToken),
+            new uint256[](0),
+            new address[](0),
+            new uint256[](0),
+            new uint64[](0)
+        );
+
+        // Old lane, old fee token: works today.
+        _registerLane(CHAIN_ETH_MAINNET, address(erc20Adapter), remoteAdapter, SEL_ETH_MAINNET);
+        assertTrue(controller.isRegisteredLocalAdapter(address(erc20Adapter)));
+
+        router.setFee(1 ether);
+        feeTokenErc20.setBalance(address(controller), 1 ether);
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
+        assertEq(router.lastFeeToken(), address(feeTokenErc20));
+
+        // Rotate: repoint the SAME chain id at the new adapter/fee token.
+        _registerLane(CHAIN_ETH_MAINNET, address(newAdapter), remoteAdapter, SEL_ETH_MAINNET);
+
+        assertFalse(
+            controller.isRegisteredLocalAdapter(address(erc20Adapter)),
+            "old adapter must lose the right to call receiveMessage once its last lane is repointed"
+        );
+        assertTrue(controller.isRegisteredLocalAdapter(address(newAdapter)));
+
+        router.setFee(1 ether);
+        newFeeToken.setBalance(address(controller), 1 ether);
+        controller.forwardMessage(CHAIN_ETH_MAINNET, 200_000, "");
+        assertEq(router.lastFeeToken(), address(newFeeToken), "send must now use the new adapter's fee token");
     }
 }

--- a/test/common/crosschain/CrossChainController.t.sol
+++ b/test/common/crosschain/CrossChainController.t.sol
@@ -1,0 +1,630 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {CrossChainController} from "../../../src/common/crosschain/CrossChainController.sol";
+import {Errors} from "../../../src/common/crosschain/lib/Errors.sol";
+import {Action} from "../../../src/common/executors/IExecutor.sol";
+import {DaoUnauthorized} from "../../../src/common/permission/auth/auth.sol";
+import {AdapterMock} from "../../mocks/commons/crosschain/AdapterMock.sol";
+import {CrossChainControllerDAOMock} from "../../mocks/commons/crosschain/CrossChainControllerDAOMock.sol";
+import {ERC20Mock} from "../../mocks/commons/token/ERC20Mock.sol";
+import {ActionExecute} from "../../mocks/commons/executors/ActionExecute.sol";
+
+/// @notice Regression suite for the hardened `CrossChainController`
+///         (`src/common/crosschain/CrossChainController.sol`).
+///
+/// Every test here targets a specific finding from the security review and is
+/// written to genuinely FAIL against the pre-hardening version of the
+/// contract:
+///  - `receiveMessage` inbound authentication (only a registered local
+///    adapter may call it) and correct refcounted adapter rotation.
+///  - `updateConfig` input validation (length mismatch, chain id 0,
+///    half-configured lanes) and its `ConfigUpdated` event payload.
+///  - The "silent no-op" footgun: `forwardMessage` to an unconfigured chain
+///    or to a codeless local adapter must revert, not silently succeed.
+///  - Fee custody: exact fee amounts moved for both ERC20 and native, and
+///    `INSUFFICIENT_FEE_BALANCE` when underfunded.
+///  - The defensive `try/catch` around inbound execution: a reverting or
+///    malformed payload is captured as a `FailedMessage` instead of
+///    reverting message delivery, and can later be retried.
+///  - `executeActions`'s `CALLER_NOT_SELF` self-call guard.
+///  - `sweep`'s auth check and zero-address guard.
+///  - `deriveCallId` determinism.
+contract CrossChainControllerTest is Test {
+    // Solc 0.8.17 (this repo's pinned version) cannot `emit Contract.Event(...)`
+    // for an externally-defined event, so the events under test are
+    // redeclared here with identical signatures purely so `vm.expectEmit`
+    // has something to match topics/data against (topic0 only depends on the
+    // signature, not on which contract declares it).
+    event ConfigUpdated(uint256 indexed chainId, address localAdapter, address remoteAdapter);
+    event MessageForwarded(
+        uint256 indexed destinationChainId,
+        bytes32 indexed messageId,
+        address indexed localAdapter,
+        address remoteAdapter,
+        uint256 gasLimit,
+        address feeToken,
+        uint256 fee
+    );
+    event MessageExecutionFailed(
+        uint256 indexed originChainId, bytes32 indexed messageId, bytes32 indexed callId, bytes reason
+    );
+    event MessageRetried(bytes32 indexed callId);
+    event Swept(address indexed token, address indexed to, uint256 amount);
+
+    uint256 internal constant CHAIN_ID = 10;
+    uint256 internal constant OTHER_CHAIN_ID = 20;
+    uint256 internal constant GAS_LIMIT = 200_000;
+
+    CrossChainControllerDAOMock internal daoMock;
+    CrossChainController internal controller;
+    AdapterMock internal adapterA;
+    AdapterMock internal adapterB;
+    ERC20Mock internal feeToken;
+    ActionExecute internal actionTarget;
+
+    address internal remoteAdapterA;
+    address internal remoteAdapterB;
+    address internal alice; // holds every permission
+    address internal bob; // holds none
+
+    bytes32 internal FORWARD_MESSAGE_PERMISSION_ID;
+    bytes32 internal UPDATE_CONFIG_PERMISSION_ID;
+    bytes32 internal RETRY_MESSAGE_PERMISSION_ID;
+    bytes32 internal SWEEP_PERMISSION_ID;
+
+    function setUp() public {
+        daoMock = new CrossChainControllerDAOMock();
+        controller = new CrossChainController(address(daoMock));
+
+        adapterA = new AdapterMock(address(controller));
+        adapterB = new AdapterMock(address(controller));
+        feeToken = new ERC20Mock("Fee", "FEE");
+        actionTarget = new ActionExecute();
+
+        remoteAdapterA = makeAddr("remoteAdapterA");
+        remoteAdapterB = makeAddr("remoteAdapterB");
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+
+        FORWARD_MESSAGE_PERMISSION_ID = controller.FORWARD_MESSAGE_PERMISSION_ID();
+        UPDATE_CONFIG_PERMISSION_ID = controller.UPDATE_CONFIG_PERMISSION_ID();
+        RETRY_MESSAGE_PERMISSION_ID = controller.RETRY_MESSAGE_PERMISSION_ID();
+        SWEEP_PERMISSION_ID = controller.SWEEP_PERMISSION_ID();
+
+        daoMock.setHasPermission(address(controller), alice, FORWARD_MESSAGE_PERMISSION_ID, true);
+        daoMock.setHasPermission(address(controller), alice, UPDATE_CONFIG_PERMISSION_ID, true);
+        daoMock.setHasPermission(address(controller), alice, RETRY_MESSAGE_PERMISSION_ID, true);
+        daoMock.setHasPermission(address(controller), alice, SWEEP_PERMISSION_ID, true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    function _lane(address _local, address _remote) internal pure returns (CrossChainController.AdapterByChain memory) {
+        return CrossChainController.AdapterByChain({localAdapter: _local, remoteAdapter: _remote});
+    }
+
+    function _configureLane(uint256 _chainId, address _local, address _remote) internal {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = _chainId;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(_local, _remote);
+
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function _emptyActionsPayload() internal pure returns (bytes memory) {
+        return abi.encode(new Action[](0));
+    }
+
+    // -------------------------------------------------------------------------
+    // a) receiveMessage inbound authentication
+    // -------------------------------------------------------------------------
+
+    function test_receiveMessage_revertsForCallerNotLocalAdapter() public {
+        address random = makeAddr("random");
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, random));
+        vm.prank(random);
+        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
+    }
+
+    function test_receiveMessage_revertsForUnregisteredContract() public {
+        // A deployed contract that was never configured as a lane's local
+        // adapter is just as unauthorized as an EOA.
+        AdapterMock strangerAdapter = new AdapterMock(address(controller));
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(strangerAdapter)));
+        vm.prank(address(strangerAdapter));
+        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
+    }
+
+    function test_receiveMessage_succeedsForRegisteredLocalAdapter() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        bytes32 messageId = bytes32(uint256(42));
+        vm.prank(address(adapterA));
+        bytes32 callId = controller.receiveMessage(messageId, _emptyActionsPayload(), CHAIN_ID);
+
+        assertEq(callId, controller.deriveCallId(CHAIN_ID, messageId));
+    }
+
+    function test_receiveMessage_revertsIfMessageAlreadyPending() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        Action[] memory actions = new Action[](1);
+        actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
+        bytes memory payload = abi.encode(actions);
+
+        bytes32 messageId = bytes32(uint256(7));
+        bytes32 callId = controller.deriveCallId(CHAIN_ID, messageId);
+
+        vm.prank(address(adapterA));
+        controller.receiveMessage(messageId, payload, CHAIN_ID);
+        assertTrue(controller.getFailedMessage(callId).pending);
+
+        // Redelivering the same (originChainId, messageId) while the first
+        // attempt is still pending must revert, not overwrite/duplicate it.
+        vm.expectRevert(abi.encodeWithSelector(Errors.MESSAGE_ALREADY_PENDING.selector, callId));
+        vm.prank(address(adapterA));
+        controller.receiveMessage(messageId, payload, CHAIN_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // b) Adapter rotation / refcounting
+    // -------------------------------------------------------------------------
+
+    function test_updateConfig_rotatingLocalAdapterRevokesOldAdapter() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        vm.prank(address(adapterA));
+        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
+
+        // Rotate the lane to adapterB.
+        _configureLane(CHAIN_ID, address(adapterB), remoteAdapterB);
+
+        assertFalse(controller.isRegisteredLocalAdapter(address(adapterA)));
+        assertEq(controller.localAdapterLaneCount(address(adapterA)), 0);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(adapterA)));
+        vm.prank(address(adapterA));
+        controller.receiveMessage(bytes32(uint256(2)), _emptyActionsPayload(), CHAIN_ID);
+
+        // The new adapter works.
+        vm.prank(address(adapterB));
+        controller.receiveMessage(bytes32(uint256(3)), _emptyActionsPayload(), CHAIN_ID);
+    }
+
+    function test_updateConfig_refcountKeepsAdapterAuthorizedUntilBothLanesCleared() public {
+        // adapterA serves two lanes.
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(OTHER_CHAIN_ID, address(adapterA), remoteAdapterB);
+
+        assertEq(controller.localAdapterLaneCount(address(adapterA)), 2);
+        assertTrue(controller.isRegisteredLocalAdapter(address(adapterA)));
+
+        // Clear the first lane only; adapterA must remain authorized.
+        _configureLane(CHAIN_ID, address(0), address(0));
+
+        assertEq(controller.localAdapterLaneCount(address(adapterA)), 1);
+        assertTrue(controller.isRegisteredLocalAdapter(address(adapterA)));
+
+        vm.prank(address(adapterA));
+        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), OTHER_CHAIN_ID);
+
+        // Clear the second (last) lane; adapterA now loses authorization.
+        _configureLane(OTHER_CHAIN_ID, address(0), address(0));
+
+        assertEq(controller.localAdapterLaneCount(address(adapterA)), 0);
+        assertFalse(controller.isRegisteredLocalAdapter(address(adapterA)));
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(adapterA)));
+        vm.prank(address(adapterA));
+        controller.receiveMessage(bytes32(uint256(2)), _emptyActionsPayload(), OTHER_CHAIN_ID);
+    }
+
+    function test_updateConfig_clearingLaneWithZeroPairResetsMapping() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(0), address(0));
+
+        (address local, address remote) = controller.chainToAdapter(CHAIN_ID);
+        assertEq(local, address(0));
+        assertEq(remote, address(0));
+
+        // A cleared lane is "unconfigured" again for sends.
+        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    // -------------------------------------------------------------------------
+    // c) updateConfig validation
+    // -------------------------------------------------------------------------
+
+    function test_updateConfig_revertsOnLengthMismatch() public {
+        uint256[] memory chainIds = new uint256[](2);
+        chainIds[0] = CHAIN_ID;
+        chainIds[1] = OTHER_CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+
+        vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_revertsOnZeroChainId() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = 0;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+
+        vm.expectRevert(Errors.INVALID_CHAIN_ID.selector);
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_revertsOnHalfConfiguredLane_missingRemote() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), address(0));
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_revertsOnHalfConfiguredLane_missingLocal() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(0), remoteAdapterA);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_revertsIfCallerUnauthorized() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, UPDATE_CONFIG_PERMISSION_ID)
+        );
+        vm.prank(bob);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    function test_updateConfig_emitsConfigUpdatedWithCorrectPayload() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
+        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+
+        vm.expectEmit(true, false, false, true, address(controller));
+        emit ConfigUpdated(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        vm.prank(alice);
+        controller.updateConfig(chainIds, adapters);
+    }
+
+    // -------------------------------------------------------------------------
+    // d) forwardMessage silent no-op guards
+    // -------------------------------------------------------------------------
+
+    function test_forwardMessage_revertsIfChainNotConfigured() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_revertsIfLocalAdapterHasNoCode() public {
+        address codelessAdapter = makeAddr("codelessAdapter");
+        address codelessRemote = makeAddr("codelessRemote");
+        _configureLane(CHAIN_ID, codelessAdapter, codelessRemote);
+
+        assertEq(codelessAdapter.code.length, 0);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_HAS_NO_CODE.selector, codelessAdapter));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    // -------------------------------------------------------------------------
+    // e) forwardMessage auth + happy path
+    // -------------------------------------------------------------------------
+
+    function test_forwardMessage_revertsIfCallerUnauthorized() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, FORWARD_MESSAGE_PERMISSION_ID)
+        );
+        vm.prank(bob);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_happyPathEmitsMessageForwardedAndReturnsMessageId() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        adapterA.setFee(address(0), 0); // no fee due, no funding required
+        bytes32 expectedMessageId = bytes32(uint256(999));
+        adapterA.setMessageId(expectedMessageId);
+
+        bytes memory message = abi.encode("hello");
+
+        vm.expectEmit(true, true, true, true, address(controller));
+        emit MessageForwarded(
+            CHAIN_ID, expectedMessageId, address(adapterA), remoteAdapterA, GAS_LIMIT, address(0), 0
+        );
+
+        vm.prank(alice);
+        bytes32 messageId = controller.forwardMessage(CHAIN_ID, GAS_LIMIT, message);
+
+        assertEq(messageId, expectedMessageId);
+        assertEq(adapterA.lastReceiver(), remoteAdapterA);
+        assertEq(adapterA.lastGasLimit(), GAS_LIMIT);
+        assertEq(adapterA.lastDestinationChainId(), CHAIN_ID);
+        assertEq(adapterA.lastMessage(), message);
+        assertEq(adapterA.sendMessageCallCount(), 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // f) Fees
+    // -------------------------------------------------------------------------
+
+    function test_forwardMessage_erc20Fee_revertsIfControllerBalanceInsufficient() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        adapterA.setFee(address(feeToken), 100 ether);
+        // Controller holds 0 of feeToken.
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(feeToken), 100 ether, 0));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_erc20Fee_transfersExactFeeToAdapterWhenFunded() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        uint256 requiredFee = 100 ether;
+        adapterA.setFee(address(feeToken), requiredFee);
+        feeToken.setBalance(address(controller), requiredFee + 1 ether); // extra buffer left untouched
+
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+
+        assertEq(feeToken.balanceOf(address(adapterA)), requiredFee);
+        assertEq(feeToken.balanceOf(address(controller)), 1 ether);
+    }
+
+    function test_forwardMessage_nativeFee_revertsIfControllerBalanceInsufficient() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        adapterA.setFee(address(0), 1 ether);
+        // Controller holds 0 native.
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(0), 1 ether, 0));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_nativeFee_forwardsExactFeeWeiToAdapterWhenFunded() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        uint256 requiredFee = 1 ether;
+        adapterA.setFee(address(0), requiredFee);
+        vm.deal(address(controller), requiredFee + 3 ether);
+
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+
+        assertEq(address(adapterA).balance, requiredFee);
+        assertEq(address(controller).balance, 3 ether);
+        assertEq(adapterA.lastValueReceived(), requiredFee);
+    }
+
+    // -------------------------------------------------------------------------
+    // g) Defensive receive / retry
+    // -------------------------------------------------------------------------
+
+    function test_receiveMessage_capturesRevertingPayloadInsteadOfReverting() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        Action[] memory actions = new Action[](1);
+        actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
+        bytes memory payload = abi.encode(actions);
+
+        bytes32 messageId = bytes32(uint256(55));
+        bytes32 expectedCallId = controller.deriveCallId(CHAIN_ID, messageId);
+        // `CrossChainControllerDAOMock.execute` bubbles the low-level call's
+        // raw returndata on failure, which is `ActionExecute.fail`'s
+        // `Error(string)`-encoded revert reason.
+        bytes memory expectedReason = abi.encodeWithSignature("Error(string)", "ActionExecute:Revert");
+
+        vm.expectEmit(true, true, true, true, address(controller));
+        emit MessageExecutionFailed(CHAIN_ID, messageId, expectedCallId, expectedReason);
+
+        vm.prank(address(adapterA));
+        bytes32 callId = controller.receiveMessage(messageId, payload, CHAIN_ID); // must NOT revert
+        assertEq(callId, expectedCallId);
+
+        CrossChainController.FailedMessage memory failed = controller.getFailedMessage(callId);
+        assertTrue(failed.pending);
+        assertEq(failed.originChainId, CHAIN_ID);
+        assertEq(failed.messageId, messageId);
+        assertEq(failed.payload, payload);
+    }
+
+    function test_receiveMessage_capturesMalformedPayloadInsteadOfReverting() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        // Not a valid ABI-encoding of `Action[]`.
+        bytes memory garbage = hex"deadbeef";
+
+        bytes32 messageId = bytes32(uint256(56));
+        bytes32 expectedCallId = controller.deriveCallId(CHAIN_ID, messageId);
+
+        // Only check the indexed topics here (origin/message/call id); the
+        // exact revert bytes produced by a failed `abi.decode` are an
+        // implementation/compiler detail we don't want to pin.
+        vm.expectEmit(true, true, true, false, address(controller));
+        emit MessageExecutionFailed(CHAIN_ID, messageId, expectedCallId, "");
+
+        vm.prank(address(adapterA));
+        bytes32 callId = controller.receiveMessage(messageId, garbage, CHAIN_ID); // must NOT revert
+        assertEq(callId, expectedCallId);
+        assertTrue(controller.getFailedMessage(callId).pending);
+    }
+
+    function test_retryFailedMessage_revertsIfCallerUnauthorized() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        bytes32 callId = _causeFailure(bytes32(uint256(60)));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, RETRY_MESSAGE_PERMISSION_ID)
+        );
+        vm.prank(bob);
+        controller.retryFailedMessage(callId);
+    }
+
+    function test_retryFailedMessage_revertsForUnknownCallId() public {
+        bytes32 unknownCallId = keccak256("nope");
+        vm.expectRevert(abi.encodeWithSelector(Errors.NO_FAILED_MESSAGE.selector, unknownCallId));
+        vm.prank(alice);
+        controller.retryFailedMessage(unknownCallId);
+    }
+
+    function test_retryFailedMessage_succeedsOnceFailureConditionRemoved() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+
+        FlakyTarget flaky = new FlakyTarget();
+        Action[] memory actions = new Action[](1);
+        actions[0] = Action({to: address(flaky), value: 0, data: abi.encodeCall(FlakyTarget.maybeRevert, ())});
+        bytes memory payload = abi.encode(actions);
+
+        bytes32 messageId = bytes32(uint256(61));
+        bytes32 callId = controller.deriveCallId(CHAIN_ID, messageId);
+
+        vm.prank(address(adapterA));
+        controller.receiveMessage(messageId, payload, CHAIN_ID);
+        assertTrue(controller.getFailedMessage(callId).pending);
+
+        // Fix the failure condition.
+        flaky.setShouldRevert(false);
+
+        vm.expectEmit(true, false, false, false, address(controller));
+        emit MessageRetried(callId);
+
+        vm.prank(alice);
+        controller.retryFailedMessage(callId);
+
+        CrossChainController.FailedMessage memory cleared = controller.getFailedMessage(callId);
+        assertFalse(cleared.pending);
+        assertTrue(flaky.wasCalled());
+    }
+
+    /// @dev Delivers a message whose payload always fails, leaving a stored
+    ///      `FailedMessage` at the returned call id.
+    function _causeFailure(bytes32 _messageId) internal returns (bytes32 callId) {
+        Action[] memory actions = new Action[](1);
+        actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
+        bytes memory payload = abi.encode(actions);
+
+        vm.prank(address(adapterA));
+        callId = controller.receiveMessage(_messageId, payload, CHAIN_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // h) executeActions self-call guard
+    // -------------------------------------------------------------------------
+
+    function test_executeActions_revertsIfCallerNotSelf() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_SELF.selector, address(this)));
+        controller.executeActions(bytes32(0), _emptyActionsPayload());
+    }
+
+    // -------------------------------------------------------------------------
+    // i) sweep
+    // -------------------------------------------------------------------------
+
+    function test_sweep_revertsIfCallerUnauthorized() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, SWEEP_PERMISSION_ID)
+        );
+        vm.prank(bob);
+        controller.sweep(address(0), bob, 1 ether);
+    }
+
+    function test_sweep_revertsIfRecipientIsZeroAddress() public {
+        vm.expectRevert(Errors.ZERO_ADDRESS.selector);
+        vm.prank(alice);
+        controller.sweep(address(0), address(0), 0);
+    }
+
+    function test_sweep_native_movesExactAmountAndEmits() public {
+        vm.deal(address(controller), 5 ether);
+        address recipient = makeAddr("recipient");
+
+        vm.expectEmit(true, true, false, true, address(controller));
+        emit Swept(address(0), recipient, 2 ether);
+
+        vm.prank(alice);
+        controller.sweep(address(0), recipient, 2 ether);
+
+        assertEq(recipient.balance, 2 ether);
+        assertEq(address(controller).balance, 3 ether);
+    }
+
+    function test_sweep_erc20_movesExactAmountAndEmits() public {
+        feeToken.setBalance(address(controller), 10 ether);
+        address recipient = makeAddr("recipient");
+
+        vm.expectEmit(true, true, false, true, address(controller));
+        emit Swept(address(feeToken), recipient, 4 ether);
+
+        vm.prank(alice);
+        controller.sweep(address(feeToken), recipient, 4 ether);
+
+        assertEq(feeToken.balanceOf(recipient), 4 ether);
+        assertEq(feeToken.balanceOf(address(controller)), 6 ether);
+    }
+
+    // -------------------------------------------------------------------------
+    // j) deriveCallId
+    // -------------------------------------------------------------------------
+
+    function test_deriveCallId_isDeterministicAndInputSensitive() public view {
+        bytes32 messageId = bytes32(uint256(123));
+
+        bytes32 callId1 = controller.deriveCallId(CHAIN_ID, messageId);
+        bytes32 callId2 = controller.deriveCallId(CHAIN_ID, messageId);
+        assertEq(callId1, callId2);
+        assertEq(callId1, keccak256(abi.encode(CHAIN_ID, messageId)));
+
+        bytes32 differentChain = controller.deriveCallId(OTHER_CHAIN_ID, messageId);
+        assertTrue(callId1 != differentChain);
+
+        bytes32 differentMessage = controller.deriveCallId(CHAIN_ID, bytes32(uint256(124)));
+        assertTrue(callId1 != differentMessage);
+    }
+}
+
+/// @dev Minimal target whose revert behaviour can be flipped on demand, used
+///      to prove `retryFailedMessage` succeeds once the underlying failure
+///      condition is actually fixed (as opposed to merely being re-run).
+contract FlakyTarget {
+    bool public shouldRevert = true;
+    bool public wasCalled;
+
+    function setShouldRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+
+    function maybeRevert() external {
+        if (shouldRevert) revert("FlakyTarget: still failing");
+        wasCalled = true;
+    }
+}

--- a/test/common/crosschain/CrossChainController.t.sol
+++ b/test/common/crosschain/CrossChainController.t.sol
@@ -4,55 +4,28 @@ pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {CrossChainController} from "../../../src/common/crosschain/CrossChainController.sol";
+import {
+    CrossChainController
+} from "../../../src/common/crosschain/CrossChainController.sol";
 import {Errors} from "../../../src/common/crosschain/lib/Errors.sol";
 import {Action} from "../../../src/common/executors/IExecutor.sol";
 import {DaoUnauthorized} from "../../../src/common/permission/auth/auth.sol";
 import {AdapterMock} from "../../mocks/commons/crosschain/AdapterMock.sol";
 import {
-    MaliciousAdapterMock, PwnTarget
+    MaliciousAdapterMock,
+    PwnTarget
 } from "../../mocks/commons/crosschain/MaliciousAdapterMock.sol";
-import {CrossChainControllerDAOMock} from "../../mocks/commons/crosschain/CrossChainControllerDAOMock.sol";
+import {
+    CrossChainControllerDAOMock
+} from "../../mocks/commons/crosschain/CrossChainControllerDAOMock.sol";
 import {ERC20Mock} from "../../mocks/commons/token/ERC20Mock.sol";
 import {ActionExecute} from "../../mocks/commons/executors/ActionExecute.sol";
 
-/// @notice Regression suite for the "Option 1" `CrossChainController`
-///         (`src/common/crosschain/CrossChainController.sol`), which sends by
-///         `delegatecall`ing the local adapter instead of `call`ing it. Every
-///         send-path parameter that used to live in adapter storage now lives
-///         in the controller's `chainToAdapter` mapping and is passed as an
-///         argument, so the adapter's send path reads NO storage.
-///
-/// Sections a)-j) preserve the pre-redesign coverage (inbound auth, adapter
-/// rotation, `updateConfig` validation, silent-no-op / fail-loudly guards,
-/// forwarding auth + happy path, fees, defensive receive/retry, the
-/// `executeActions` self-call guard, `sweep`, `deriveCallId`), adapted to the
-/// new `ChainConfig{localAdapter, remoteAdapter, bridgeChainId}` shape and to
-/// `AdapterMock` now being immutable-configured (constructor args, no
-/// setters, records calls via `SendMessageCalled` instead of storage).
-///
-/// Sections k)-o) are NEW and are the entire point of this redesign:
-///  k) the controller's own storage is byte-identical before/after a send
-///     (no collision with whatever the delegatecalled adapter code touches);
-///  l) two adapters with different `immutable`s produce provably different
-///     results, proving delegatecall resolves the CALLED adapter's bytecode
-///     immutables, not the controller's storage;
-///  m) an unconfigured/zeroed `bridgeChainId` can never silently address
-///     bridge lane `0`;
-///  n) an adapter's send path refuses to run outside a delegatecall from its
-///     owning controller;
-///  o) the accepted residual risk (security-review finding 7): whoever holds
-///     `UPDATE_CONFIG_PERMISSION` can fully take over the controller and, by
-///     extension, the DAO. This is NOT mitigated in code; it documents why
-///     that permission must be DAO-only.
 contract CrossChainControllerTest is Test {
-    // Solc 0.8.17 (this repo's pinned version) cannot `emit Contract.Event(...)`
-    // for an externally-defined event, so every event under test is
-    // redeclared here with an IDENTICAL signature purely so `vm.expectEmit`
-    // has something to match topics/data against (topic0 only depends on the
-    // signature, not on which contract declares it).
     event ConfigUpdated(
-        uint256 indexed chainId, address localAdapter, address remoteAdapter, uint64 bridgeChainId
+        uint256 indexed chainId,
+        address localAdapter,
+        address remoteAdapter
     );
     event MessageForwarded(
         uint256 indexed destinationChainId,
@@ -60,24 +33,16 @@ contract CrossChainControllerTest is Test {
         address indexed localAdapter,
         address remoteAdapter,
         uint256 gasLimit,
-        address feeToken,
         uint256 fee
     );
     event MessageExecutionFailed(
-        uint256 indexed originChainId, bytes32 indexed messageId, bytes32 indexed callId, bytes reason
+        uint256 indexed originChainId,
+        bytes32 indexed messageId,
+        bytes32 indexed callId,
+        bytes reason
     );
     event MessageRetried(bytes32 indexed callId);
     event Swept(address indexed token, address indexed to, uint256 amount);
-    /// @dev Mirrors `AdapterMock.SendMessageCalled`. IMPORTANT: because
-    ///      `forwardMessage` reaches this via `delegatecall`, the EVM records
-    ///      the log's emitting address as the CONTROLLER, not the adapter
-    ///      (exactly like storage, `LOG*` uses the current execution
-    ///      context's address, which delegatecall does not change). Every
-    ///      `vm.expectEmit` against this event below therefore targets
-    ///      `address(controller)`, never the adapter.
-    event SendMessageCalled(
-        address context, address receiver, uint64 bridgeChainId, uint256 gasLimit, bytes message, uint256 value
-    );
 
     uint256 internal constant CHAIN_ID = 10;
     uint256 internal constant OTHER_CHAIN_ID = 20;
@@ -123,18 +88,55 @@ contract CrossChainControllerTest is Test {
         // need to fund the controller. `AdapterMock` has no setters -- tests
         // that need different fee/messageId/feeSink/revert behaviour deploy
         // their own dedicated instance instead.
-        adapterA = new AdapterMock(address(controller), address(0), 0, bytes32(uint256(1)), feeSinkA, false, false);
-        adapterB = new AdapterMock(address(controller), address(0), 0, bytes32(uint256(2)), feeSinkB, false, false);
+        adapterA = new AdapterMock(
+            address(controller),
+            address(0),
+            0,
+            bytes32(uint256(1)),
+            feeSinkA,
+            false,
+            false
+        );
+        adapterB = new AdapterMock(
+            address(controller),
+            address(0),
+            0,
+            bytes32(uint256(2)),
+            feeSinkB,
+            false,
+            false
+        );
 
-        FORWARD_MESSAGE_PERMISSION_ID = controller.FORWARD_MESSAGE_PERMISSION_ID();
+        FORWARD_MESSAGE_PERMISSION_ID = controller
+            .FORWARD_MESSAGE_PERMISSION_ID();
         UPDATE_CONFIG_PERMISSION_ID = controller.UPDATE_CONFIG_PERMISSION_ID();
         RETRY_MESSAGE_PERMISSION_ID = controller.RETRY_MESSAGE_PERMISSION_ID();
         SWEEP_PERMISSION_ID = controller.SWEEP_PERMISSION_ID();
 
-        daoMock.setHasPermission(address(controller), alice, FORWARD_MESSAGE_PERMISSION_ID, true);
-        daoMock.setHasPermission(address(controller), alice, UPDATE_CONFIG_PERMISSION_ID, true);
-        daoMock.setHasPermission(address(controller), alice, RETRY_MESSAGE_PERMISSION_ID, true);
-        daoMock.setHasPermission(address(controller), alice, SWEEP_PERMISSION_ID, true);
+        daoMock.setHasPermission(
+            address(controller),
+            alice,
+            FORWARD_MESSAGE_PERMISSION_ID,
+            true
+        );
+        daoMock.setHasPermission(
+            address(controller),
+            alice,
+            UPDATE_CONFIG_PERMISSION_ID,
+            true
+        );
+        daoMock.setHasPermission(
+            address(controller),
+            alice,
+            RETRY_MESSAGE_PERMISSION_ID,
+            true
+        );
+        daoMock.setHasPermission(
+            address(controller),
+            alice,
+            SWEEP_PERMISSION_ID,
+            true
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -143,21 +145,25 @@ contract CrossChainControllerTest is Test {
 
     function _lane(
         address _local,
-        address _remote,
-        uint64 _bridgeChainId
+        address _remote
     ) internal pure returns (CrossChainController.ChainConfig memory) {
-        return CrossChainController.ChainConfig({
-            localAdapter: _local,
-            remoteAdapter: _remote,
-            bridgeChainId: _bridgeChainId
-        });
+        return
+            CrossChainController.ChainConfig({
+                localAdapter: _local,
+                remoteAdapter: _remote
+            });
     }
 
-    function _configureLane(uint256 _chainId, address _local, address _remote, uint64 _bridgeChainId) internal {
+    function _configureLane(
+        uint256 _chainId,
+        address _local,
+        address _remote
+    ) internal {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = _chainId;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
-        configs[0] = _lane(_local, _remote, _bridgeChainId);
+        CrossChainController.ChainConfig[]
+            memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(_local, _remote);
 
         vm.prank(alice);
         controller.updateConfig(chainIds, configs);
@@ -174,7 +180,9 @@ contract CrossChainControllerTest is Test {
     ///      TWO words: word 0 holds `localAdapter`; word 1 packs
     ///      `remoteAdapter` (low 20 bytes) with `bridgeChainId` (next 8
     ///      bytes). This returns word 0's slot; word 1 is `+ 1`.
-    function _chainConfigSlot(uint256 _chainId) internal pure returns (bytes32) {
+    function _chainConfigSlot(
+        uint256 _chainId
+    ) internal pure returns (bytes32) {
         return keccak256(abi.encode(_chainId, uint256(0)));
     }
 
@@ -189,36 +197,69 @@ contract CrossChainControllerTest is Test {
 
     function test_receiveMessage_revertsForCallerNotLocalAdapter() public {
         address random = makeAddr("random");
-        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, random));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.CALLER_NOT_LOCAL_ADAPTER.selector,
+                random
+            )
+        );
         vm.prank(random);
-        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
+        controller.receiveMessage(
+            bytes32(uint256(1)),
+            _emptyActionsPayload(),
+            CHAIN_ID
+        );
     }
 
     function test_receiveMessage_revertsForUnregisteredContract() public {
         // A deployed contract that was never configured as a lane's local
         // adapter is just as unauthorized as an EOA.
-        AdapterMock strangerAdapter =
-            new AdapterMock(address(controller), address(0), 0, bytes32(0), feeSinkA, false, false);
-        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(strangerAdapter)));
+        AdapterMock strangerAdapter = new AdapterMock(
+            address(controller),
+            address(0),
+            0,
+            bytes32(0),
+            feeSinkA,
+            false,
+            false
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.CALLER_NOT_LOCAL_ADAPTER.selector,
+                address(strangerAdapter)
+            )
+        );
         vm.prank(address(strangerAdapter));
-        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
+        controller.receiveMessage(
+            bytes32(uint256(1)),
+            _emptyActionsPayload(),
+            CHAIN_ID
+        );
     }
 
     function test_receiveMessage_succeedsForRegisteredLocalAdapter() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
 
         bytes32 messageId = bytes32(uint256(42));
         vm.prank(address(adapterA));
-        bytes32 callId = controller.receiveMessage(messageId, _emptyActionsPayload(), CHAIN_ID);
+        bytes32 callId = controller.receiveMessage(
+            messageId,
+            _emptyActionsPayload(),
+            CHAIN_ID
+        );
 
         assertEq(callId, controller.deriveCallId(CHAIN_ID, messageId));
     }
 
     function test_receiveMessage_revertsIfMessageAlreadyPending() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
 
         Action[] memory actions = new Action[](1);
-        actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
+        actions[0] = Action({
+            to: address(actionTarget),
+            value: 0,
+            data: abi.encodeCall(ActionExecute.fail, ())
+        });
         bytes memory payload = abi.encode(actions);
 
         bytes32 messageId = bytes32(uint256(7));
@@ -230,7 +271,12 @@ contract CrossChainControllerTest is Test {
 
         // Redelivering the same (originChainId, messageId) while the first
         // attempt is still pending must revert, not overwrite/duplicate it.
-        vm.expectRevert(abi.encodeWithSelector(Errors.MESSAGE_ALREADY_PENDING.selector, callId));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.MESSAGE_ALREADY_PENDING.selector,
+                callId
+            )
+        );
         vm.prank(address(adapterA));
         controller.receiveMessage(messageId, payload, CHAIN_ID);
     }
@@ -240,65 +286,113 @@ contract CrossChainControllerTest is Test {
     // -------------------------------------------------------------------------
 
     function test_updateConfig_rotatingLocalAdapterRevokesOldAdapter() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
 
         vm.prank(address(adapterA));
-        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
+        controller.receiveMessage(
+            bytes32(uint256(1)),
+            _emptyActionsPayload(),
+            CHAIN_ID
+        );
 
         // Rotate the lane to adapterB.
-        _configureLane(CHAIN_ID, address(adapterB), remoteAdapterB, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(adapterB), remoteAdapterB);
 
-        assertFalse(controller.isRegisteredLocalAdapter(address(adapterA)));
-        assertEq(controller.localAdapterLaneCount(address(adapterA)), 0);
+        assertFalse(
+            controller.isRegisteredLocalAdapter(address(adapterA), CHAIN_ID)
+        );
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(adapterA)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.CALLER_NOT_LOCAL_ADAPTER.selector,
+                address(adapterA)
+            )
+        );
         vm.prank(address(adapterA));
-        controller.receiveMessage(bytes32(uint256(2)), _emptyActionsPayload(), CHAIN_ID);
+        controller.receiveMessage(
+            bytes32(uint256(2)),
+            _emptyActionsPayload(),
+            CHAIN_ID
+        );
 
         // The new adapter works.
         vm.prank(address(adapterB));
-        controller.receiveMessage(bytes32(uint256(3)), _emptyActionsPayload(), CHAIN_ID);
+        controller.receiveMessage(
+            bytes32(uint256(3)),
+            _emptyActionsPayload(),
+            CHAIN_ID
+        );
     }
 
-    function test_updateConfig_refcountKeepsAdapterAuthorizedUntilBothLanesCleared() public {
+    function test_updateConfig_refcountKeepsAdapterAuthorizedUntilBothLanesCleared()
+        public
+    {
         // adapterA serves two lanes.
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
-        _configureLane(OTHER_CHAIN_ID, address(adapterA), remoteAdapterB, OTHER_BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(OTHER_CHAIN_ID, address(adapterA), remoteAdapterB);
 
-        assertEq(controller.localAdapterLaneCount(address(adapterA)), 2);
-        assertTrue(controller.isRegisteredLocalAdapter(address(adapterA)));
+        assertTrue(
+            controller.isRegisteredLocalAdapter(address(adapterA), CHAIN_ID)
+        );
 
         // Clear the first lane only; adapterA must remain authorized.
-        _configureLane(CHAIN_ID, address(0), address(0), 0);
+        _configureLane(CHAIN_ID, address(0), address(0));
 
-        assertEq(controller.localAdapterLaneCount(address(adapterA)), 1);
-        assertTrue(controller.isRegisteredLocalAdapter(address(adapterA)));
+        assertTrue(
+            controller.isRegisteredLocalAdapter(
+                address(adapterA),
+                OTHER_CHAIN_ID
+            )
+        );
 
         vm.prank(address(adapterA));
-        controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), OTHER_CHAIN_ID);
+        controller.receiveMessage(
+            bytes32(uint256(1)),
+            _emptyActionsPayload(),
+            OTHER_CHAIN_ID
+        );
 
         // Clear the second (last) lane; adapterA now loses authorization.
-        _configureLane(OTHER_CHAIN_ID, address(0), address(0), 0);
+        _configureLane(OTHER_CHAIN_ID, address(0), address(0));
 
-        assertEq(controller.localAdapterLaneCount(address(adapterA)), 0);
-        assertFalse(controller.isRegisteredLocalAdapter(address(adapterA)));
+        assertFalse(
+            controller.isRegisteredLocalAdapter(
+                address(adapterA),
+                OTHER_CHAIN_ID
+            )
+        );
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(adapterA)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.CALLER_NOT_LOCAL_ADAPTER.selector,
+                address(adapterA)
+            )
+        );
         vm.prank(address(adapterA));
-        controller.receiveMessage(bytes32(uint256(2)), _emptyActionsPayload(), OTHER_CHAIN_ID);
+        controller.receiveMessage(
+            bytes32(uint256(2)),
+            _emptyActionsPayload(),
+            OTHER_CHAIN_ID
+        );
     }
 
-    function test_updateConfig_clearingLaneWithAllZeroConfigResetsMapping() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
-        _configureLane(CHAIN_ID, address(0), address(0), 0);
+    function test_updateConfig_clearingLaneWithAllZeroConfigResetsMapping()
+        public
+    {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(0), address(0));
 
-        (address local, address remote, uint64 bridgeChainId) = controller.chainToAdapter(CHAIN_ID);
+        (address local, address remote) = controller.chainToAdapter(CHAIN_ID);
         assertEq(local, address(0));
         assertEq(remote, address(0));
-        assertEq(bridgeChainId, 0);
 
         // A cleared lane is "unconfigured" again for sends.
-        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.ADAPTER_NOT_CONFIGURED.selector,
+                CHAIN_ID
+            )
+        );
         vm.prank(alice);
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
     }
@@ -311,8 +405,9 @@ contract CrossChainControllerTest is Test {
         uint256[] memory chainIds = new uint256[](2);
         chainIds[0] = CHAIN_ID;
         chainIds[1] = OTHER_CHAIN_ID;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
-        configs[0] = _lane(address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        CrossChainController.ChainConfig[]
+            memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), remoteAdapterA);
 
         vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
         vm.prank(alice);
@@ -322,49 +417,49 @@ contract CrossChainControllerTest is Test {
     function test_updateConfig_revertsOnZeroChainId() public {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = 0;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
-        configs[0] = _lane(address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        CrossChainController.ChainConfig[]
+            memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), remoteAdapterA);
 
         vm.expectRevert(Errors.INVALID_CHAIN_ID.selector);
         vm.prank(alice);
         controller.updateConfig(chainIds, configs);
     }
 
-    function test_updateConfig_revertsOnHalfConfiguredLane_missingRemote() public {
+    function test_updateConfig_revertsOnHalfConfiguredLane_missingRemote()
+        public
+    {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = CHAIN_ID;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
-        configs[0] = _lane(address(adapterA), address(0), BRIDGE_CHAIN_ID);
+        CrossChainController.ChainConfig[]
+            memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), address(0));
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.INCOMPLETE_ADAPTER_CONFIG.selector,
+                CHAIN_ID
+            )
+        );
         vm.prank(alice);
         controller.updateConfig(chainIds, configs);
     }
 
-    function test_updateConfig_revertsOnHalfConfiguredLane_missingLocal() public {
+    function test_updateConfig_revertsOnHalfConfiguredLane_missingLocal()
+        public
+    {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = CHAIN_ID;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
-        configs[0] = _lane(address(0), remoteAdapterA, BRIDGE_CHAIN_ID);
+        CrossChainController.ChainConfig[]
+            memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(0), remoteAdapterA);
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
-        vm.prank(alice);
-        controller.updateConfig(chainIds, configs);
-    }
-
-    /// @dev NEW dimension introduced by `ChainConfig` gaining `bridgeChainId`:
-    ///      adapters set but the bridge-native id left at `0` is just as much
-    ///      a half-configured lane as a missing address would be -- `0` is
-    ///      the "unset" marker and would otherwise silently address bridge
-    ///      lane `0`. See `m)` below for the complementary "already stored,
-    ///      then zeroed by hand" scenario.
-    function test_updateConfig_revertsOnHalfConfiguredLane_missingBridgeChainId() public {
-        uint256[] memory chainIds = new uint256[](1);
-        chainIds[0] = CHAIN_ID;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
-        configs[0] = _lane(address(adapterA), remoteAdapterA, 0);
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.INCOMPLETE_ADAPTER_CONFIG.selector,
+                CHAIN_ID
+            )
+        );
         vm.prank(alice);
         controller.updateConfig(chainIds, configs);
     }
@@ -372,12 +467,17 @@ contract CrossChainControllerTest is Test {
     function test_updateConfig_revertsIfCallerUnauthorized() public {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = CHAIN_ID;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
-        configs[0] = _lane(address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        CrossChainController.ChainConfig[]
+            memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), remoteAdapterA);
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                DaoUnauthorized.selector, address(daoMock), address(controller), bob, UPDATE_CONFIG_PERMISSION_ID
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(controller),
+                bob,
+                UPDATE_CONFIG_PERMISSION_ID
             )
         );
         vm.prank(bob);
@@ -387,11 +487,12 @@ contract CrossChainControllerTest is Test {
     function test_updateConfig_emitsConfigUpdatedWithCorrectPayload() public {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = CHAIN_ID;
-        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
-        configs[0] = _lane(address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        CrossChainController.ChainConfig[]
+            memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), remoteAdapterA);
 
         vm.expectEmit(true, false, false, true, address(controller));
-        emit ConfigUpdated(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        emit ConfigUpdated(CHAIN_ID, address(adapterA), remoteAdapterA);
 
         vm.prank(alice);
         controller.updateConfig(chainIds, configs);
@@ -411,27 +512,27 @@ contract CrossChainControllerTest is Test {
     // `(bytes32, address, uint256)`.
 
     function test_forwardMessage_revertsIfChainNotConfigured() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
-        vm.prank(alice);
-        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
-    }
-
-    function test_forwardMessage_revertsIfLocalAdapterHasNoCode() public {
-        address codelessAdapter = makeAddr("codelessAdapter");
-        address codelessRemote = makeAddr("codelessRemote");
-        _configureLane(CHAIN_ID, codelessAdapter, codelessRemote, BRIDGE_CHAIN_ID);
-
-        assertEq(codelessAdapter.code.length, 0);
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_HAS_NO_CODE.selector, codelessAdapter));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.ADAPTER_NOT_CONFIGURED.selector,
+                CHAIN_ID
+            )
+        );
         vm.prank(alice);
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
     }
 
     function test_forwardMessage_bubblesAdapterRevertReasonVerbatim() public {
-        AdapterMock revertingAdapter =
-            new AdapterMock(address(controller), address(0), 0, bytes32(0), feeSinkA, true, false);
-        _configureLane(CHAIN_ID, address(revertingAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        AdapterMock revertingAdapter = new AdapterMock(
+            address(controller),
+            address(0),
+            0,
+            bytes32(0),
+            feeSinkA,
+            true,
+            false
+        );
+        _configureLane(CHAIN_ID, address(revertingAdapter), remoteAdapterA);
 
         // `AdapterMock` reverts with a plain string reason; `forwardMessage`
         // must bubble that exact reason rather than swallowing it.
@@ -440,9 +541,11 @@ contract CrossChainControllerTest is Test {
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
     }
 
-    function test_forwardMessage_revertsWithMessageSendFailed_whenAdapterFailsWithNoReturnData() public {
+    function test_forwardMessage_revertsWithMessageSendFailed_whenAdapterFailsWithNoReturnData()
+        public
+    {
         RevertNoReasonAdapterStub badAdapter = new RevertNoReasonAdapterStub();
-        _configureLane(CHAIN_ID, address(badAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(badAdapter), remoteAdapterA);
 
         vm.expectRevert(Errors.MESSAGE_SEND_FAILED.selector);
         vm.prank(alice);
@@ -453,9 +556,11 @@ contract CrossChainControllerTest is Test {
     ///      cannot possibly be a valid `(bytes32 messageId, address feeToken,
     ///      uint256 fee)` triple. `forwardMessage` must fail loudly here too,
     ///      not `abi.decode` garbage and emit `MessageForwarded` with junk.
-    function test_forwardMessage_revertsWithMessageSendFailed_whenAdapterReturnsMalformedData() public {
+    function test_forwardMessage_revertsWithMessageSendFailed_whenAdapterReturnsMalformedData()
+        public
+    {
         ShortReturnAdapterStub badAdapter = new ShortReturnAdapterStub();
-        _configureLane(CHAIN_ID, address(badAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(badAdapter), remoteAdapterA);
 
         vm.expectRevert(Errors.MESSAGE_SEND_FAILED.selector);
         vm.prank(alice);
@@ -467,36 +572,45 @@ contract CrossChainControllerTest is Test {
     // -------------------------------------------------------------------------
 
     function test_forwardMessage_revertsIfCallerUnauthorized() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                DaoUnauthorized.selector, address(daoMock), address(controller), bob, FORWARD_MESSAGE_PERMISSION_ID
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(controller),
+                bob,
+                FORWARD_MESSAGE_PERMISSION_ID
             )
         );
         vm.prank(bob);
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
     }
 
-    function test_forwardMessage_happyPathEmitsMessageForwardedAndReturnsMessageId() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+    function test_forwardMessage_happyPathEmitsMessageForwardedAndReturnsMessageId()
+        public
+    {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
         bytes32 expectedMessageId = bytes32(uint256(1)); // adapterA's immutable messageId, set in setUp
 
         bytes memory message = abi.encode("hello");
 
-        // Emitted from inside the delegatecalled adapter code -- under
-        // delegatecall the log's address is the CONTROLLER (see the event
-        // redeclaration comment above), and `bridgeChainId`/`receiver` here
-        // are exactly what the controller supplied as arguments, proving
-        // they reached the adapter correctly.
         vm.expectEmit(true, true, true, true, address(controller));
-        emit SendMessageCalled(address(controller), remoteAdapterA, BRIDGE_CHAIN_ID, GAS_LIMIT, message, 0);
-
-        vm.expectEmit(true, true, true, true, address(controller));
-        emit MessageForwarded(CHAIN_ID, expectedMessageId, address(adapterA), remoteAdapterA, GAS_LIMIT, address(0), 0);
+        emit MessageForwarded(
+            CHAIN_ID,
+            expectedMessageId,
+            address(adapterA),
+            remoteAdapterA,
+            GAS_LIMIT,
+            0
+        );
 
         vm.prank(alice);
-        bytes32 messageId = controller.forwardMessage(CHAIN_ID, GAS_LIMIT, message);
+        bytes32 messageId = controller.forwardMessage(
+            CHAIN_ID,
+            GAS_LIMIT,
+            message
+        );
 
         assertEq(messageId, expectedMessageId);
     }
@@ -514,23 +628,47 @@ contract CrossChainControllerTest is Test {
     // own balance never moves at all -- there is nothing to hand over and
     // nothing that could be stranded on the adapter.
 
-    function test_forwardMessage_nativeFee_revertsIfControllerBalanceInsufficient() public {
-        AdapterMock nativeFeeAdapter =
-            new AdapterMock(address(controller), address(0), 1 ether, bytes32(uint256(3)), feeSinkA, false, false);
-        _configureLane(CHAIN_ID, address(nativeFeeAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+    function test_forwardMessage_nativeFee_revertsIfControllerBalanceInsufficient()
+        public
+    {
+        AdapterMock nativeFeeAdapter = new AdapterMock(
+            address(controller),
+            address(0),
+            1 ether,
+            bytes32(uint256(3)),
+            feeSinkA,
+            false,
+            false
+        );
+        _configureLane(CHAIN_ID, address(nativeFeeAdapter), remoteAdapterA);
         // Controller holds 0 native.
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(0), 1 ether, 0));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.INSUFFICIENT_FEE_BALANCE.selector,
+                address(0),
+                1 ether,
+                0
+            )
+        );
         vm.prank(alice);
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
     }
 
-    function test_forwardMessage_nativeFee_feeMovesDirectlyFromControllerToSink_adapterBalanceUntouched() public {
+    function test_forwardMessage_nativeFee_feeMovesDirectlyFromControllerToSink_adapterBalanceUntouched()
+        public
+    {
         uint256 requiredFee = 1 ether;
         AdapterMock nativeFeeAdapter = new AdapterMock(
-            address(controller), address(0), requiredFee, bytes32(uint256(3)), feeSinkA, false, false
+            address(controller),
+            address(0),
+            requiredFee,
+            bytes32(uint256(3)),
+            feeSinkA,
+            false,
+            false
         );
-        _configureLane(CHAIN_ID, address(nativeFeeAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(nativeFeeAdapter), remoteAdapterA);
         vm.deal(address(controller), requiredFee + 3 ether); // extra buffer left untouched
 
         vm.prank(alice);
@@ -543,26 +681,47 @@ contract CrossChainControllerTest is Test {
         assertEq(address(nativeFeeAdapter).balance, 0);
     }
 
-    function test_forwardMessage_erc20Fee_revertsIfControllerBalanceInsufficient() public {
+    function test_forwardMessage_erc20Fee_revertsIfControllerBalanceInsufficient()
+        public
+    {
         AdapterMock erc20FeeAdapter = new AdapterMock(
-            address(controller), address(feeToken), 100 ether, bytes32(uint256(4)), feeSinkB, false, false
+            address(controller),
+            address(feeToken),
+            100 ether,
+            bytes32(uint256(4)),
+            feeSinkB,
+            false,
+            false
         );
-        _configureLane(CHAIN_ID, address(erc20FeeAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(erc20FeeAdapter), remoteAdapterA);
         // Controller holds 0 of feeToken.
 
         vm.expectRevert(
-            abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(feeToken), 100 ether, 0)
+            abi.encodeWithSelector(
+                Errors.INSUFFICIENT_FEE_BALANCE.selector,
+                address(feeToken),
+                100 ether,
+                0
+            )
         );
         vm.prank(alice);
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
     }
 
-    function test_forwardMessage_erc20Fee_feeMovesDirectlyFromControllerToSink_adapterBalanceUntouched() public {
+    function test_forwardMessage_erc20Fee_feeMovesDirectlyFromControllerToSink_adapterBalanceUntouched()
+        public
+    {
         uint256 requiredFee = 100 ether;
         AdapterMock erc20FeeAdapter = new AdapterMock(
-            address(controller), address(feeToken), requiredFee, bytes32(uint256(4)), feeSinkB, false, false
+            address(controller),
+            address(feeToken),
+            requiredFee,
+            bytes32(uint256(4)),
+            feeSinkB,
+            false,
+            false
         );
-        _configureLane(CHAIN_ID, address(erc20FeeAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(erc20FeeAdapter), remoteAdapterA);
         feeToken.setBalance(address(controller), requiredFee + 1 ether); // extra buffer left untouched
 
         vm.prank(alice);
@@ -579,11 +738,17 @@ contract CrossChainControllerTest is Test {
     // g) Defensive receive / retry
     // -------------------------------------------------------------------------
 
-    function test_receiveMessage_capturesRevertingPayloadInsteadOfReverting() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+    function test_receiveMessage_capturesRevertingPayloadInsteadOfReverting()
+        public
+    {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
 
         Action[] memory actions = new Action[](1);
-        actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
+        actions[0] = Action({
+            to: address(actionTarget),
+            value: 0,
+            data: abi.encodeCall(ActionExecute.fail, ())
+        });
         bytes memory payload = abi.encode(actions);
 
         bytes32 messageId = bytes32(uint256(55));
@@ -591,24 +756,39 @@ contract CrossChainControllerTest is Test {
         // `CrossChainControllerDAOMock.execute` bubbles the low-level call's
         // raw returndata on failure, which is `ActionExecute.fail`'s
         // `Error(string)`-encoded revert reason.
-        bytes memory expectedReason = abi.encodeWithSignature("Error(string)", "ActionExecute:Revert");
+        bytes memory expectedReason = abi.encodeWithSignature(
+            "Error(string)",
+            "ActionExecute:Revert"
+        );
 
         vm.expectEmit(true, true, true, true, address(controller));
-        emit MessageExecutionFailed(CHAIN_ID, messageId, expectedCallId, expectedReason);
+        emit MessageExecutionFailed(
+            CHAIN_ID,
+            messageId,
+            expectedCallId,
+            expectedReason
+        );
 
         vm.prank(address(adapterA));
-        bytes32 callId = controller.receiveMessage(messageId, payload, CHAIN_ID); // must NOT revert
+        bytes32 callId = controller.receiveMessage(
+            messageId,
+            payload,
+            CHAIN_ID
+        ); // must NOT revert
         assertEq(callId, expectedCallId);
 
-        CrossChainController.FailedMessage memory failed = controller.getFailedMessage(callId);
+        CrossChainController.FailedMessage memory failed = controller
+            .getFailedMessage(callId);
         assertTrue(failed.pending);
         assertEq(failed.originChainId, CHAIN_ID);
         assertEq(failed.messageId, messageId);
         assertEq(failed.payload, payload);
     }
 
-    function test_receiveMessage_capturesMalformedPayloadInsteadOfReverting() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+    function test_receiveMessage_capturesMalformedPayloadInsteadOfReverting()
+        public
+    {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
 
         // Not a valid ABI-encoding of `Action[]`.
         bytes memory garbage = hex"deadbeef";
@@ -623,18 +803,26 @@ contract CrossChainControllerTest is Test {
         emit MessageExecutionFailed(CHAIN_ID, messageId, expectedCallId, "");
 
         vm.prank(address(adapterA));
-        bytes32 callId = controller.receiveMessage(messageId, garbage, CHAIN_ID); // must NOT revert
+        bytes32 callId = controller.receiveMessage(
+            messageId,
+            garbage,
+            CHAIN_ID
+        ); // must NOT revert
         assertEq(callId, expectedCallId);
         assertTrue(controller.getFailedMessage(callId).pending);
     }
 
     function test_retryFailedMessage_revertsIfCallerUnauthorized() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
         bytes32 callId = _causeFailure(bytes32(uint256(60)));
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                DaoUnauthorized.selector, address(daoMock), address(controller), bob, RETRY_MESSAGE_PERMISSION_ID
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(controller),
+                bob,
+                RETRY_MESSAGE_PERMISSION_ID
             )
         );
         vm.prank(bob);
@@ -643,17 +831,28 @@ contract CrossChainControllerTest is Test {
 
     function test_retryFailedMessage_revertsForUnknownCallId() public {
         bytes32 unknownCallId = keccak256("nope");
-        vm.expectRevert(abi.encodeWithSelector(Errors.NO_FAILED_MESSAGE.selector, unknownCallId));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.NO_FAILED_MESSAGE.selector,
+                unknownCallId
+            )
+        );
         vm.prank(alice);
         controller.retryFailedMessage(unknownCallId);
     }
 
-    function test_retryFailedMessage_succeedsOnceFailureConditionRemoved() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+    function test_retryFailedMessage_succeedsOnceFailureConditionRemoved()
+        public
+    {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
 
         FlakyTarget flaky = new FlakyTarget();
         Action[] memory actions = new Action[](1);
-        actions[0] = Action({to: address(flaky), value: 0, data: abi.encodeCall(FlakyTarget.maybeRevert, ())});
+        actions[0] = Action({
+            to: address(flaky),
+            value: 0,
+            data: abi.encodeCall(FlakyTarget.maybeRevert, ())
+        });
         bytes memory payload = abi.encode(actions);
 
         bytes32 messageId = bytes32(uint256(61));
@@ -672,16 +871,23 @@ contract CrossChainControllerTest is Test {
         vm.prank(alice);
         controller.retryFailedMessage(callId);
 
-        CrossChainController.FailedMessage memory cleared = controller.getFailedMessage(callId);
+        CrossChainController.FailedMessage memory cleared = controller
+            .getFailedMessage(callId);
         assertFalse(cleared.pending);
         assertTrue(flaky.wasCalled());
     }
 
     /// @dev Delivers a message whose payload always fails, leaving a stored
     ///      `FailedMessage` at the returned call id.
-    function _causeFailure(bytes32 _messageId) internal returns (bytes32 callId) {
+    function _causeFailure(
+        bytes32 _messageId
+    ) internal returns (bytes32 callId) {
         Action[] memory actions = new Action[](1);
-        actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
+        actions[0] = Action({
+            to: address(actionTarget),
+            value: 0,
+            data: abi.encodeCall(ActionExecute.fail, ())
+        });
         bytes memory payload = abi.encode(actions);
 
         vm.prank(address(adapterA));
@@ -693,7 +899,12 @@ contract CrossChainControllerTest is Test {
     // -------------------------------------------------------------------------
 
     function test_executeActions_revertsIfCallerNotSelf() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_SELF.selector, address(this)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.CALLER_NOT_SELF.selector,
+                address(this)
+            )
+        );
         controller.executeActions(bytes32(0), _emptyActionsPayload());
     }
 
@@ -703,7 +914,13 @@ contract CrossChainControllerTest is Test {
 
     function test_sweep_revertsIfCallerUnauthorized() public {
         vm.expectRevert(
-            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, SWEEP_PERMISSION_ID)
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector,
+                address(daoMock),
+                address(controller),
+                bob,
+                SWEEP_PERMISSION_ID
+            )
         );
         vm.prank(bob);
         controller.sweep(address(0), bob, 1 ether);
@@ -755,10 +972,16 @@ contract CrossChainControllerTest is Test {
         assertEq(callId1, callId2);
         assertEq(callId1, keccak256(abi.encode(CHAIN_ID, messageId)));
 
-        bytes32 differentChain = controller.deriveCallId(OTHER_CHAIN_ID, messageId);
+        bytes32 differentChain = controller.deriveCallId(
+            OTHER_CHAIN_ID,
+            messageId
+        );
         assertTrue(callId1 != differentChain);
 
-        bytes32 differentMessage = controller.deriveCallId(CHAIN_ID, bytes32(uint256(124)));
+        bytes32 differentMessage = controller.deriveCallId(
+            CHAIN_ID,
+            bytes32(uint256(124))
+        );
         assertTrue(callId1 != differentMessage);
     }
 
@@ -776,18 +999,25 @@ contract CrossChainControllerTest is Test {
     // assert byte-for-byte equality, plus the equivalent public getters.
 
     function test_forwardMessage_doesNotCollideWithControllerStorage() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
 
         // Bundled into arrays / a single hash on purpose: enough distinct
         // named locals here (six raw slots, the three `ChainConfig` fields
         // twice over, plus lane-count/registration) trips solc 0.8.17's
         // "stack too deep" with the optimizer configuration this repo pins.
-        bytes32[] memory slots = _controllerSnapshotSlots(CHAIN_ID, address(adapterA));
+        bytes32[] memory slots = _controllerSnapshotSlots(
+            CHAIN_ID,
+            address(adapterA)
+        );
         bytes32[] memory valuesBefore = _loadAll(slots);
         bytes32 gettersHashBefore = _gettersHash(CHAIN_ID, address(adapterA));
 
         vm.prank(alice);
-        bytes32 messageId = controller.forwardMessage(CHAIN_ID, GAS_LIMIT, abi.encode("no collision"));
+        bytes32 messageId = controller.forwardMessage(
+            CHAIN_ID,
+            GAS_LIMIT,
+            abi.encode("no collision")
+        );
         // Sanity: the send actually happened, this isn't vacuously true.
         assertEq(messageId, bytes32(uint256(1)));
 
@@ -816,7 +1046,9 @@ contract CrossChainControllerTest is Test {
         slots[5] = _laneCountSlot(_adapter);
     }
 
-    function _loadAll(bytes32[] memory _slots) internal view returns (bytes32[] memory values) {
+    function _loadAll(
+        bytes32[] memory _slots
+    ) internal view returns (bytes32[] memory values) {
         values = new bytes32[](_slots.length);
         for (uint256 i = 0; i < _slots.length; i++) {
             values[i] = vm.load(address(controller), _slots[i]);
@@ -825,17 +1057,19 @@ contract CrossChainControllerTest is Test {
 
     /// @dev Collapses every public getter relevant to a lane/adapter into one
     ///      hash, so before/after comparisons need one local instead of five.
-    function _gettersHash(uint256 _chainId, address _adapter) internal view returns (bytes32) {
-        (address local, address remote, uint64 bridgeChainId) = controller.chainToAdapter(_chainId);
-        return keccak256(
-            abi.encode(
-                local,
-                remote,
-                bridgeChainId,
-                controller.localAdapterLaneCount(_adapter),
-                controller.isRegisteredLocalAdapter(_adapter)
-            )
-        );
+    function _gettersHash(
+        uint256 _chainId,
+        address _adapter
+    ) internal view returns (bytes32) {
+        (address local, address remote) = controller.chainToAdapter(_chainId);
+        return
+            keccak256(
+                abi.encode(
+                    local,
+                    remote,
+                    controller.isRegisteredLocalAdapter(_adapter, _chainId)
+                )
+            );
     }
 
     // -------------------------------------------------------------------------
@@ -843,7 +1077,9 @@ contract CrossChainControllerTest is Test {
     //    delegatecall, not the controller's storage
     // -------------------------------------------------------------------------
 
-    function test_forwardMessage_immutablesResolveToConfiguredAdapter_notTheOtherOne_notZero() public {
+    function test_forwardMessage_immutablesResolveToConfiguredAdapter_notTheOtherOne_notZero()
+        public
+    {
         address sinkX = makeAddr("sinkX");
         address sinkY = makeAddr("sinkY");
         bytes32 messageIdX = bytes32(uint256(111));
@@ -852,11 +1088,26 @@ contract CrossChainControllerTest is Test {
         // adapterX: native fee. adapterY: ERC20 fee, different amount,
         // different messageId, different sink. Only adapterX is ever wired
         // into a lane.
-        AdapterMock adapterX = new AdapterMock(address(controller), address(0), 1 ether, messageIdX, sinkX, false, false);
-        AdapterMock adapterY =
-            new AdapterMock(address(controller), address(feeToken), 2 ether, messageIdY, sinkY, false, false);
+        AdapterMock adapterX = new AdapterMock(
+            address(controller),
+            address(0),
+            1 ether,
+            messageIdX,
+            sinkX,
+            false,
+            false
+        );
+        AdapterMock adapterY = new AdapterMock(
+            address(controller),
+            address(feeToken),
+            2 ether,
+            messageIdY,
+            sinkY,
+            false,
+            false
+        );
 
-        _configureLane(CHAIN_ID, address(adapterX), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(adapterX), remoteAdapterA);
 
         // Fund the controller for BOTH adapters' fees, so a bug that read
         // adapterY's immutables (or the controller's own storage, which has
@@ -867,7 +1118,11 @@ contract CrossChainControllerTest is Test {
         feeToken.setBalance(address(controller), 2 ether);
 
         vm.prank(alice);
-        bytes32 messageId = controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+        bytes32 messageId = controller.forwardMessage(
+            CHAIN_ID,
+            GAS_LIMIT,
+            _emptyActionsPayload()
+        );
 
         assertEq(messageId, messageIdX);
         assertTrue(messageId != messageIdY);
@@ -886,87 +1141,47 @@ contract CrossChainControllerTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // m) NEW -- an unconfigured/zeroed bridgeChainId can never silently send
-    //    to bridge lane 0
-    // -------------------------------------------------------------------------
-    //
-    // `test_updateConfig_revertsOnHalfConfiguredLane_missingBridgeChainId`
-    // above already proves `updateConfig` rejects `bridgeChainId == 0` with
-    // adapters set. This section proves the second half: even if a lane's
-    // packed word were force-corrupted to zero the `bridgeChainId` bits
-    // directly in storage (bypassing `updateConfig` entirely), the send path
-    // still refuses to dispatch rather than silently addressing selector `0`.
-
-    function test_forwardMessage_revertsIfBridgeChainIdZeroedDirectlyInStorage() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
-
-        bytes32 configWord1Slot = bytes32(uint256(_chainConfigSlot(CHAIN_ID)) + 1);
-        bytes32 packed = vm.load(address(controller), configWord1Slot);
-
-        // Word 1 is `remoteAdapter` (low 160 bits) | `bridgeChainId` (next 64
-        // bits) | padding. Keep the low 160 bits (remoteAdapter), zero
-        // everything above (bridgeChainId + padding).
-        bytes32 zeroedBridgeChainId = bytes32(uint256(packed) & ((uint256(1) << 160) - 1));
-        vm.store(address(controller), configWord1Slot, zeroedBridgeChainId);
-
-        (address local, address remote, uint64 bridgeChainId) = controller.chainToAdapter(CHAIN_ID);
-        assertEq(local, address(adapterA)); // untouched
-        assertEq(remote, remoteAdapterA); // untouched
-        assertEq(bridgeChainId, 0); // corrupted to the "unset" marker
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
-        vm.prank(alice);
-        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
-    }
-
-    // -------------------------------------------------------------------------
     // n) NEW -- an adapter's send path refuses to run outside a delegatecall
     //    from its owning controller
     // -------------------------------------------------------------------------
 
-    function test_adapterSendMessage_revertsIfCalledDirectlyNotViaControllerDelegatecall() public {
+    function test_adapterSendMessage_revertsIfCalledDirectlyNotViaControllerDelegatecall()
+        public
+    {
         // Calling `adapterA.sendMessage(...)` directly (a normal `call`, not
         // a `delegatecall` from `controller`) means `address(this)` inside
         // the adapter's code is the ADAPTER itself, which the guard rejects:
         // using the adapter's own (empty) balance and having the bridge see
         // the adapter -- not the controller -- as sender would be wrong.
-        vm.expectRevert(abi.encodeWithSelector(Errors.SEND_PATH_NOT_DELEGATECALLED.selector, address(adapterA)));
-        adapterA.sendMessage(remoteAdapterA, BRIDGE_CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SEND_PATH_NOT_DELEGATECALLED.selector,
+                address(adapterA)
+            )
+        );
+        adapterA.sendMessage(
+            remoteAdapterA,
+            BRIDGE_CHAIN_ID,
+            GAS_LIMIT,
+            _emptyActionsPayload()
+        );
     }
 
-    // -------------------------------------------------------------------------
-    // o) NEW -- residual risk (documentation, not mitigation)
-    // -------------------------------------------------------------------------
-
-    /// @notice DOCUMENTS security-review finding 7. This is EXPECTED,
-    ///         ACCEPTED behaviour of the `delegatecall` send design -- it is
-    ///         NOT a bug for the contract to fix, and this test is not
-    ///         supposed to ever start failing as a "regression". It exists so
-    ///         that:
-    ///          1. the blast radius of `UPDATE_CONFIG_PERMISSION` is provable
-    ///             rather than asserted in a comment, and
-    ///          2. nobody "fixes" this test by loosening it if a future
-    ///             change accidentally narrows the actual risk -- if this
-    ///             test starts failing because the takeover no longer works,
-    ///             that is a MEANINGFUL change to re-review, not noise.
-    ///
-    ///         See the NatSpec on `CrossChainController.UPDATE_CONFIG_PERMISSION_ID`:
-    ///         this permission is effectively root on the DAO precisely
-    ///         because `forwardMessage` executes the configured local
-    ///         adapter's code in the controller's own context. Whoever can
-    ///         set `localAdapter` can (a) overwrite ANY controller storage
-    ///         slot and (b) make the DAO execute ANY action, since the
-    ///         controller holds `EXECUTE_PERMISSION` on it. The only real
-    ///         mitigation is operational: grant `UPDATE_CONFIG_PERMISSION` to
-    ///         the DAO itself ONLY, reachable exclusively through a passed
-    ///         proposal.
-    function test_residualRisk_maliciousAdapterCanCorruptControllerAndExecuteOnDAO() public {
+    function test_residualRisk_maliciousAdapterCanCorruptControllerAndExecuteOnDAO()
+        public
+    {
         PwnTarget target = new PwnTarget();
-        bytes32 arbitrarySlot = keccak256("some arbitrary controller storage slot");
+        bytes32 arbitrarySlot = keccak256(
+            "some arbitrary controller storage slot"
+        );
         bytes32 arbitraryValue = bytes32(uint256(0xDEADBEEF));
 
         MaliciousAdapterMock evilAdapter = new MaliciousAdapterMock(
-            address(controller), address(daoMock), address(target), arbitrarySlot, arbitraryValue
+            address(controller),
+            address(daoMock),
+            address(target),
+            arbitrarySlot,
+            arbitraryValue
         );
 
         // `CrossChainControllerDAOMock.execute` in this suite performs the
@@ -975,13 +1190,18 @@ contract CrossChainControllerTest is Test {
         // for documentation parity with production, where the controller
         // holding `EXECUTE_PERMISSION` on its DAO is exactly what makes this
         // finding devastating rather than merely embarrassing.
-        daoMock.setHasPermission(address(daoMock), address(controller), keccak256("EXECUTE_PERMISSION"), true);
+        daoMock.setHasPermission(
+            address(daoMock),
+            address(controller),
+            keccak256("EXECUTE_PERMISSION"),
+            true
+        );
 
         // Anyone holding UPDATE_CONFIG_PERMISSION -- alice, per setUp --
         // points a lane at the malicious "adapter". In production this
         // permission must be DAO-only; the contract cannot and does not
         // enforce that itself.
-        _configureLane(CHAIN_ID, address(evilAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(evilAdapter), remoteAdapterA);
 
         assertEq(vm.load(address(controller), arbitrarySlot), bytes32(0));
         assertFalse(target.pwned());
@@ -1025,9 +1245,9 @@ contract FlakyTarget {
 ///      real adapter.
 contract ShortReturnAdapterStub {
     function sendMessage(
-        address, /* receiver */
-        uint64, /* bridgeChainId */
-        uint256, /* gasLimit */
+        address /* receiver */,
+        uint64 /* bridgeChainId */,
+        uint256 /* gasLimit */,
         bytes calldata /* message */
     ) external payable returns (bool) {
         return true;
@@ -1040,9 +1260,9 @@ contract ShortReturnAdapterStub {
 ///      (as opposed to the "reason bubbled verbatim" branch).
 contract RevertNoReasonAdapterStub {
     function sendMessage(
-        address, /* receiver */
-        uint64, /* bridgeChainId */
-        uint256, /* gasLimit */
+        address /* receiver */,
+        uint64 /* bridgeChainId */,
+        uint256 /* gasLimit */,
         bytes calldata /* message */
     ) external payable returns (bytes32, address, uint256) {
         revert();

--- a/test/common/crosschain/CrossChainController.t.sol
+++ b/test/common/crosschain/CrossChainController.t.sol
@@ -3,42 +3,57 @@
 pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {CrossChainController} from "../../../src/common/crosschain/CrossChainController.sol";
 import {Errors} from "../../../src/common/crosschain/lib/Errors.sol";
 import {Action} from "../../../src/common/executors/IExecutor.sol";
 import {DaoUnauthorized} from "../../../src/common/permission/auth/auth.sol";
 import {AdapterMock} from "../../mocks/commons/crosschain/AdapterMock.sol";
+import {
+    MaliciousAdapterMock, PwnTarget
+} from "../../mocks/commons/crosschain/MaliciousAdapterMock.sol";
 import {CrossChainControllerDAOMock} from "../../mocks/commons/crosschain/CrossChainControllerDAOMock.sol";
 import {ERC20Mock} from "../../mocks/commons/token/ERC20Mock.sol";
 import {ActionExecute} from "../../mocks/commons/executors/ActionExecute.sol";
 
-/// @notice Regression suite for the hardened `CrossChainController`
-///         (`src/common/crosschain/CrossChainController.sol`).
+/// @notice Regression suite for the "Option 1" `CrossChainController`
+///         (`src/common/crosschain/CrossChainController.sol`), which sends by
+///         `delegatecall`ing the local adapter instead of `call`ing it. Every
+///         send-path parameter that used to live in adapter storage now lives
+///         in the controller's `chainToAdapter` mapping and is passed as an
+///         argument, so the adapter's send path reads NO storage.
 ///
-/// Every test here targets a specific finding from the security review and is
-/// written to genuinely FAIL against the pre-hardening version of the
-/// contract:
-///  - `receiveMessage` inbound authentication (only a registered local
-///    adapter may call it) and correct refcounted adapter rotation.
-///  - `updateConfig` input validation (length mismatch, chain id 0,
-///    half-configured lanes) and its `ConfigUpdated` event payload.
-///  - The "silent no-op" footgun: `forwardMessage` to an unconfigured chain
-///    or to a codeless local adapter must revert, not silently succeed.
-///  - Fee custody: exact fee amounts moved for both ERC20 and native, and
-///    `INSUFFICIENT_FEE_BALANCE` when underfunded.
-///  - The defensive `try/catch` around inbound execution: a reverting or
-///    malformed payload is captured as a `FailedMessage` instead of
-///    reverting message delivery, and can later be retried.
-///  - `executeActions`'s `CALLER_NOT_SELF` self-call guard.
-///  - `sweep`'s auth check and zero-address guard.
-///  - `deriveCallId` determinism.
+/// Sections a)-j) preserve the pre-redesign coverage (inbound auth, adapter
+/// rotation, `updateConfig` validation, silent-no-op / fail-loudly guards,
+/// forwarding auth + happy path, fees, defensive receive/retry, the
+/// `executeActions` self-call guard, `sweep`, `deriveCallId`), adapted to the
+/// new `ChainConfig{localAdapter, remoteAdapter, bridgeChainId}` shape and to
+/// `AdapterMock` now being immutable-configured (constructor args, no
+/// setters, records calls via `SendMessageCalled` instead of storage).
+///
+/// Sections k)-o) are NEW and are the entire point of this redesign:
+///  k) the controller's own storage is byte-identical before/after a send
+///     (no collision with whatever the delegatecalled adapter code touches);
+///  l) two adapters with different `immutable`s produce provably different
+///     results, proving delegatecall resolves the CALLED adapter's bytecode
+///     immutables, not the controller's storage;
+///  m) an unconfigured/zeroed `bridgeChainId` can never silently address
+///     bridge lane `0`;
+///  n) an adapter's send path refuses to run outside a delegatecall from its
+///     owning controller;
+///  o) the accepted residual risk (security-review finding 7): whoever holds
+///     `UPDATE_CONFIG_PERMISSION` can fully take over the controller and, by
+///     extension, the DAO. This is NOT mitigated in code; it documents why
+///     that permission must be DAO-only.
 contract CrossChainControllerTest is Test {
     // Solc 0.8.17 (this repo's pinned version) cannot `emit Contract.Event(...)`
-    // for an externally-defined event, so the events under test are
-    // redeclared here with identical signatures purely so `vm.expectEmit`
+    // for an externally-defined event, so every event under test is
+    // redeclared here with an IDENTICAL signature purely so `vm.expectEmit`
     // has something to match topics/data against (topic0 only depends on the
     // signature, not on which contract declares it).
-    event ConfigUpdated(uint256 indexed chainId, address localAdapter, address remoteAdapter);
+    event ConfigUpdated(
+        uint256 indexed chainId, address localAdapter, address remoteAdapter, uint64 bridgeChainId
+    );
     event MessageForwarded(
         uint256 indexed destinationChainId,
         bytes32 indexed messageId,
@@ -53,10 +68,22 @@ contract CrossChainControllerTest is Test {
     );
     event MessageRetried(bytes32 indexed callId);
     event Swept(address indexed token, address indexed to, uint256 amount);
+    /// @dev Mirrors `AdapterMock.SendMessageCalled`. IMPORTANT: because
+    ///      `forwardMessage` reaches this via `delegatecall`, the EVM records
+    ///      the log's emitting address as the CONTROLLER, not the adapter
+    ///      (exactly like storage, `LOG*` uses the current execution
+    ///      context's address, which delegatecall does not change). Every
+    ///      `vm.expectEmit` against this event below therefore targets
+    ///      `address(controller)`, never the adapter.
+    event SendMessageCalled(
+        address context, address receiver, uint64 bridgeChainId, uint256 gasLimit, bytes message, uint256 value
+    );
 
     uint256 internal constant CHAIN_ID = 10;
     uint256 internal constant OTHER_CHAIN_ID = 20;
     uint256 internal constant GAS_LIMIT = 200_000;
+    uint64 internal constant BRIDGE_CHAIN_ID = 1000;
+    uint64 internal constant OTHER_BRIDGE_CHAIN_ID = 2000;
 
     CrossChainControllerDAOMock internal daoMock;
     CrossChainController internal controller;
@@ -67,6 +94,8 @@ contract CrossChainControllerTest is Test {
 
     address internal remoteAdapterA;
     address internal remoteAdapterB;
+    address internal feeSinkA;
+    address internal feeSinkB;
     address internal alice; // holds every permission
     address internal bob; // holds none
 
@@ -79,15 +108,23 @@ contract CrossChainControllerTest is Test {
         daoMock = new CrossChainControllerDAOMock();
         controller = new CrossChainController(address(daoMock));
 
-        adapterA = new AdapterMock(address(controller));
-        adapterB = new AdapterMock(address(controller));
         feeToken = new ERC20Mock("Fee", "FEE");
         actionTarget = new ActionExecute();
 
         remoteAdapterA = makeAddr("remoteAdapterA");
         remoteAdapterB = makeAddr("remoteAdapterB");
+        feeSinkA = makeAddr("feeSinkA");
+        feeSinkB = makeAddr("feeSinkB");
         alice = makeAddr("alice");
         bob = makeAddr("bob");
+
+        // Default adapters: zero fee, native. Most tests that aren't
+        // specifically about fee mechanics use these unmodified so they don't
+        // need to fund the controller. `AdapterMock` has no setters -- tests
+        // that need different fee/messageId/feeSink/revert behaviour deploy
+        // their own dedicated instance instead.
+        adapterA = new AdapterMock(address(controller), address(0), 0, bytes32(uint256(1)), feeSinkA, false, false);
+        adapterB = new AdapterMock(address(controller), address(0), 0, bytes32(uint256(2)), feeSinkB, false, false);
 
         FORWARD_MESSAGE_PERMISSION_ID = controller.FORWARD_MESSAGE_PERMISSION_ID();
         UPDATE_CONFIG_PERMISSION_ID = controller.UPDATE_CONFIG_PERMISSION_ID();
@@ -104,22 +141,46 @@ contract CrossChainControllerTest is Test {
     // Helpers
     // -------------------------------------------------------------------------
 
-    function _lane(address _local, address _remote) internal pure returns (CrossChainController.AdapterByChain memory) {
-        return CrossChainController.AdapterByChain({localAdapter: _local, remoteAdapter: _remote});
+    function _lane(
+        address _local,
+        address _remote,
+        uint64 _bridgeChainId
+    ) internal pure returns (CrossChainController.ChainConfig memory) {
+        return CrossChainController.ChainConfig({
+            localAdapter: _local,
+            remoteAdapter: _remote,
+            bridgeChainId: _bridgeChainId
+        });
     }
 
-    function _configureLane(uint256 _chainId, address _local, address _remote) internal {
+    function _configureLane(uint256 _chainId, address _local, address _remote, uint64 _bridgeChainId) internal {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = _chainId;
-        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
-        adapters[0] = _lane(_local, _remote);
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(_local, _remote, _bridgeChainId);
 
         vm.prank(alice);
-        controller.updateConfig(chainIds, adapters);
+        controller.updateConfig(chainIds, configs);
     }
 
     function _emptyActionsPayload() internal pure returns (bytes memory) {
         return abi.encode(new Action[](0));
+    }
+
+    /// @dev Storage layout, verified with
+    ///      `forge inspect .../CrossChainController.sol:CrossChainController storageLayout`:
+    ///      slot 0 = `chainToAdapter`, slot 1 = `_localAdapterLaneCount`,
+    ///      slot 2 = `_failedMessages`. `chainToAdapter[_chainId]` occupies
+    ///      TWO words: word 0 holds `localAdapter`; word 1 packs
+    ///      `remoteAdapter` (low 20 bytes) with `bridgeChainId` (next 8
+    ///      bytes). This returns word 0's slot; word 1 is `+ 1`.
+    function _chainConfigSlot(uint256 _chainId) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_chainId, uint256(0)));
+    }
+
+    /// @dev The slot of `_localAdapterLaneCount[_adapter]` (mapping at slot 1).
+    function _laneCountSlot(address _adapter) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_adapter, uint256(1)));
     }
 
     // -------------------------------------------------------------------------
@@ -136,14 +197,15 @@ contract CrossChainControllerTest is Test {
     function test_receiveMessage_revertsForUnregisteredContract() public {
         // A deployed contract that was never configured as a lane's local
         // adapter is just as unauthorized as an EOA.
-        AdapterMock strangerAdapter = new AdapterMock(address(controller));
+        AdapterMock strangerAdapter =
+            new AdapterMock(address(controller), address(0), 0, bytes32(0), feeSinkA, false, false);
         vm.expectRevert(abi.encodeWithSelector(Errors.CALLER_NOT_LOCAL_ADAPTER.selector, address(strangerAdapter)));
         vm.prank(address(strangerAdapter));
         controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
     }
 
     function test_receiveMessage_succeedsForRegisteredLocalAdapter() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         bytes32 messageId = bytes32(uint256(42));
         vm.prank(address(adapterA));
@@ -153,7 +215,7 @@ contract CrossChainControllerTest is Test {
     }
 
     function test_receiveMessage_revertsIfMessageAlreadyPending() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         Action[] memory actions = new Action[](1);
         actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
@@ -178,13 +240,13 @@ contract CrossChainControllerTest is Test {
     // -------------------------------------------------------------------------
 
     function test_updateConfig_rotatingLocalAdapterRevokesOldAdapter() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         vm.prank(address(adapterA));
         controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), CHAIN_ID);
 
         // Rotate the lane to adapterB.
-        _configureLane(CHAIN_ID, address(adapterB), remoteAdapterB);
+        _configureLane(CHAIN_ID, address(adapterB), remoteAdapterB, BRIDGE_CHAIN_ID);
 
         assertFalse(controller.isRegisteredLocalAdapter(address(adapterA)));
         assertEq(controller.localAdapterLaneCount(address(adapterA)), 0);
@@ -200,14 +262,14 @@ contract CrossChainControllerTest is Test {
 
     function test_updateConfig_refcountKeepsAdapterAuthorizedUntilBothLanesCleared() public {
         // adapterA serves two lanes.
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
-        _configureLane(OTHER_CHAIN_ID, address(adapterA), remoteAdapterB);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(OTHER_CHAIN_ID, address(adapterA), remoteAdapterB, OTHER_BRIDGE_CHAIN_ID);
 
         assertEq(controller.localAdapterLaneCount(address(adapterA)), 2);
         assertTrue(controller.isRegisteredLocalAdapter(address(adapterA)));
 
         // Clear the first lane only; adapterA must remain authorized.
-        _configureLane(CHAIN_ID, address(0), address(0));
+        _configureLane(CHAIN_ID, address(0), address(0), 0);
 
         assertEq(controller.localAdapterLaneCount(address(adapterA)), 1);
         assertTrue(controller.isRegisteredLocalAdapter(address(adapterA)));
@@ -216,7 +278,7 @@ contract CrossChainControllerTest is Test {
         controller.receiveMessage(bytes32(uint256(1)), _emptyActionsPayload(), OTHER_CHAIN_ID);
 
         // Clear the second (last) lane; adapterA now loses authorization.
-        _configureLane(OTHER_CHAIN_ID, address(0), address(0));
+        _configureLane(OTHER_CHAIN_ID, address(0), address(0), 0);
 
         assertEq(controller.localAdapterLaneCount(address(adapterA)), 0);
         assertFalse(controller.isRegisteredLocalAdapter(address(adapterA)));
@@ -226,13 +288,14 @@ contract CrossChainControllerTest is Test {
         controller.receiveMessage(bytes32(uint256(2)), _emptyActionsPayload(), OTHER_CHAIN_ID);
     }
 
-    function test_updateConfig_clearingLaneWithZeroPairResetsMapping() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
-        _configureLane(CHAIN_ID, address(0), address(0));
+    function test_updateConfig_clearingLaneWithAllZeroConfigResetsMapping() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        _configureLane(CHAIN_ID, address(0), address(0), 0);
 
-        (address local, address remote) = controller.chainToAdapter(CHAIN_ID);
+        (address local, address remote, uint64 bridgeChainId) = controller.chainToAdapter(CHAIN_ID);
         assertEq(local, address(0));
         assertEq(remote, address(0));
+        assertEq(bridgeChainId, 0);
 
         // A cleared lane is "unconfigured" again for sends.
         vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
@@ -248,76 +311,104 @@ contract CrossChainControllerTest is Test {
         uint256[] memory chainIds = new uint256[](2);
         chainIds[0] = CHAIN_ID;
         chainIds[1] = OTHER_CHAIN_ID;
-        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
-        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         vm.expectRevert(Errors.INVALID_LENGTH_MISMATCH.selector);
         vm.prank(alice);
-        controller.updateConfig(chainIds, adapters);
+        controller.updateConfig(chainIds, configs);
     }
 
     function test_updateConfig_revertsOnZeroChainId() public {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = 0;
-        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
-        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         vm.expectRevert(Errors.INVALID_CHAIN_ID.selector);
         vm.prank(alice);
-        controller.updateConfig(chainIds, adapters);
+        controller.updateConfig(chainIds, configs);
     }
 
     function test_updateConfig_revertsOnHalfConfiguredLane_missingRemote() public {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = CHAIN_ID;
-        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
-        adapters[0] = _lane(address(adapterA), address(0));
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), address(0), BRIDGE_CHAIN_ID);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
         vm.prank(alice);
-        controller.updateConfig(chainIds, adapters);
+        controller.updateConfig(chainIds, configs);
     }
 
     function test_updateConfig_revertsOnHalfConfiguredLane_missingLocal() public {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = CHAIN_ID;
-        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
-        adapters[0] = _lane(address(0), remoteAdapterA);
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(0), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
         vm.prank(alice);
-        controller.updateConfig(chainIds, adapters);
+        controller.updateConfig(chainIds, configs);
+    }
+
+    /// @dev NEW dimension introduced by `ChainConfig` gaining `bridgeChainId`:
+    ///      adapters set but the bridge-native id left at `0` is just as much
+    ///      a half-configured lane as a missing address would be -- `0` is
+    ///      the "unset" marker and would otherwise silently address bridge
+    ///      lane `0`. See `m)` below for the complementary "already stored,
+    ///      then zeroed by hand" scenario.
+    function test_updateConfig_revertsOnHalfConfiguredLane_missingBridgeChainId() public {
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), remoteAdapterA, 0);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.INCOMPLETE_ADAPTER_CONFIG.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.updateConfig(chainIds, configs);
     }
 
     function test_updateConfig_revertsIfCallerUnauthorized() public {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = CHAIN_ID;
-        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
-        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         vm.expectRevert(
-            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, UPDATE_CONFIG_PERMISSION_ID)
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector, address(daoMock), address(controller), bob, UPDATE_CONFIG_PERMISSION_ID
+            )
         );
         vm.prank(bob);
-        controller.updateConfig(chainIds, adapters);
+        controller.updateConfig(chainIds, configs);
     }
 
     function test_updateConfig_emitsConfigUpdatedWithCorrectPayload() public {
         uint256[] memory chainIds = new uint256[](1);
         chainIds[0] = CHAIN_ID;
-        CrossChainController.AdapterByChain[] memory adapters = new CrossChainController.AdapterByChain[](1);
-        adapters[0] = _lane(address(adapterA), remoteAdapterA);
+        CrossChainController.ChainConfig[] memory configs = new CrossChainController.ChainConfig[](1);
+        configs[0] = _lane(address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         vm.expectEmit(true, false, false, true, address(controller));
-        emit ConfigUpdated(CHAIN_ID, address(adapterA), remoteAdapterA);
+        emit ConfigUpdated(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         vm.prank(alice);
-        controller.updateConfig(chainIds, adapters);
+        controller.updateConfig(chainIds, configs);
     }
 
     // -------------------------------------------------------------------------
-    // d) forwardMessage silent no-op guards
+    // d) forwardMessage must never return successfully having bridged nothing
     // -------------------------------------------------------------------------
+    //
+    // `forwardMessage` is on the critical path of a governance proposal
+    // racing an on-chain deadline: a silent no-op would let the proposal
+    // "execute" and look healthy while the message never left the chain.
+    // Every way dispatch can fail must revert, not return: (1) unset lane,
+    // (2) codeless local adapter, (3) an adapter revert (reason bubbled
+    // verbatim), (4) insufficient fee balance (covered under fees, f)), and
+    // (5) a "successful" delegatecall that did not return a well-formed
+    // `(bytes32, address, uint256)`.
 
     function test_forwardMessage_revertsIfChainNotConfigured() public {
         vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
@@ -328,11 +419,45 @@ contract CrossChainControllerTest is Test {
     function test_forwardMessage_revertsIfLocalAdapterHasNoCode() public {
         address codelessAdapter = makeAddr("codelessAdapter");
         address codelessRemote = makeAddr("codelessRemote");
-        _configureLane(CHAIN_ID, codelessAdapter, codelessRemote);
+        _configureLane(CHAIN_ID, codelessAdapter, codelessRemote, BRIDGE_CHAIN_ID);
 
         assertEq(codelessAdapter.code.length, 0);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_HAS_NO_CODE.selector, codelessAdapter));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_bubblesAdapterRevertReasonVerbatim() public {
+        AdapterMock revertingAdapter =
+            new AdapterMock(address(controller), address(0), 0, bytes32(0), feeSinkA, true, false);
+        _configureLane(CHAIN_ID, address(revertingAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+
+        // `AdapterMock` reverts with a plain string reason; `forwardMessage`
+        // must bubble that exact reason rather than swallowing it.
+        vm.expectRevert("AdapterMock: sendMessage reverted");
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_revertsWithMessageSendFailed_whenAdapterFailsWithNoReturnData() public {
+        RevertNoReasonAdapterStub badAdapter = new RevertNoReasonAdapterStub();
+        _configureLane(CHAIN_ID, address(badAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+
+        vm.expectRevert(Errors.MESSAGE_SEND_FAILED.selector);
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    /// @dev A "successful" delegatecall that returns fewer than 96 bytes
+    ///      cannot possibly be a valid `(bytes32 messageId, address feeToken,
+    ///      uint256 fee)` triple. `forwardMessage` must fail loudly here too,
+    ///      not `abi.decode` garbage and emit `MessageForwarded` with junk.
+    function test_forwardMessage_revertsWithMessageSendFailed_whenAdapterReturnsMalformedData() public {
+        ShortReturnAdapterStub badAdapter = new ShortReturnAdapterStub();
+        _configureLane(CHAIN_ID, address(badAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+
+        vm.expectRevert(Errors.MESSAGE_SEND_FAILED.selector);
         vm.prank(alice);
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
     }
@@ -342,69 +467,57 @@ contract CrossChainControllerTest is Test {
     // -------------------------------------------------------------------------
 
     function test_forwardMessage_revertsIfCallerUnauthorized() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         vm.expectRevert(
-            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, FORWARD_MESSAGE_PERMISSION_ID)
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector, address(daoMock), address(controller), bob, FORWARD_MESSAGE_PERMISSION_ID
+            )
         );
         vm.prank(bob);
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
     }
 
     function test_forwardMessage_happyPathEmitsMessageForwardedAndReturnsMessageId() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
-        adapterA.setFee(address(0), 0); // no fee due, no funding required
-        bytes32 expectedMessageId = bytes32(uint256(999));
-        adapterA.setMessageId(expectedMessageId);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+        bytes32 expectedMessageId = bytes32(uint256(1)); // adapterA's immutable messageId, set in setUp
 
         bytes memory message = abi.encode("hello");
 
+        // Emitted from inside the delegatecalled adapter code -- under
+        // delegatecall the log's address is the CONTROLLER (see the event
+        // redeclaration comment above), and `bridgeChainId`/`receiver` here
+        // are exactly what the controller supplied as arguments, proving
+        // they reached the adapter correctly.
         vm.expectEmit(true, true, true, true, address(controller));
-        emit MessageForwarded(
-            CHAIN_ID, expectedMessageId, address(adapterA), remoteAdapterA, GAS_LIMIT, address(0), 0
-        );
+        emit SendMessageCalled(address(controller), remoteAdapterA, BRIDGE_CHAIN_ID, GAS_LIMIT, message, 0);
+
+        vm.expectEmit(true, true, true, true, address(controller));
+        emit MessageForwarded(CHAIN_ID, expectedMessageId, address(adapterA), remoteAdapterA, GAS_LIMIT, address(0), 0);
 
         vm.prank(alice);
         bytes32 messageId = controller.forwardMessage(CHAIN_ID, GAS_LIMIT, message);
 
         assertEq(messageId, expectedMessageId);
-        assertEq(adapterA.lastReceiver(), remoteAdapterA);
-        assertEq(adapterA.lastGasLimit(), GAS_LIMIT);
-        assertEq(adapterA.lastDestinationChainId(), CHAIN_ID);
-        assertEq(adapterA.lastMessage(), message);
-        assertEq(adapterA.sendMessageCallCount(), 1);
     }
 
     // -------------------------------------------------------------------------
-    // f) Fees
+    // f) Fees -- and proof the fee flow is DIRECT (no hand-over to the adapter)
     // -------------------------------------------------------------------------
-
-    function test_forwardMessage_erc20Fee_revertsIfControllerBalanceInsufficient() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
-        adapterA.setFee(address(feeToken), 100 ether);
-        // Controller holds 0 of feeToken.
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(feeToken), 100 ether, 0));
-        vm.prank(alice);
-        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
-    }
-
-    function test_forwardMessage_erc20Fee_transfersExactFeeToAdapterWhenFunded() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
-        uint256 requiredFee = 100 ether;
-        adapterA.setFee(address(feeToken), requiredFee);
-        feeToken.setBalance(address(controller), requiredFee + 1 ether); // extra buffer left untouched
-
-        vm.prank(alice);
-        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
-
-        assertEq(feeToken.balanceOf(address(adapterA)), requiredFee);
-        assertEq(feeToken.balanceOf(address(controller)), 1 ether);
-    }
+    //
+    // Under `delegatecall` there is no separate "adapter balance": the
+    // adapter's code runs as the controller, so the fee is paid straight out
+    // of the CONTROLLER's balance into whatever the adapter code sends it to
+    // (here, `AdapterMock`'s immutable `feeSink`, standing in for a bridge
+    // router pulling payment). The tests below assert the controller's
+    // balance decreases by exactly the fee and that the adapter CONTRACT's
+    // own balance never moves at all -- there is nothing to hand over and
+    // nothing that could be stranded on the adapter.
 
     function test_forwardMessage_nativeFee_revertsIfControllerBalanceInsufficient() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
-        adapterA.setFee(address(0), 1 ether);
+        AdapterMock nativeFeeAdapter =
+            new AdapterMock(address(controller), address(0), 1 ether, bytes32(uint256(3)), feeSinkA, false, false);
+        _configureLane(CHAIN_ID, address(nativeFeeAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
         // Controller holds 0 native.
 
         vm.expectRevert(abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(0), 1 ether, 0));
@@ -412,18 +525,54 @@ contract CrossChainControllerTest is Test {
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
     }
 
-    function test_forwardMessage_nativeFee_forwardsExactFeeWeiToAdapterWhenFunded() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+    function test_forwardMessage_nativeFee_feeMovesDirectlyFromControllerToSink_adapterBalanceUntouched() public {
         uint256 requiredFee = 1 ether;
-        adapterA.setFee(address(0), requiredFee);
-        vm.deal(address(controller), requiredFee + 3 ether);
+        AdapterMock nativeFeeAdapter = new AdapterMock(
+            address(controller), address(0), requiredFee, bytes32(uint256(3)), feeSinkA, false, false
+        );
+        _configureLane(CHAIN_ID, address(nativeFeeAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        vm.deal(address(controller), requiredFee + 3 ether); // extra buffer left untouched
 
         vm.prank(alice);
         controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
 
-        assertEq(address(adapterA).balance, requiredFee);
+        assertEq(feeSinkA.balance, requiredFee);
         assertEq(address(controller).balance, 3 ether);
-        assertEq(adapterA.lastValueReceived(), requiredFee);
+        // No hand-over: the adapter CONTRACT itself never held or moved a
+        // wei -- it was never `call`ed with value, only `delegatecall`ed.
+        assertEq(address(nativeFeeAdapter).balance, 0);
+    }
+
+    function test_forwardMessage_erc20Fee_revertsIfControllerBalanceInsufficient() public {
+        AdapterMock erc20FeeAdapter = new AdapterMock(
+            address(controller), address(feeToken), 100 ether, bytes32(uint256(4)), feeSinkB, false, false
+        );
+        _configureLane(CHAIN_ID, address(erc20FeeAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        // Controller holds 0 of feeToken.
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.INSUFFICIENT_FEE_BALANCE.selector, address(feeToken), 100 ether, 0)
+        );
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    function test_forwardMessage_erc20Fee_feeMovesDirectlyFromControllerToSink_adapterBalanceUntouched() public {
+        uint256 requiredFee = 100 ether;
+        AdapterMock erc20FeeAdapter = new AdapterMock(
+            address(controller), address(feeToken), requiredFee, bytes32(uint256(4)), feeSinkB, false, false
+        );
+        _configureLane(CHAIN_ID, address(erc20FeeAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+        feeToken.setBalance(address(controller), requiredFee + 1 ether); // extra buffer left untouched
+
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+
+        assertEq(feeToken.balanceOf(feeSinkB), requiredFee);
+        assertEq(feeToken.balanceOf(address(controller)), 1 ether);
+        // No hand-over: the ERC20 never touches the adapter CONTRACT's own
+        // address -- `IERC20.transfer` is called as/from the controller.
+        assertEq(feeToken.balanceOf(address(erc20FeeAdapter)), 0);
     }
 
     // -------------------------------------------------------------------------
@@ -431,7 +580,7 @@ contract CrossChainControllerTest is Test {
     // -------------------------------------------------------------------------
 
     function test_receiveMessage_capturesRevertingPayloadInsteadOfReverting() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         Action[] memory actions = new Action[](1);
         actions[0] = Action({to: address(actionTarget), value: 0, data: abi.encodeCall(ActionExecute.fail, ())});
@@ -459,7 +608,7 @@ contract CrossChainControllerTest is Test {
     }
 
     function test_receiveMessage_capturesMalformedPayloadInsteadOfReverting() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         // Not a valid ABI-encoding of `Action[]`.
         bytes memory garbage = hex"deadbeef";
@@ -480,11 +629,13 @@ contract CrossChainControllerTest is Test {
     }
 
     function test_retryFailedMessage_revertsIfCallerUnauthorized() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
         bytes32 callId = _causeFailure(bytes32(uint256(60)));
 
         vm.expectRevert(
-            abi.encodeWithSelector(DaoUnauthorized.selector, address(daoMock), address(controller), bob, RETRY_MESSAGE_PERMISSION_ID)
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector, address(daoMock), address(controller), bob, RETRY_MESSAGE_PERMISSION_ID
+            )
         );
         vm.prank(bob);
         controller.retryFailedMessage(callId);
@@ -498,7 +649,7 @@ contract CrossChainControllerTest is Test {
     }
 
     function test_retryFailedMessage_succeedsOnceFailureConditionRemoved() public {
-        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA);
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
 
         FlakyTarget flaky = new FlakyTarget();
         Action[] memory actions = new Action[](1);
@@ -610,6 +761,243 @@ contract CrossChainControllerTest is Test {
         bytes32 differentMessage = controller.deriveCallId(CHAIN_ID, bytes32(uint256(124)));
         assertTrue(callId1 != differentMessage);
     }
+
+    // -------------------------------------------------------------------------
+    // k) NEW -- no storage collision between the controller and the
+    //    delegatecalled adapter
+    // -------------------------------------------------------------------------
+    //
+    // This is the whole point of moving every send-time parameter into the
+    // controller and making the adapter's send path storage-free: a
+    // `delegatecall` to code that touched storage would corrupt whatever the
+    // controller has at the slots that code happens to write. We snapshot
+    // every storage word the controller actually uses (per
+    // `forge inspect ... storageLayout`) around a real, successful send and
+    // assert byte-for-byte equality, plus the equivalent public getters.
+
+    function test_forwardMessage_doesNotCollideWithControllerStorage() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+
+        // Bundled into arrays / a single hash on purpose: enough distinct
+        // named locals here (six raw slots, the three `ChainConfig` fields
+        // twice over, plus lane-count/registration) trips solc 0.8.17's
+        // "stack too deep" with the optimizer configuration this repo pins.
+        bytes32[] memory slots = _controllerSnapshotSlots(CHAIN_ID, address(adapterA));
+        bytes32[] memory valuesBefore = _loadAll(slots);
+        bytes32 gettersHashBefore = _gettersHash(CHAIN_ID, address(adapterA));
+
+        vm.prank(alice);
+        bytes32 messageId = controller.forwardMessage(CHAIN_ID, GAS_LIMIT, abi.encode("no collision"));
+        // Sanity: the send actually happened, this isn't vacuously true.
+        assertEq(messageId, bytes32(uint256(1)));
+
+        bytes32[] memory valuesAfter = _loadAll(slots);
+        for (uint256 i = 0; i < slots.length; i++) {
+            assertEq(valuesAfter[i], valuesBefore[i]);
+        }
+        assertEq(_gettersHash(CHAIN_ID, address(adapterA)), gettersHashBefore);
+    }
+
+    /// @dev Slot 0/1/2 themselves hold nothing for a mapping (reading them is
+    ///      a cheap extra guarantee nothing landed there), plus the two
+    ///      concrete words `chainToAdapter[_chainId]` occupies and the one
+    ///      word `_localAdapterLaneCount[_adapter]` occupies.
+    function _controllerSnapshotSlots(
+        uint256 _chainId,
+        address _adapter
+    ) internal pure returns (bytes32[] memory slots) {
+        slots = new bytes32[](6);
+        slots[0] = bytes32(uint256(0));
+        slots[1] = bytes32(uint256(1));
+        slots[2] = bytes32(uint256(2));
+        bytes32 configWord0 = _chainConfigSlot(_chainId);
+        slots[3] = configWord0;
+        slots[4] = bytes32(uint256(configWord0) + 1);
+        slots[5] = _laneCountSlot(_adapter);
+    }
+
+    function _loadAll(bytes32[] memory _slots) internal view returns (bytes32[] memory values) {
+        values = new bytes32[](_slots.length);
+        for (uint256 i = 0; i < _slots.length; i++) {
+            values[i] = vm.load(address(controller), _slots[i]);
+        }
+    }
+
+    /// @dev Collapses every public getter relevant to a lane/adapter into one
+    ///      hash, so before/after comparisons need one local instead of five.
+    function _gettersHash(uint256 _chainId, address _adapter) internal view returns (bytes32) {
+        (address local, address remote, uint64 bridgeChainId) = controller.chainToAdapter(_chainId);
+        return keccak256(
+            abi.encode(
+                local,
+                remote,
+                bridgeChainId,
+                controller.localAdapterLaneCount(_adapter),
+                controller.isRegisteredLocalAdapter(_adapter)
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // l) NEW -- immutables resolve to the CALLED adapter's bytecode under
+    //    delegatecall, not the controller's storage
+    // -------------------------------------------------------------------------
+
+    function test_forwardMessage_immutablesResolveToConfiguredAdapter_notTheOtherOne_notZero() public {
+        address sinkX = makeAddr("sinkX");
+        address sinkY = makeAddr("sinkY");
+        bytes32 messageIdX = bytes32(uint256(111));
+        bytes32 messageIdY = bytes32(uint256(222));
+
+        // adapterX: native fee. adapterY: ERC20 fee, different amount,
+        // different messageId, different sink. Only adapterX is ever wired
+        // into a lane.
+        AdapterMock adapterX = new AdapterMock(address(controller), address(0), 1 ether, messageIdX, sinkX, false, false);
+        AdapterMock adapterY =
+            new AdapterMock(address(controller), address(feeToken), 2 ether, messageIdY, sinkY, false, false);
+
+        _configureLane(CHAIN_ID, address(adapterX), remoteAdapterA, BRIDGE_CHAIN_ID);
+
+        // Fund the controller for BOTH adapters' fees, so a bug that read
+        // adapterY's immutables (or the controller's own storage, which has
+        // none of this at all) would still be able to "succeed" -- the only
+        // thing that can make this assert the right values is genuinely
+        // resolving adapterX's bytecode-embedded immutables.
+        vm.deal(address(controller), 1 ether);
+        feeToken.setBalance(address(controller), 2 ether);
+
+        vm.prank(alice);
+        bytes32 messageId = controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+
+        assertEq(messageId, messageIdX);
+        assertTrue(messageId != messageIdY);
+        assertTrue(messageId != bytes32(0));
+
+        // adapterX's fee was moved to adapterX's sink...
+        assertEq(sinkX.balance, 1 ether);
+        assertEq(address(controller).balance, 0);
+        // ...and adapterY's configuration was never touched at all: it was
+        // deployed and left wired into nothing, yet still had to exist for
+        // this to be a meaningful "not the other one" comparison.
+        assertTrue(address(adapterY).code.length > 0);
+        assertEq(sinkY.balance, 0);
+        assertEq(feeToken.balanceOf(sinkY), 0);
+        assertEq(feeToken.balanceOf(address(controller)), 2 ether);
+    }
+
+    // -------------------------------------------------------------------------
+    // m) NEW -- an unconfigured/zeroed bridgeChainId can never silently send
+    //    to bridge lane 0
+    // -------------------------------------------------------------------------
+    //
+    // `test_updateConfig_revertsOnHalfConfiguredLane_missingBridgeChainId`
+    // above already proves `updateConfig` rejects `bridgeChainId == 0` with
+    // adapters set. This section proves the second half: even if a lane's
+    // packed word were force-corrupted to zero the `bridgeChainId` bits
+    // directly in storage (bypassing `updateConfig` entirely), the send path
+    // still refuses to dispatch rather than silently addressing selector `0`.
+
+    function test_forwardMessage_revertsIfBridgeChainIdZeroedDirectlyInStorage() public {
+        _configureLane(CHAIN_ID, address(adapterA), remoteAdapterA, BRIDGE_CHAIN_ID);
+
+        bytes32 configWord1Slot = bytes32(uint256(_chainConfigSlot(CHAIN_ID)) + 1);
+        bytes32 packed = vm.load(address(controller), configWord1Slot);
+
+        // Word 1 is `remoteAdapter` (low 160 bits) | `bridgeChainId` (next 64
+        // bits) | padding. Keep the low 160 bits (remoteAdapter), zero
+        // everything above (bridgeChainId + padding).
+        bytes32 zeroedBridgeChainId = bytes32(uint256(packed) & ((uint256(1) << 160) - 1));
+        vm.store(address(controller), configWord1Slot, zeroedBridgeChainId);
+
+        (address local, address remote, uint64 bridgeChainId) = controller.chainToAdapter(CHAIN_ID);
+        assertEq(local, address(adapterA)); // untouched
+        assertEq(remote, remoteAdapterA); // untouched
+        assertEq(bridgeChainId, 0); // corrupted to the "unset" marker
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.ADAPTER_NOT_CONFIGURED.selector, CHAIN_ID));
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    // -------------------------------------------------------------------------
+    // n) NEW -- an adapter's send path refuses to run outside a delegatecall
+    //    from its owning controller
+    // -------------------------------------------------------------------------
+
+    function test_adapterSendMessage_revertsIfCalledDirectlyNotViaControllerDelegatecall() public {
+        // Calling `adapterA.sendMessage(...)` directly (a normal `call`, not
+        // a `delegatecall` from `controller`) means `address(this)` inside
+        // the adapter's code is the ADAPTER itself, which the guard rejects:
+        // using the adapter's own (empty) balance and having the bridge see
+        // the adapter -- not the controller -- as sender would be wrong.
+        vm.expectRevert(abi.encodeWithSelector(Errors.SEND_PATH_NOT_DELEGATECALLED.selector, address(adapterA)));
+        adapterA.sendMessage(remoteAdapterA, BRIDGE_CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+    }
+
+    // -------------------------------------------------------------------------
+    // o) NEW -- residual risk (documentation, not mitigation)
+    // -------------------------------------------------------------------------
+
+    /// @notice DOCUMENTS security-review finding 7. This is EXPECTED,
+    ///         ACCEPTED behaviour of the `delegatecall` send design -- it is
+    ///         NOT a bug for the contract to fix, and this test is not
+    ///         supposed to ever start failing as a "regression". It exists so
+    ///         that:
+    ///          1. the blast radius of `UPDATE_CONFIG_PERMISSION` is provable
+    ///             rather than asserted in a comment, and
+    ///          2. nobody "fixes" this test by loosening it if a future
+    ///             change accidentally narrows the actual risk -- if this
+    ///             test starts failing because the takeover no longer works,
+    ///             that is a MEANINGFUL change to re-review, not noise.
+    ///
+    ///         See the NatSpec on `CrossChainController.UPDATE_CONFIG_PERMISSION_ID`:
+    ///         this permission is effectively root on the DAO precisely
+    ///         because `forwardMessage` executes the configured local
+    ///         adapter's code in the controller's own context. Whoever can
+    ///         set `localAdapter` can (a) overwrite ANY controller storage
+    ///         slot and (b) make the DAO execute ANY action, since the
+    ///         controller holds `EXECUTE_PERMISSION` on it. The only real
+    ///         mitigation is operational: grant `UPDATE_CONFIG_PERMISSION` to
+    ///         the DAO itself ONLY, reachable exclusively through a passed
+    ///         proposal.
+    function test_residualRisk_maliciousAdapterCanCorruptControllerAndExecuteOnDAO() public {
+        PwnTarget target = new PwnTarget();
+        bytes32 arbitrarySlot = keccak256("some arbitrary controller storage slot");
+        bytes32 arbitraryValue = bytes32(uint256(0xDEADBEEF));
+
+        MaliciousAdapterMock evilAdapter = new MaliciousAdapterMock(
+            address(controller), address(daoMock), address(target), arbitrarySlot, arbitraryValue
+        );
+
+        // `CrossChainControllerDAOMock.execute` in this suite performs the
+        // action unconditionally (it doesn't gate on `EXECUTE_PERMISSION`,
+        // unlike a real Aragon `PermissionManager`); the grant below is kept
+        // for documentation parity with production, where the controller
+        // holding `EXECUTE_PERMISSION` on its DAO is exactly what makes this
+        // finding devastating rather than merely embarrassing.
+        daoMock.setHasPermission(address(daoMock), address(controller), keccak256("EXECUTE_PERMISSION"), true);
+
+        // Anyone holding UPDATE_CONFIG_PERMISSION -- alice, per setUp --
+        // points a lane at the malicious "adapter". In production this
+        // permission must be DAO-only; the contract cannot and does not
+        // enforce that itself.
+        _configureLane(CHAIN_ID, address(evilAdapter), remoteAdapterA, BRIDGE_CHAIN_ID);
+
+        assertEq(vm.load(address(controller), arbitrarySlot), bytes32(0));
+        assertFalse(target.pwned());
+
+        // The next ordinary-looking forwardMessage call -- by anyone holding
+        // only FORWARD_MESSAGE_PERMISSION, for what looks like a routine send
+        // -- actually runs the malicious adapter's code IN THE CONTROLLER'S
+        // OWN CONTEXT.
+        vm.prank(alice);
+        controller.forwardMessage(CHAIN_ID, GAS_LIMIT, _emptyActionsPayload());
+
+        // (a) Arbitrary controller storage was overwritten.
+        assertEq(vm.load(address(controller), arbitrarySlot), arbitraryValue);
+        // (b) The DAO executed an arbitrary action chosen by the "adapter".
+        assertTrue(target.pwned());
+    }
 }
 
 /// @dev Minimal target whose revert behaviour can be flipped on demand, used
@@ -626,5 +1014,37 @@ contract FlakyTarget {
     function maybeRevert() external {
         if (shouldRevert) revert("FlakyTarget: still failing");
         wasCalled = true;
+    }
+}
+
+/// @dev A non-conforming "adapter" whose `sendMessage` succeeds but returns
+///      too little data to be a valid `(bytes32, address, uint256)` triple.
+///      Matches `IBaseAdapter.sendMessage`'s selector (name + parameter
+///      types only determine the selector, not the return type), so the
+///      controller's `delegatecall` dispatches into it exactly as it would a
+///      real adapter.
+contract ShortReturnAdapterStub {
+    function sendMessage(
+        address, /* receiver */
+        uint64, /* bridgeChainId */
+        uint256, /* gasLimit */
+        bytes calldata /* message */
+    ) external payable returns (bool) {
+        return true;
+    }
+}
+
+/// @dev A non-conforming "adapter" whose `sendMessage` reverts with NO
+///      returndata at all, exercising `forwardMessage`'s
+///      `returndata.length == 0` branch of `Errors.MESSAGE_SEND_FAILED()`
+///      (as opposed to the "reason bubbled verbatim" branch).
+contract RevertNoReasonAdapterStub {
+    function sendMessage(
+        address, /* receiver */
+        uint64, /* bridgeChainId */
+        uint256, /* gasLimit */
+        bytes calldata /* message */
+    ) external payable returns (bytes32, address, uint256) {
+        revert();
     }
 }

--- a/test/mocks/commons/crosschain/AdapterMock.sol
+++ b/test/mocks/commons/crosschain/AdapterMock.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IBaseAdapter} from "../../../../src/common/crosschain/adapters/IBaseAdapter.sol";
+
+/// @notice A fully configurable mock implementing `IBaseAdapter`, used to drive
+///         `CrossChainController`'s sending and receiving paths in isolation
+///         from any real bridge.
+/// @dev DO NOT USE IN PRODUCTION!
+contract AdapterMock is IBaseAdapter {
+    address private immutable _controller;
+
+    /// @notice The fee token/amount `quoteFee` and `sendMessage` will honor.
+    address public feeToken;
+    uint256 public fee;
+
+    /// @notice The messageId `sendMessage` will return.
+    bytes32 public messageIdToReturn;
+
+    /// @notice When true, `sendMessage` reverts instead of recording the call.
+    bool public revertOnSend;
+
+    /// @notice When true, `quoteFee` reverts instead of returning `(feeToken, fee)`.
+    bool public revertOnQuote;
+
+    /// @notice Number of times `sendMessage` was successfully called.
+    uint256 public sendMessageCallCount;
+
+    // Args recorded from the last successful `sendMessage` call.
+    address public lastReceiver;
+    uint256 public lastGasLimit;
+    uint256 public lastDestinationChainId;
+    bytes public lastMessage;
+    uint256 public lastValueReceived;
+
+    constructor(address _controllerAddr) {
+        _controller = _controllerAddr;
+    }
+
+    // -------------------------------------------------------------------------
+    // Test configuration
+    // -------------------------------------------------------------------------
+
+    function setFee(address _feeToken, uint256 _fee) external {
+        feeToken = _feeToken;
+        fee = _fee;
+    }
+
+    function setMessageId(bytes32 _messageId) external {
+        messageIdToReturn = _messageId;
+    }
+
+    function setRevertOnSend(bool _revert) external {
+        revertOnSend = _revert;
+    }
+
+    function setRevertOnQuote(bool _revert) external {
+        revertOnQuote = _revert;
+    }
+
+    /// @notice Convenience for tests: the ERC20 balance this mock currently
+    ///         holds of `_token`, i.e. what the controller transferred to it.
+    function tokenBalance(address _token) external view returns (uint256) {
+        return IERC20(_token).balanceOf(address(this));
+    }
+
+    // -------------------------------------------------------------------------
+    // IBaseAdapter
+    // -------------------------------------------------------------------------
+
+    function CROSS_CHAIN_CONTROLLER() external view override returns (address) {
+        return _controller;
+    }
+
+    function toNativeChainId(uint256 _chainId) external pure override returns (uint256) {
+        return _chainId;
+    }
+
+    function fromNativeChainId(uint256 _chainId) external pure override returns (uint256) {
+        return _chainId;
+    }
+
+    function quoteFee(
+        address _receiver,
+        uint256 _gasLimit,
+        uint256 _destinationChainId,
+        bytes calldata _message
+    ) external view override returns (address, uint256) {
+        (_receiver, _gasLimit, _destinationChainId, _message);
+        if (revertOnQuote) revert("AdapterMock: quoteFee reverted");
+        return (feeToken, fee);
+    }
+
+    function sendMessage(
+        address _receiver,
+        uint256 _gasLimit,
+        uint256 _destinationChainId,
+        bytes calldata _message
+    ) external payable override returns (bytes32) {
+        if (revertOnSend) revert("AdapterMock: sendMessage reverted");
+
+        lastReceiver = _receiver;
+        lastGasLimit = _gasLimit;
+        lastDestinationChainId = _destinationChainId;
+        lastMessage = _message;
+        lastValueReceived = msg.value;
+        sendMessageCallCount++;
+
+        return messageIdToReturn;
+    }
+}

--- a/test/mocks/commons/crosschain/AdapterMock.sol
+++ b/test/mocks/commons/crosschain/AdapterMock.sol
@@ -32,7 +32,7 @@ contract AdapterMock is IBaseAdapter {
     event SendMessageCalled(
         address context,
         address receiver,
-        uint64 bridgeChainId,
+        uint256 destinationChainId,
         uint256 gasLimit,
         bytes message,
         uint256 value
@@ -86,11 +86,11 @@ contract AdapterMock is IBaseAdapter {
 
     function quoteFee(
         address _receiver,
-        uint64 _bridgeChainId,
+        uint256 _destinationChainId,
         uint256 _gasLimit,
         bytes calldata _message
     ) external view override returns (address, uint256) {
-        (_receiver, _bridgeChainId, _gasLimit, _message);
+        (_receiver, _destinationChainId, _gasLimit, _message);
         // solhint-disable-next-line custom-errors, reason-string
         if (_revertOnQuote) revert("AdapterMock: quoteFee reverted");
         return (_feeToken, _fee);
@@ -101,22 +101,17 @@ contract AdapterMock is IBaseAdapter {
     ///      and moves the fee out of it.
     function sendMessage(
         address _receiver,
-        uint64 _bridgeChainId,
+        uint256 _destinationChainId,
         uint256 _gasLimit,
         bytes calldata _message
-    )
-        external
-        payable
-        override
-        returns (bytes32 messageId, address feeToken, uint256 fee)
-    {
+    ) external payable override returns (bytes32 messageId, uint256 fee) {
         if (address(this) != _controller) {
             revert Errors.SEND_PATH_NOT_DELEGATECALLED(address(this));
         }
         // solhint-disable-next-line custom-errors, reason-string
         if (_revertOnSend) revert("AdapterMock: sendMessage reverted");
 
-        feeToken = _feeToken;
+        address feeToken = _feeToken;
         fee = _fee;
 
         if (feeToken == address(0)) {
@@ -152,7 +147,7 @@ contract AdapterMock is IBaseAdapter {
         emit SendMessageCalled(
             address(this),
             _receiver,
-            _bridgeChainId,
+            _destinationChainId,
             _gasLimit,
             _message,
             msg.value

--- a/test/mocks/commons/crosschain/AdapterMock.sol
+++ b/test/mocks/commons/crosschain/AdapterMock.sol
@@ -4,66 +4,64 @@ pragma solidity ^0.8.17;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IBaseAdapter} from "../../../../src/common/crosschain/adapters/IBaseAdapter.sol";
+import {Errors} from "../../../../src/common/crosschain/lib/Errors.sol";
 
-/// @notice A fully configurable mock implementing `IBaseAdapter`, used to drive
-///         `CrossChainController`'s sending and receiving paths in isolation
-///         from any real bridge.
+/// @notice A bridge-less `IBaseAdapter` implementation used to drive
+///         `CrossChainController`'s send path in isolation.
 /// @dev DO NOT USE IN PRODUCTION!
+///
+///      This mock is deliberately built the way a REAL Option-1 adapter must
+///      be built: its send path touches NO storage. Every knob is an
+///      `immutable` set at construction, and the call is recorded by EMITTING
+///      an event rather than by writing state — writing state would land in
+///      the controller's slots, which is exactly the bug this design exists to
+///      avoid. Tests configure behaviour by deploying a differently
+///      parameterised mock, not by calling a setter.
 contract AdapterMock is IBaseAdapter {
     address private immutable _controller;
+    address private immutable _feeToken;
+    uint256 private immutable _fee;
+    bytes32 private immutable _messageId;
+    address private immutable _feeSink;
+    bool private immutable _revertOnSend;
+    bool private immutable _revertOnQuote;
 
-    /// @notice The fee token/amount `quoteFee` and `sendMessage` will honor.
-    address public feeToken;
-    uint256 public fee;
+    /// @notice Emitted by `sendMessage`; the only record this mock keeps.
+    /// @param context `address(this)` at execution time — the CONTROLLER when
+    ///        the mock is reached by `delegatecall`, as it must be.
+    event SendMessageCalled(
+        address context,
+        address receiver,
+        uint64 bridgeChainId,
+        uint256 gasLimit,
+        bytes message,
+        uint256 value
+    );
 
-    /// @notice The messageId `sendMessage` will return.
-    bytes32 public messageIdToReturn;
-
-    /// @notice When true, `sendMessage` reverts instead of recording the call.
-    bool public revertOnSend;
-
-    /// @notice When true, `quoteFee` reverts instead of returning `(feeToken, fee)`.
-    bool public revertOnQuote;
-
-    /// @notice Number of times `sendMessage` was successfully called.
-    uint256 public sendMessageCallCount;
-
-    // Args recorded from the last successful `sendMessage` call.
-    address public lastReceiver;
-    uint256 public lastGasLimit;
-    uint256 public lastDestinationChainId;
-    bytes public lastMessage;
-    uint256 public lastValueReceived;
-
-    constructor(address _controllerAddr) {
-        _controller = _controllerAddr;
-    }
-
-    // -------------------------------------------------------------------------
-    // Test configuration
-    // -------------------------------------------------------------------------
-
-    function setFee(address _feeToken, uint256 _fee) external {
-        feeToken = _feeToken;
-        fee = _fee;
-    }
-
-    function setMessageId(bytes32 _messageId) external {
-        messageIdToReturn = _messageId;
-    }
-
-    function setRevertOnSend(bool _revert) external {
-        revertOnSend = _revert;
-    }
-
-    function setRevertOnQuote(bool _revert) external {
-        revertOnQuote = _revert;
-    }
-
-    /// @notice Convenience for tests: the ERC20 balance this mock currently
-    ///         holds of `_token`, i.e. what the controller transferred to it.
-    function tokenBalance(address _token) external view returns (uint256) {
-        return IERC20(_token).balanceOf(address(this));
+    /// @param controller_ The owning `CrossChainController`.
+    /// @param feeToken_ The fee token to report/charge; `address(0)` native.
+    /// @param fee_ The fee amount to report/charge.
+    /// @param messageId_ The bridge message id `sendMessage` returns.
+    /// @param feeSink_ Where the charged fee is sent, standing in for the
+    ///        bridge router pulling payment from the fee payer.
+    /// @param revertOnSend_ Make `sendMessage` revert.
+    /// @param revertOnQuote_ Make `quoteFee` revert.
+    constructor(
+        address controller_,
+        address feeToken_,
+        uint256 fee_,
+        bytes32 messageId_,
+        address feeSink_,
+        bool revertOnSend_,
+        bool revertOnQuote_
+    ) {
+        _controller = controller_;
+        _feeToken = feeToken_;
+        _fee = fee_;
+        _messageId = messageId_;
+        _feeSink = feeSink_;
+        _revertOnSend = revertOnSend_;
+        _revertOnQuote = revertOnQuote_;
     }
 
     // -------------------------------------------------------------------------
@@ -74,40 +72,92 @@ contract AdapterMock is IBaseAdapter {
         return _controller;
     }
 
-    function toNativeChainId(uint256 _chainId) external pure override returns (uint256) {
+    function toNativeChainId(
+        uint256 _chainId
+    ) external pure override returns (uint256) {
         return _chainId;
     }
 
-    function fromNativeChainId(uint256 _chainId) external pure override returns (uint256) {
+    function fromNativeChainId(
+        uint256 _chainId
+    ) external pure override returns (uint256) {
         return _chainId;
     }
 
     function quoteFee(
         address _receiver,
+        uint64 _bridgeChainId,
         uint256 _gasLimit,
-        uint256 _destinationChainId,
         bytes calldata _message
     ) external view override returns (address, uint256) {
-        (_receiver, _gasLimit, _destinationChainId, _message);
-        if (revertOnQuote) revert("AdapterMock: quoteFee reverted");
-        return (feeToken, fee);
+        (_receiver, _bridgeChainId, _gasLimit, _message);
+        // solhint-disable-next-line custom-errors, reason-string
+        if (_revertOnQuote) revert("AdapterMock: quoteFee reverted");
+        return (_feeToken, _fee);
     }
 
+    /// @dev Mirrors a real adapter: guards the execution context, checks the
+    ///      FEE PAYER's balance (which under `delegatecall` is the controller's)
+    ///      and moves the fee out of it.
     function sendMessage(
         address _receiver,
+        uint64 _bridgeChainId,
         uint256 _gasLimit,
-        uint256 _destinationChainId,
         bytes calldata _message
-    ) external payable override returns (bytes32) {
-        if (revertOnSend) revert("AdapterMock: sendMessage reverted");
+    )
+        external
+        payable
+        override
+        returns (bytes32 messageId, address feeToken, uint256 fee)
+    {
+        if (address(this) != _controller) {
+            revert Errors.SEND_PATH_NOT_DELEGATECALLED(address(this));
+        }
+        // solhint-disable-next-line custom-errors, reason-string
+        if (_revertOnSend) revert("AdapterMock: sendMessage reverted");
 
-        lastReceiver = _receiver;
-        lastGasLimit = _gasLimit;
-        lastDestinationChainId = _destinationChainId;
-        lastMessage = _message;
-        lastValueReceived = msg.value;
-        sendMessageCallCount++;
+        feeToken = _feeToken;
+        fee = _fee;
 
-        return messageIdToReturn;
+        if (feeToken == address(0)) {
+            uint256 balance = address(this).balance;
+            if (balance < fee) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(
+                    address(0),
+                    fee,
+                    balance
+                );
+            }
+            if (fee != 0) {
+                // solhint-disable-next-line avoid-low-level-calls
+                (bool ok, ) = _feeSink.call{value: fee}("");
+                if (!ok) revert Errors.NATIVE_TRANSFER_FAILED(_feeSink, fee);
+            }
+        } else {
+            if (msg.value != 0) revert Errors.UNEXPECTED_NATIVE_VALUE();
+
+            uint256 balance = IERC20(feeToken).balanceOf(address(this));
+            if (balance < fee) {
+                revert Errors.INSUFFICIENT_FEE_BALANCE(feeToken, fee, balance);
+            }
+            if (fee != 0) {
+                // solhint-disable-next-line custom-errors, reason-string
+                require(
+                    IERC20(feeToken).transfer(_feeSink, fee),
+                    "AdapterMock: fee transfer failed"
+                );
+            }
+        }
+
+        emit SendMessageCalled(
+            address(this),
+            _receiver,
+            _bridgeChainId,
+            _gasLimit,
+            _message,
+            msg.value
+        );
+
+        messageId = _messageId;
     }
 }

--- a/test/mocks/commons/crosschain/CCIPRouterMock.sol
+++ b/test/mocks/commons/crosschain/CCIPRouterMock.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {
+    IRouterClient
+} from "@chainlink/contracts-ccip/contracts/interfaces/IRouterClient.sol";
+import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
+
+/// @notice Minimal CCIP Router mock used to regression-test `CCIPAdapter`.
+/// @dev DO NOT USE IN PRODUCTION!
+///      Deliberately pulls the ERC20 fee via `transferFrom` — exactly like the
+///      real Router does — instead of trusting a pre-existing balance. The old
+///      `CCIPAdapter` never approved the router, so a mock that trusted the
+///      balance instead of pulling it would silently pass on a broken adapter.
+///      This is the regression test for the missing-`forceApprove` bug.
+contract CCIPRouterMock is IRouterClient {
+    /// @notice The fee returned by `getFee` and required by `ccipSend`.
+    uint256 public fee;
+
+    /// @notice Toggle for `isChainSupported`.
+    bool public chainSupported = true;
+
+    /// @notice The `messageId` returned by the next `ccipSend` call.
+    bytes32 public nextMessageId = keccak256("CCIPRouterMock: default-message-id");
+
+    /// @notice Number of times `ccipSend` was called.
+    uint256 public ccipSendCallCount;
+
+    // -- Recorded data of the most recent `ccipSend` call --------------------
+    uint64 public lastDestChainSelector;
+    bytes public lastReceiver;
+    bytes public lastData;
+    address public lastFeeToken;
+    bytes public lastExtraArgs;
+    uint256 public lastMsgValue;
+    address public lastCaller;
+
+    /// @notice Sets the fee quoted by `getFee` / required by `ccipSend`.
+    function setFee(uint256 _fee) external {
+        fee = _fee;
+    }
+
+    /// @notice Sets whether `isChainSupported` reports a chain as supported.
+    function setChainSupported(bool _supported) external {
+        chainSupported = _supported;
+    }
+
+    /// @notice Sets the `messageId` the next `ccipSend` call will return.
+    function setNextMessageId(bytes32 _id) external {
+        nextMessageId = _id;
+    }
+
+    /// @inheritdoc IRouterClient
+    function isChainSupported(uint64) external view returns (bool) {
+        return chainSupported;
+    }
+
+    /// @inheritdoc IRouterClient
+    function getFee(
+        uint64,
+        Client.EVM2AnyMessage memory
+    ) external view returns (uint256) {
+        return fee;
+    }
+
+    /// @inheritdoc IRouterClient
+    function ccipSend(
+        uint64 destinationChainSelector,
+        Client.EVM2AnyMessage calldata message
+    ) external payable returns (bytes32) {
+        lastDestChainSelector = destinationChainSelector;
+        lastReceiver = message.receiver;
+        lastData = message.data;
+        lastFeeToken = message.feeToken;
+        lastExtraArgs = message.extraArgs;
+        lastMsgValue = msg.value;
+        lastCaller = msg.sender;
+        ccipSendCallCount++;
+
+        if (message.feeToken == address(0)) {
+            require(msg.value == fee, "CCIPRouterMock: bad native fee");
+        } else {
+            require(msg.value == 0, "CCIPRouterMock: unexpected native value");
+            // Pull the fee exactly like the real Router. Reverts if the
+            // caller never approved this contract for at least `fee`.
+            require(
+                IERC20(message.feeToken).transferFrom(
+                    msg.sender,
+                    address(this),
+                    fee
+                ),
+                "CCIPRouterMock: transferFrom failed"
+            );
+        }
+
+        return nextMessageId;
+    }
+}

--- a/test/mocks/commons/crosschain/CrossChainControllerDAOMock.sol
+++ b/test/mocks/commons/crosschain/CrossChainControllerDAOMock.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
+import {IExecutor, Action} from "../../../../src/common/executors/IExecutor.sol";
+
+/// @notice A DAO mock purpose-built for `CrossChainController` tests.
+/// @dev Differs from `DAOMock` in two ways the controller's suite needs:
+///      - `hasPermission` is granted per `(where, who, permissionId)` instead
+///        of one global bool, so a caller can be authorized for one
+///        permission (e.g. `RETRY_MESSAGE_PERMISSION`) but not another.
+///      - `execute` actually performs the actions (bubbling a real revert
+///        reason on failure) instead of being a silent no-op, and can
+///        additionally be forced to revert outright via
+///        `setExecuteReverts`. This is required to exercise
+///        `CrossChainController`'s defensive `try/catch` around
+///        `executeActions` and the retry path with genuine pass/fail
+///        outcomes.
+/// @dev DO NOT USE IN PRODUCTION!
+contract CrossChainControllerDAOMock is IDAO, IExecutor {
+    /// @notice where => who => permissionId => granted.
+    mapping(address => mapping(address => mapping(bytes32 => bool))) public permissions;
+
+    /// @notice When true, `execute` reverts unconditionally before touching
+    ///         any action, regardless of the granted permissions.
+    bool public executeReverts;
+
+    function setHasPermission(address _where, address _who, bytes32 _permissionId, bool _granted) external {
+        permissions[_where][_who][_permissionId] = _granted;
+    }
+
+    function setExecuteReverts(bool _reverts) external {
+        executeReverts = _reverts;
+    }
+
+    function hasPermission(
+        address _where,
+        address _who,
+        bytes32 _permissionId,
+        bytes memory _data
+    ) external view override returns (bool) {
+        (_data);
+        return permissions[_where][_who][_permissionId];
+    }
+
+    function getTrustedForwarder() public pure override returns (address) {
+        return address(0);
+    }
+
+    function setTrustedForwarder(address _trustedForwarder) external pure override {
+        (_trustedForwarder);
+    }
+
+    function setMetadata(bytes calldata _metadata) external pure override {
+        (_metadata);
+    }
+
+    /// @dev Actually calls every action and reverts (bubbling the original
+    ///      reason) on the first failure, mirroring the real `Executor`'s
+    ///      default (`allowFailureMap == 0`) behaviour closely enough for
+    ///      these tests: a reverting action makes `execute` revert.
+    function execute(
+        bytes32 callId,
+        Action[] memory _actions,
+        uint256 allowFailureMap
+    ) external override returns (bytes[] memory execResults, uint256 failureMap) {
+        if (executeReverts) {
+            // solhint-disable-next-line reason-string, custom-errors
+            revert("CrossChainControllerDAOMock: forced revert");
+        }
+
+        execResults = new bytes[](_actions.length);
+        for (uint256 i = 0; i < _actions.length; i++) {
+            (bool success, bytes memory result) = _actions[i].to.call{value: _actions[i].value}(_actions[i].data);
+            if (!success) {
+                assembly {
+                    revert(add(result, 32), mload(result))
+                }
+            }
+            execResults[i] = result;
+        }
+
+        emit Executed(msg.sender, callId, _actions, allowFailureMap, failureMap, execResults);
+    }
+
+    function deposit(address _token, uint256 _amount, string calldata _reference) external payable override {
+        (_token, _amount, _reference);
+    }
+
+    function setSignatureValidator(address _signatureValidator) external pure override {
+        (_signatureValidator);
+    }
+
+    function isValidSignature(bytes32 _hash, bytes memory _signature) external pure override returns (bytes4) {
+        (_hash, _signature);
+        return 0x0;
+    }
+
+    function registerStandardCallback(
+        bytes4 _interfaceId,
+        bytes4 _callbackSelector,
+        bytes4 _magicNumber
+    ) external pure override {
+        (_interfaceId, _callbackSelector, _magicNumber);
+    }
+}

--- a/test/mocks/commons/crosschain/DelegateCallerMock.sol
+++ b/test/mocks/commons/crosschain/DelegateCallerMock.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {IDAO} from "../../../../src/common/dao/IDAO.sol";
+
+/// @notice Minimal helper that DELEGATECALLS into a target with caller-supplied
+///         calldata, bubbling the target's exact revert data on failure.
+/// @dev DO NOT USE IN PRODUCTION! Test-only.
+///
+///      Exists to drive two execution contexts the real `CrossChainController`
+///      cannot produce, because its own public entry points already validate
+///      the relevant scenarios away before any `delegatecall` happens:
+///
+///        1. `BaseAdapter._forwardMessage`'s `DELEGATE_CALL_FORBIDDEN` guard --
+///           reached by delegatecalling `ccipReceive` (the RECEIVE path) into
+///           an adapter instead of calling it normally, so the adapter's
+///           storage-reading receive code runs against a foreign contract's
+///           (this one's) storage instead of its own.
+///
+///        2. `CCIPAdapter.sendMessage`'s `RECEIVER_ADDRESS_ZERO` and
+///           `UNEXPECTED_NATIVE_VALUE` checks, which sit behind
+///           `onlyDelegatecallFromController` (`address(this) ==
+///           CROSS_CHAIN_CONTROLLER`). The real controller's `forwardMessage`
+///           always supplies a non-zero receiver and is not `payable`, so both
+///           branches are unreachable through that entry point. Deploying an
+///           adapter whose `CROSS_CHAIN_CONTROLLER` is set to THIS contract's
+///           address lets the guard be satisfied and the checks behind it
+///           exercised directly, in isolation.
+///
+///      Implements `dao()` purely so `BaseAdapter`'s constructor -- which calls
+///      `CrossChainController(_crossChainController).dao()` to adopt a
+///      permission manager -- succeeds when an adapter is constructed with
+///      this contract as its `CROSS_CHAIN_CONTROLLER`. The returned DAO is not
+///      otherwise used by the isolation tests.
+contract DelegateCallerMock {
+    IDAO public immutable dao;
+
+    constructor(IDAO _dao) {
+        dao = _dao;
+    }
+
+    /// @notice Delegatecalls `_target` with `_data`; on failure, reverts with
+    ///         the target's exact revert data instead of swallowing it, so
+    ///         callers can use `vm.expectRevert` normally.
+    function delegateCall(
+        address _target,
+        bytes calldata _data
+    ) external payable returns (bytes memory returndata) {
+        bool success;
+        (success, returndata) = _target.delegatecall(_data);
+        if (!success) {
+            if (returndata.length == 0) revert();
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                revert(add(returndata, 32), mload(returndata))
+            }
+        }
+    }
+}

--- a/test/mocks/commons/crosschain/MaliciousAdapterMock.sol
+++ b/test/mocks/commons/crosschain/MaliciousAdapterMock.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.17;
+
+import {IBaseAdapter} from "../../../../src/common/crosschain/adapters/IBaseAdapter.sol";
+import {Action, IExecutor} from "../../../../src/common/executors/IExecutor.sol";
+
+/// @notice An adapter that abuses being `delegatecall`ed, used to DEMONSTRATE —
+///         not to mitigate — the residual risk of the `delegatecall` send
+///         mechanism (security-review finding 7).
+/// @dev DO NOT USE IN PRODUCTION!
+///
+///      Whoever holds `UPDATE_CONFIG_PERMISSION` on a `CrossChainController`
+///      can point a lane at a contract like this one. The next
+///      `forwardMessage` — triggered by anybody with
+///      `FORWARD_MESSAGE_PERMISSION`, for any legitimate reason — then runs
+///      this code IN THE CONTROLLER'S CONTEXT, which means it can:
+///        1. overwrite any storage slot of the controller, and
+///        2. make the DAO execute arbitrary actions, because the controller
+///           holds `EXECUTE_PERMISSION`.
+///      Both are exercised by `sendMessage` below.
+contract MaliciousAdapterMock is IBaseAdapter {
+    address private immutable _controller;
+    address private immutable _dao;
+    address private immutable _target;
+    bytes32 private immutable _slot;
+    bytes32 private immutable _value;
+
+    /// @param controller_ The controller whose context will be hijacked.
+    /// @param dao_ The DAO the controller can execute on.
+    /// @param target_ A contract to call through the DAO (`pwn()`).
+    /// @param slot_ An arbitrary controller storage slot to overwrite.
+    /// @param value_ The value to write into `slot_`.
+    constructor(
+        address controller_,
+        address dao_,
+        address target_,
+        bytes32 slot_,
+        bytes32 value_
+    ) {
+        _controller = controller_;
+        _dao = dao_;
+        _target = target_;
+        _slot = slot_;
+        _value = value_;
+    }
+
+    function CROSS_CHAIN_CONTROLLER() external view override returns (address) {
+        return _controller;
+    }
+
+    function toNativeChainId(uint256 c) external pure override returns (uint256) {
+        return c;
+    }
+
+    function fromNativeChainId(uint256 c) external pure override returns (uint256) {
+        return c;
+    }
+
+    function quoteFee(
+        address,
+        uint64,
+        uint256,
+        bytes calldata
+    ) external view override returns (address, uint256) {
+        return (address(0), 0);
+    }
+
+    /// @dev Ignores its arguments entirely and instead corrupts the caller.
+    function sendMessage(
+        address,
+        uint64,
+        uint256,
+        bytes calldata
+    )
+        external
+        payable
+        override
+        returns (bytes32 messageId, address feeToken, uint256 fee)
+    {
+        // 1. Arbitrary storage write in the controller's context.
+        bytes32 slot = _slot;
+        bytes32 value = _value;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            sstore(slot, value)
+        }
+
+        // 2. Arbitrary execution on the DAO, as the controller.
+        Action[] memory actions = new Action[](1);
+        actions[0] = Action({
+            to: _target,
+            value: 0,
+            data: abi.encodeWithSignature("pwn()")
+        });
+        IExecutor(_dao).execute(keccak256("pwned"), actions, 0);
+
+        return (bytes32(0), address(0), 0);
+    }
+}
+
+/// @notice Trivial target recording that it was reached through the DAO.
+/// @dev DO NOT USE IN PRODUCTION!
+contract PwnTarget {
+    bool public pwned;
+
+    function pwn() external {
+        pwned = true;
+    }
+}

--- a/test/mocks/commons/crosschain/MaliciousAdapterMock.sol
+++ b/test/mocks/commons/crosschain/MaliciousAdapterMock.sol
@@ -2,8 +2,13 @@
 
 pragma solidity ^0.8.17;
 
-import {IBaseAdapter} from "../../../../src/common/crosschain/adapters/IBaseAdapter.sol";
-import {Action, IExecutor} from "../../../../src/common/executors/IExecutor.sol";
+import {
+    IBaseAdapter
+} from "../../../../src/common/crosschain/adapters/IBaseAdapter.sol";
+import {
+    Action,
+    IExecutor
+} from "../../../../src/common/executors/IExecutor.sol";
 
 /// @notice An adapter that abuses being `delegatecall`ed, used to DEMONSTRATE —
 ///         not to mitigate — the residual risk of the `delegatecall` send
@@ -49,35 +54,34 @@ contract MaliciousAdapterMock is IBaseAdapter {
         return _controller;
     }
 
-    function toNativeChainId(uint256 c) external pure override returns (uint256) {
+    function toNativeChainId(
+        uint256 c
+    ) external pure override returns (uint256) {
         return c;
     }
 
-    function fromNativeChainId(uint256 c) external pure override returns (uint256) {
+    function fromNativeChainId(
+        uint256 c
+    ) external pure override returns (uint256) {
         return c;
     }
 
     function quoteFee(
         address,
-        uint64,
+        uint256,
         uint256,
         bytes calldata
-    ) external view override returns (address, uint256) {
+    ) external pure override returns (address, uint256) {
         return (address(0), 0);
     }
 
     /// @dev Ignores its arguments entirely and instead corrupts the caller.
     function sendMessage(
         address,
-        uint64,
+        uint256,
         uint256,
         bytes calldata
-    )
-        external
-        payable
-        override
-        returns (bytes32 messageId, address feeToken, uint256 fee)
-    {
+    ) external payable override returns (bytes32 messageId, uint256 fee) {
         // 1. Arbitrary storage write in the controller's context.
         bytes32 slot = _slot;
         bytes32 value = _value;
@@ -95,7 +99,7 @@ contract MaliciousAdapterMock is IBaseAdapter {
         });
         IExecutor(_dao).execute(keccak256("pwned"), actions, 0);
 
-        return (bytes32(0), address(0), 0);
+        return (bytes32(0), 0);
     }
 }
 


### PR DESCRIPTION
Hardens the cross-chain module in `src/common/crosschain/`, adds the first test coverage for it, and resolves the storage collision that made the send path unusable.

## Why

Review of `e49e055` found ten issues, two of them unauthenticated paths to full DAO takeover. Both were confirmed empirically with a proof-of-concept against the pre-fix contracts: an arbitrary address executing actions on a real `DAO` via `receiveMessage`, and again via the adapter's public `_forwardMessage`. Neither required a compromised bridge, a forged message, or any special position — just an ordinary transaction from any address.

The module was also non-functional as written: the send path always reverted (finding 3), and when a lane was unconfigured it reported success while sending nothing (finding 4).

## Findings addressed

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | Critical | `receiveMessage()` public, no access control — anyone could execute arbitrary `Action[]` on the DAO | restricted to registered local adapters via a **refcounted** registry (an adapter serves multiple lanes, so it must stay authorised until its last lane clears — a boolean would brick rotation) |
| 2 | Critical | `BaseAdapter._forwardMessage()` public despite the underscore — second independent takeover path | made `internal`; receive path additionally asserts it is never reached via `delegatecall` |
| 3 | High | Adapter storage collided with controller storage under `delegatecall`; `feeToken` read an unset slot, so sends always reverted | send-path config moved into the controller and passed as arguments — the adapter now performs **zero storage reads** and relies only on immutables |
| 4 | High | Sending to an unconfigured chain `delegatecall`ed `address(0)`, which the EVM reports as success — the caller saw success and nothing was sent | unconfigured and codeless lanes revert |
| 5 | High | `to/fromNativeChainId` were identity functions, but CCIP addresses lanes by selector | real bidirectional mapping; unknown ids revert |
| 6 | Medium | No router approval (the router pulls via `transferFrom`, so sends failed) and no native-fee support | `forceApprove` plus native-fee path |
| 7 | Medium | `UPDATE_CONFIG_PERMISSION` sets `delegatecall` targets and is therefore root-equivalent | documented prominently in NatSpec — see *Residual risk* |
| 8 | Medium | A reverting action stranded the message | failed messages stored and retryable under a dedicated permission |
| 9 | Low | Ambiguous trusted-remote semantics | documented, plus a deployment-time assertion helper |
| 10 | Low | Always-zero call ids, empty event, constructor-only config | derived call ids, real event payloads, permissioned setters |

## Send mechanism

The controller `delegatecall`s the adapter, and the adapter is stateless on that path — everything it needs is either `immutable` (router, fee token) or a call argument sourced from controller storage:

```solidity
struct ChainConfig { address localAdapter; address remoteAdapter; uint64 bridgeChainId; }
```

Making adapter state `immutable` alone is not sufficient, because the fix for finding 5 needs lookup tables and mappings cannot be `immutable`. Moving that config into the controller is what makes the send path storage-free.

Consequence: the bridge sees the **controller** as sender, so a destination's trusted remote holds the remote **controller** address while `ChainConfig.remoteAdapter` holds the remote **adapter**. Two kinds of address; `assertTrustedRemotesMatchController` exists to catch mismatches at deployment.

## Fees

The controller custodies pre-funded fees and pays the router directly — no per-send hand-over, no change to return. Adds `receive()`, a DAO-only withdraw for native and ERC20, a distinct insufficient-balance error, and a `quoteFee()` view so monitoring can top up before a deadline rather than discovering the shortfall at execution.

Only the sending side needs a balance; destination gas is bought by the source-side fee via `extraArgs`.

## Residual risk

`UPDATE_CONFIG_PERMISSION` sets `delegatecall` targets, so it can execute arbitrary code in the controller's context, and the controller can act as the DAO. **It is root-equivalent and must not be granted outside governance.** This is inherent to the `delegatecall` mechanism, not reduced by this PR, and is documented in NatSpec at the permission definition.

Relatedly, "the adapter must not touch storage on the send path" is enforced by review, not the compiler. Any future adapter that performs a single `SLOAD` there will silently corrupt controller storage.

## Tests

95 tests (41 controller, 54 CCIP adapter) where there were none. Regression coverage per finding, plus a test proving immutables resolve from the adapter's bytecode under `delegatecall` while a storage read in the same position resolves against the caller's slots.

`chainlink-local` could not be used: `CCIPLocalSimulator` requires `pragma ^0.8.19` and this repo pins `solc 0.8.17`. A mock router that genuinely pulls fees via `transferFrom` is used instead — so the missing-approve bug fails tests for real, but **a live CCIP round trip remains unproven** and should be covered by fork tests downstream.

## Notes for reviewers

- Two guards in `CCIPAdapter.sendMessage` (`RECEIVER_ADDRESS_ZERO`, `UNEXPECTED_NATIVE_VALUE`) are currently unreachable — earlier validation catches those cases. Kept with the reachability analysis in NatSpec rather than deleted.
- The residual-risk test uses a mock DAO whose `execute` has no permission gate, so it corroborates the takeover path rather than proving it against a production `PermissionManager`.
- `NOT_ENOUGH_TO_PAY_BRIDGE` and `TRUSTED_REMOTE_NOT_SET` are now unused; left in `Errors.sol` to avoid widening the diff.
- No reentrancy guard on `forwardMessage` — judged unnecessary (DAO-configured adapter, no state mutation around the call), but worth a second opinion.
- Chain selectors are configuration rather than constants; verify values against Chainlink's directory at deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
